### PR TITLE
Add buffer reuse appender flag

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -135,8 +135,8 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			.ofList() //
 			.map(AppenderFlag::parse) //
 			.buildWithName(LogAppender.APPENDER_FLAGS_PROPERTY, name) //
-			.require(EnumSet.noneOf(AppenderFlag.class));
-
+			.get(config.properties())
+			.value(EnumSet.noneOf(LogAppender.AppenderFlag.class));
 	}
 
 	static LogAppender fileAppender(LogConfig config) {

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -178,12 +178,16 @@ public interface LogEncoder {
 	}
 
 	/**
-	 * Hints the writer can pass to the encoder for creating buffers like max size and
+	 * Hints the output can pass to the encoder for creating buffers like max size and
 	 * storage style of the buffer etc.
 	 *
 	 * @apiNote There is no guarantees the encoder/buffer will honor these hints.
 	 */
 	public interface BufferHints {
+
+		/*
+		 * TODO should we seal this?
+		 */
 
 		/**
 		 * The preferred write style of the output.

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.Nullable;
 
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
 import io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType;
 import io.jstach.rainbowgum.LogProperties.Builder.AbstractLogProperties;
 import io.jstach.rainbowgum.LogProperties.FoundProperty.ListProperty;
@@ -234,6 +235,12 @@ public interface LogProperties {
 	 * Encoder appender property.
 	 */
 	static final String APPENDER_ENCODER_PROPERTY = LogProperties.APPENDER_PREFIX + "encoder";
+
+	/**
+	 * Appender flags. A list of flags (usually comma separated).
+	 * @see AppenderFlag
+	 */
+	static final String APPENDER_FLAGS_PROPERTY = LogProperties.APPENDER_PREFIX + "flags";
 
 	/**
 	 * Logging publisher prefix for configuration.

--- a/core/src/main/java/io/jstach/rainbowgum/LogPublisher.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogPublisher.java
@@ -288,6 +288,13 @@ final class DefaultSyncLogPublisher implements LogPublisher.SyncLogPublisher {
 		appender.close();
 	}
 
+	/*
+	 * Exposed for unit test.
+	 */
+	LogAppender appender() {
+		return this.appender;
+	}
+
 	@Override
 	public String toString() {
 		return "DefaultSyncLogPublisher[appender=" + appender + "]";


### PR DESCRIPTION
Adds an appender configuration of

```properties
logging.appender.{name}.flags=reuse_buffer
```

This will reuse an encoding buffer at the cost of increased lock contention but in theory lower GC pressure.