### PR TITLE
Issue 160 of Apt module having corrupt descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,13 @@
     <pistachio.version>0.1.2</pistachio.version>
     <jstachio.version>1.3.6</jstachio.version>
     <slf4j.version>2.0.16</slf4j.version>
-
+    <!-- 
+      This is needed because of moditect generating
+      the module-info for the annotation processing
+      jar which angers the javadoc system.
+      https://bugs.openjdk.org/browse/JDK-8274639
+    -->
+    <javadoc.modularity.mismatch>info</javadoc.modularity.mismatch>
   </properties>
       
   <scm>
@@ -564,6 +570,7 @@
                 <additionalOption>--allow-script-in-comments</additionalOption>
                 <additionalOption>--snippet-path ${project.basedir}/${doc.resources}${doc.snippets}</additionalOption>
                 <additionalOption>--add-stylesheet ${parent.root}/doc/jstachio.css</additionalOption>
+                <additionalOption>--link-modularity-mismatch=${javadoc.modularity.mismatch}</additionalOption>
               </additionalOptions>
             </configuration>
             <executions>
@@ -1116,5 +1123,6 @@
     <module>rainbowgum-systemlogger</module>
     <module>rainbowgum-tomcat</module>
     <module>spring</module>
+    <module>rainbowgum-maven-last</module>
   </modules>
 </project>

--- a/rainbowgum-apt/src/main/java/module-info.moditect
+++ b/rainbowgum-apt/src/main/java/module-info.moditect
@@ -1,8 +1,13 @@
 /**
  * Rainbow Gum annotation processors.
- * @provides Processor with config processor.
+ * @provides javax.annotation.processing.Processor with config processor.
  */
 module io.jstach.rainbowgum.apt {
 	requires jdk.compiler;
+	requires static io.jstach.rainbowgum.annotation;
+	requires static io.jstach.prism;
+	requires static io.jstach.svc;
+	requires static org.eclipse.jdt.annotation;
+	requires static io.jstach.jstache;
 	provides javax.annotation.processing.Processor with io.jstach.rainbowgum.apt.ConfigProcessor;
 }

--- a/rainbowgum-apt/src/main/java/module-info.moditect
+++ b/rainbowgum-apt/src/main/java/module-info.moditect
@@ -1,10 +1,8 @@
-import javax.annotation.processing.Processor;
-
 /**
  * Rainbow Gum annotation processors.
  * @provides Processor with config processor.
  */
 module io.jstach.rainbowgum.apt {
 	requires jdk.compiler;
-	provides Processor with io.jstach.rainbowgum.apt.ConfigProcessor;
+	provides javax.annotation.processing.Processor with io.jstach.rainbowgum.apt.ConfigProcessor;
 }

--- a/rainbowgum-maven-last/pom.xml
+++ b/rainbowgum-maven-last/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach.rainbowgum</groupId>
+    <artifactId>rainbowgum-maven-parent</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>rainbowgum-maven-last</artifactId>
+  <packaging>pom</packaging>
+  <!--
+    This POM and artifact is a hack for reliable maven reactor order.
+    The sonatype deploy plugin needs the last artifact
+    to be actually deployable.
+  -->
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-test-jdk</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency> 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-test-rabbitmq</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-tomcat</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-etc</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>

--- a/rainbowgum/pom.xml
+++ b/rainbowgum/pom.xml
@@ -54,26 +54,6 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rainbowgum-rabbitmq</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rainbowgum-test-jdk</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency> 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rainbowgum-test-rabbitmq</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
This fix was larger than I anticipated because as soon as the module was corrected the Javadoc system started to validate the module.

Consequently every module that depended on APT wants javadoc links associated with apt module even if no reference is actually made. This is probably a bug with either javadoc system (doubtful) or the Maven javadoc plugin (likely).

Thus the new feature https://bugs.openjdk.org/browse/JDK-8274639 was used.

Thanks @bowbahdoe!