### PR TITLE
add avaje spi marker annotation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,5 +23,12 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-apt</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-spi-service</artifactId>
+      <version>2.1</version>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 </project>

--- a/core/src/main/java/io/jstach/rainbowgum/spi/RainbowGumServiceProvider.java
+++ b/core/src/main/java/io/jstach/rainbowgum/spi/RainbowGumServiceProvider.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.Nullable;
 
+import io.avaje.spi.Service;
 import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.RainbowGum;
@@ -46,6 +47,7 @@ import io.jstach.rainbowgum.ServiceRegistry;
  * </ol>
  *
  */
+@Service
 @SuppressWarnings("InvalidInlineTag")
 public sealed interface RainbowGumServiceProvider {
 

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,12 +1,12 @@
 /**
- * Core module for RainbowGum which provides low level components for logging as well as a builder 
+ * Core module for RainbowGum which provides low level components for logging as well as a builder
  * for creating custom RainbowGums. Use {@link io.jstach.rainbowgum.RainbowGum#builder()} to
  * get started configuring.
  * <p>
  * <strong>Thread Safety:</strong>
  * With the exception of builders, buffers, and outputs this modules components are
  * all threadsafe. Output thread safety is protected by Appenders which are threadsafe.
- * 
+ *
  * @see io.jstach.rainbowgum
  * @uses io.jstach.rainbowgum.spi.RainbowGumServiceProvider
  */
@@ -16,9 +16,10 @@ module io.jstach.rainbowgum {
 	exports io.jstach.rainbowgum.format;
 	exports io.jstach.rainbowgum.output;
 	exports io.jstach.rainbowgum.spi;
-	
+
 	requires static io.jstach.rainbowgum.annotation;
 	requires static org.eclipse.jdt.annotation;
-	
+	requires static io.avaje.spi;
+
 	uses io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
 }


### PR DESCRIPTION
Now, when using Avaje SPI, it will default to registering the `RainbowGumServiceProvider` instead of its many subimplementations when annotating a type with `@ServiceProvider`.


In essence, it prevents situations like https://github.com/jstachio/rainbowgum/discussions/211 when using avaje.