### PR TITLE
Make pattern encoder default #266

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -117,7 +117,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 
 		var encoderProperty = encoderProperty(LogAppender.APPENDER_ENCODER_PROPERTY, name, config);
 
-		var encoder = resolveEncoder(config, output, encoderProperty).value();
+		var encoder = resolveEncoder(name, config, output, encoderProperty).value();
 
 		var flags = resolveFlags(config, name);
 
@@ -175,9 +175,9 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 		if (output instanceof LogEncoder e) {
 			encoder = e;
 		}
-		encoder = resolveEncoder(config, output, encoderProperty).override(encoder);
-
 		String name = appenderConfig.name();
+
+		encoder = resolveEncoder(name, config, output, encoderProperty).override(encoder);
 
 		@Nullable
 		Set<LogAppender.AppenderFlag> flags = appenderConfig.flags();
@@ -188,11 +188,11 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 		return DirectLogAppender.of(name, output, encoder, flags);
 	}
 
-	private static PropertyValue<LogEncoder> resolveEncoder(LogConfig config, LogOutput output,
+	private static PropertyValue<LogEncoder> resolveEncoder(String name, LogConfig config, LogOutput output,
 			PropertyValue<LogEncoder> encoderProperty) {
 		return encoderProperty.or(() -> {
 			var encoderRegistry = config.encoderRegistry();
-			return encoderRegistry.encoderForOutputType(output.type());
+			return encoderRegistry.encoderForOutputType(output.type()).provide(name, config);
 		});
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import io.jstach.rainbowgum.LogEncoder.AbstractEncoder;
 import io.jstach.rainbowgum.LogEncoder.Buffer.StringBuilderBuffer;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.format.AbstractStandardEventFormatter;
 
 /**
  * Encodes a {@link LogEvent} into a buffer of its choosing. While the {@link Buffer} does
@@ -81,6 +82,14 @@ public interface LogEncoder {
 	}
 
 	/**
+	 * Provides the standard TTLL encoder.
+	 * @return provider of encoder.
+	 */
+	public static LogProvider<LogEncoder> ofTTLL() {
+		return of(LogProviderRef.of(URI.create(AbstractStandardEventFormatter.SCHEMA)));
+	}
+
+	/**
 	 * Provides a lazy loaded encoder from a provider ref.
 	 * @param ref uri.
 	 * @return provider of output.
@@ -104,6 +113,15 @@ public interface LogEncoder {
 		 * @throws LogProviderRef.NotFoundException if there is no registered provider.
 		 */
 		LogProvider<LogEncoder> provide(LogProviderRef ref) throws LogProviderRef.NotFoundException;
+
+		/**
+		 * Convenience method to register encoders that require no configuration.
+		 * @param encoder already configured encoder.
+		 * @return encoder provider.
+		 */
+		static EncoderProvider of(LogEncoder encoder) {
+			return ref -> LogProvider.of(encoder);
+		}
 
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/format/AbstractStandardEventFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/format/AbstractStandardEventFormatter.java
@@ -1,5 +1,8 @@
 package io.jstach.rainbowgum.format;
 
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEncoder.EncoderProvider;
+import io.jstach.rainbowgum.LogEncoderRegistry;
 import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogFormatter;
 
@@ -25,6 +28,13 @@ import io.jstach.rainbowgum.LogFormatter;
  * @see AbstractBuilder
  */
 public class AbstractStandardEventFormatter implements LogFormatter.EventFormatter {
+
+	/**
+	 * Recommended URI schema for this type of encoder.
+	 * @see LogEncoderRegistry#register(String,
+	 * io.jstach.rainbowgum.LogEncoder.EncoderProvider)
+	 */
+	public static final String SCHEMA = "ttll";
 
 	/**
 	 * immutable field
@@ -296,6 +306,24 @@ public class AbstractStandardEventFormatter implements LogFormatter.EventFormatt
 			return self();
 		}
 
+	}
+
+	/**
+	 * Convenience to register the encoder.
+	 * @return encoder provider.
+	 * @see AbstractStandardEventFormatter#SCHEMA
+	 */
+	public EncoderProvider toEncoderProvider() {
+		return EncoderProvider.of(LogEncoder.of(eventFormatter));
+	}
+
+	/**
+	 * Will register this TTLL like encoder with the uri schema {@value #SCHEMA} and will
+	 * be used as the default encoder if other encoders are not found.
+	 * @param registry encoder registry.
+	 */
+	public void register(LogEncoderRegistry registry) {
+		registry.register(SCHEMA, toEncoderProvider());
 	}
 
 	@Override

--- a/core/src/main/java/io/jstach/rainbowgum/output/ListLogOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/output/ListLogOutput.java
@@ -16,7 +16,7 @@ import io.jstach.rainbowgum.LogOutput;
 /**
  * An output for debugging.
  */
-public final class ListLogOutput implements LogOutput {
+public class ListLogOutput implements LogOutput {
 
 	private List<Entry<LogEvent, String>> events;
 

--- a/core/src/main/java/io/jstach/rainbowgum/spi/RainbowGumServiceProvider.java
+++ b/core/src/main/java/io/jstach/rainbowgum/spi/RainbowGumServiceProvider.java
@@ -120,7 +120,7 @@ public sealed interface RainbowGumServiceProvider {
 	 * @see LogConfig#outputRegistry()
 	 * @see ServiceRegistry
 	 */
-	@FunctionalInterface
+	@FunctionalInterface // TODO remove and make the builder take a function
 	public non-sealed interface Configurator extends RainbowGumServiceProvider {
 
 		/**
@@ -159,7 +159,8 @@ public sealed interface RainbowGumServiceProvider {
 		 */
 		private static void runConfigurators(Stream<? extends RainbowGumServiceProvider.Configurator> configurators,
 				LogConfig config, int passes) {
-			List<Configurator> unresolved = new ArrayList<>(configurators.toList());
+			List<Configurator> unresolved = new ArrayList<>(
+					configurators.sorted(Comparator.comparing(Configurator::priority).reversed()).toList());
 			for (int i = 0; i < passes; i++) {
 				var it = unresolved.iterator();
 				while (it.hasNext()) {
@@ -180,6 +181,14 @@ public sealed interface RainbowGumServiceProvider {
 						+ passes + " passes. configurators = " + unresolved);
 			}
 
+		}
+
+		/**
+		 * Priority of configurators.
+		 * @return priority order where higher number means it will be tried earlier.
+		 */
+		default int priority() {
+			return 0;
 		}
 
 	}

--- a/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
@@ -75,7 +75,7 @@ class LogEncoderRegistryTest {
 			config.encoderRegistry().register("custom", provider);
 			config.encoderRegistry()
 				.setEncoderForOutputType(OutputType.MEMORY,
-						() -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder());
+						(name, c) -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder());
 			return true;
 		}
 

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
@@ -8,6 +8,7 @@ import io.jstach.rainbowgum.LogEncoder;
 import io.jstach.rainbowgum.LogOutput.OutputType;
 import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.LogProperty.Property;
+import io.jstach.rainbowgum.LogProvider;
 import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
 import io.jstach.svc.ServiceProvider;
 
@@ -30,6 +31,11 @@ public class JAnsiConfigurator implements RainbowGumServiceProvider.Configurator
 	}
 
 	@Override
+	public int priority() {
+		return -1 << 1; // internal group 1
+	}
+
+	@Override
 	public boolean configure(LogConfig config, Pass pass) {
 		boolean globalDisable = isGlobalAnsiDisabled(config);
 		if (!globalDisable && installJansi(config)) {
@@ -43,9 +49,13 @@ public class JAnsiConfigurator implements RainbowGumServiceProvider.Configurator
 	}
 
 	void installJansiLogFormatter(LogConfig config, boolean disableAnsi) {
+		/*
+		 * TODO probably get rid of this. Most will be using the pattern formatter anyway
+		 * if they want colors.
+		 */
+		var jansiFormatter = JansiLogFormatter.builder().disableAnsi(disableAnsi).build();
 		config.encoderRegistry()
-			.setEncoderForOutputType(OutputType.CONSOLE_OUT,
-					() -> LogEncoder.of(JansiLogFormatter.builder().disableAnsi(disableAnsi).build()));
+			.setEncoderForOutputType(OutputType.CONSOLE_OUT, LogProvider.of(LogEncoder.of(jansiFormatter)));
 	}
 
 	boolean installJansi(LogConfig config) {

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JansiLogFormatter.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JansiLogFormatter.java
@@ -8,6 +8,7 @@ import io.jstach.rainbowgum.LogFormatter;
 import io.jstach.rainbowgum.format.AbstractStandardEventFormatter;
 import io.jstach.rainbowgum.format.StandardEventFormatter;
 
+// TODO deprecate
 /**
  * Jansi TTLL formater.
  */

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternCompiler.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternCompiler.java
@@ -58,7 +58,7 @@ public sealed interface PatternCompiler {
 						.build(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY) //
 						.get(config.properties()) //
 						.value(false);
-					var b = PatternConfig.builder()
+					var b = PatternConfig.builder(name)
 						.propertyFunction(PatternConfig.propertyFunction(config.properties(),
 								PatternConfig.PATTERN_PROPERY_PREFIX))
 						.fromProperties(config.properties());
@@ -173,6 +173,7 @@ final class Compiler implements PatternCompiler {
 				case FormattingNode fn -> {
 					PatternFormatterFactory f = registry.getOrNull(fn.keyword());
 					if (f == null) {
+						// TODO better error message
 						throw new IllegalStateException("Missing formatter for key: " + fn.keyword());
 					}
 

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -5,12 +5,22 @@ import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BLUE_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BOLD;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.CYAN_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.DEFAULT_FG;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.GRAY_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.GREEN_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.MAGENTA_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.RED_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.WHITE_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.YELLOW_FG;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.FAINT;
+
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_BLACK;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_RED;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_GREEN;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_YELLOW;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_BLUE;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_MAGENTA;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_CYAN;
+import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_WHITE;
 
 import java.lang.System.Logger.Level;
 import java.time.ZoneId;
@@ -154,6 +164,9 @@ enum StandardKeywordFactory implements KeywordFactory {
 		}
 
 	},
+	/**
+	 * This is logbacks MDC style
+	 */
 	MDC() {
 
 		@Override
@@ -195,6 +208,9 @@ enum StandardKeywordFactory implements KeywordFactory {
 		}
 
 	},
+	/**
+	 * This comes from Spring Boot %esb
+	 */
 	ENCLOSED_SQUARE_BRACKET() {
 
 		@Override
@@ -292,7 +308,28 @@ final class ANSIConstants {
 
 	final static String DEFAULT_FG = "39";
 
+	final static String GRAY_FG = BOLD + BLACK_FG; // Logback is a little weird about gray
+
 	final static String SET_DEFAULT_COLOR = ESC_START + RESET + DEFAULT_FG + ESC_END;
+
+	/*
+	 * Spring Boot colors
+	 */
+	final static String BRIGHT_BLACK = "90";
+
+	final static String BRIGHT_RED = "91";
+
+	final static String BRIGHT_GREEN = "92";
+
+	final static String BRIGHT_YELLOW = "93";
+
+	final static String BRIGHT_BLUE = "94";
+
+	final static String BRIGHT_MAGENTA = "95";
+
+	final static String BRIGHT_CYAN = "96";
+
+	final static String BRIGHT_WHITE = "97";
 
 }
 
@@ -325,6 +362,9 @@ record HighlightFormatter(@Nullable LogFormatter child) implements LogFormatter.
 
 }
 
+/*
+ * From Spring Boot
+ */
 record ClrLevelFormatter(@Nullable LogFormatter child) implements LogFormatter.EventFormatter {
 
 	@Override
@@ -388,6 +428,9 @@ enum HighlightCompositeFactory implements CompositeFactory {
 
 	},
 
+	/**
+	 * This style come from Spring Boot.
+	 */
 	CLR() {
 
 		@Override
@@ -398,7 +441,7 @@ enum HighlightCompositeFactory implements CompositeFactory {
 				}
 				return child;
 			}
-			String color = node.optOrNull(0, HighlightCompositeFactory::parseColor);
+			String color = node.optOrNull(0, HighlightCompositeFactory::clrParseColor);
 			if (color == null) {
 				return new ClrLevelFormatter(child);
 			}
@@ -407,7 +450,7 @@ enum HighlightCompositeFactory implements CompositeFactory {
 
 	};
 
-	static String parseColor(String color) {
+	static String clrParseColor(String color) {
 		color = color.toLowerCase(Locale.ROOT);
 		return switch (color) {
 			case "blue" -> BLACK_FG;
@@ -417,12 +460,23 @@ enum HighlightCompositeFactory implements CompositeFactory {
 			case "magenta" -> MAGENTA_FG;
 			case "red" -> RED_FG;
 			case "yellow" -> YELLOW_FG;
+			case "bright_black" -> BRIGHT_BLACK;
+			case "bright_red" -> BRIGHT_RED;
+			case "bright_green" -> BRIGHT_GREEN;
+			case "bright_yellow" -> BRIGHT_YELLOW;
+			case "bright_blue" -> BRIGHT_BLUE;
+			case "bright_magenta" -> BRIGHT_MAGENTA;
+			case "bright_cyan" -> BRIGHT_CYAN;
+			case "bright_white" -> BRIGHT_WHITE;
 			default -> throw new IllegalArgumentException("Bad color:" + color);
 		};
 	}
 
 }
 
+/**
+ * This style of colors largely comes from logback
+ */
 enum ColorCompositeFactory implements CompositeFactory {
 
 	BLACK(BLACK_FG, "black"), //
@@ -433,7 +487,7 @@ enum ColorCompositeFactory implements CompositeFactory {
 	MAGENTA(MAGENTA_FG, "magenta"), //
 	CYAN(CYAN_FG, "cyan"), //
 	WHITE(WHITE_FG, "white"), //
-	GRAY(DEFAULT_FG, "gray"), //
+	GRAY(GRAY_FG, "gray"), //
 	BOLD_RED(BOLD + RED_FG, "boldRed"), //
 	BOLD_GREEN(BOLD + GREEN_FG, "boldGreen"), //
 	BOLD_YELLOW(BOLD + YELLOW_FG, "boldYellow"), //

--- a/spring/rainbowgum-spring-boot/src/main/java/io/jstach/rainbowgum/spring/boot/RainbowGumLoggingSystemFactory.java
+++ b/spring/rainbowgum-spring-boot/src/main/java/io/jstach/rainbowgum/spring/boot/RainbowGumLoggingSystemFactory.java
@@ -188,16 +188,13 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 				.build();
 			LogProperties patternProperties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 			Patterns patterns = new Patterns(patternProperties);
-			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern())
-				.build()
-				.provide("console", config);
 
-			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern())
-				.build()
-				.provide("file", config);
+			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern()).build();
 
-			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, () -> consoleEncoder);
-			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, () -> fileEncoder);
+			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern()).build();
+
+			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, consoleEncoder);
+			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, fileEncoder);
 			rainbowGum = findAndSet(config, classLoader, initializationContext.getEnvironment());
 		}
 


### PR DESCRIPTION
The pattern encoder was never set as the default encoder but the jansi encoder was making configuration confusing.

The jansi encoder is pretty worthless as you cannot configure it and I mainly added it just to give rainbow gum some initial color.

The jansi encoder will be removed in the long run (jansi will stay for ansi safe output though).

There is a default encoder called TTLL always shipped with core rainbow gum that now can be accessed through URI schema.

I made it easier to register a TTLL encoder which is used if no other encoders are found / not specified. This should be separated out as different work but oh well it got put in this change.

I also found some missing Spring Boot colors while looking at the ANSI stuff in pattern module. Again probably should be separate issue.