### PR TITLE
Add output access callback #270

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -7,6 +7,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
@@ -410,9 +411,9 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 
 }
 
-interface AppenderVisitor {
+interface AppenderVisitor<R> {
 
-	boolean consume(DirectLogAppender appender);
+	Optional<R> apply(DirectLogAppender appender);
 
 }
 
@@ -524,10 +525,21 @@ sealed interface InternalLogAppender extends LogAppender, Actor {
 
 	/**
 	 * THIS IS A JAVADOC BUG.
+	 * @param <R> return type.
 	 * @param visitor ignore
 	 * @return true if stop.
 	 */
-	boolean visit(AppenderVisitor visitor);
+	<R> Optional<R> visit(AppenderVisitor<R> visitor);
+
+	default <R> Optional<R> useOutput(String name, Function<? super LogOutput, ? extends R> action) {
+		return visit(da -> {
+			if (name.equals(da.name())) {
+				return Optional.ofNullable(action.apply(da.output()));
+			}
+			return Optional.empty();
+
+		});
+	}
 
 	// InternalLogAppender changeLock(AppenderLock lock);
 	//
@@ -543,6 +555,7 @@ sealed interface InternalLogAppender extends LogAppender, Actor {
 
 }
 
+// This is super private because there is no locking protection
 sealed interface DirectLogAppender extends InternalLogAppender {
 
 	String name();
@@ -551,6 +564,7 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 
 	LogEncoder encoder();
 
+	// Should be called within lock block.
 	default List<LogResponse> _request(LogAction action) {
 		List<LogResponse> r = switch (action) {
 			case LogAction.StandardAction a -> switch (a) {
@@ -563,17 +577,17 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		return r;
 	}
 
-	default LogResponse reopen() {
+	private LogResponse reopen() {
 		var status = output().reopen();
 		return new Response(LogOutput.class, name(), status);
 	}
 
-	default LogResponse flush() {
+	private LogResponse flush() {
 		output().flush();
 		return new Response(LogOutput.class, name(), LogResponse.Status.StandardStatus.OK);
 	}
 
-	default LogResponse status() {
+	private LogResponse status() {
 		Status status;
 		try {
 			status = output().status();
@@ -584,16 +598,6 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		return new Response(LogOutput.class, name(), status);
 	}
 
-	static List<DirectLogAppender> findAppenders(ServiceRegistry registry) {
-		List<DirectLogAppender> appenders = new ArrayList<>();
-		for (var a : registry.find(LogAppender.class)) {
-			if (a instanceof InternalLogAppender internal) {
-				internal.visit(appenders::add);
-			}
-		}
-		return appenders;
-	}
-
 	static DirectLogAppender of(String name, LogOutput output, LogEncoder encoder,
 			Set<LogAppender.AppenderFlag> flags) {
 		var lock = AppenderLock.of(flags);
@@ -602,6 +606,8 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		}
 		return new DefaultLogAppender(name, output, encoder, flags, lock);
 	}
+
+	// <R> R execute(Function<? super LogOutput, ? extends R> action);
 
 	// @Override
 	DirectLogAppender withFlags(Set<LogAppender.AppenderFlag> flags);
@@ -667,10 +673,10 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 				+ flags + "]";
 	}
 
-	@Override
-	public boolean visit(AppenderVisitor visitor) {
-		return visitor.consume(this);
-	}
+	// @Override
+	// public <R> Optional<R> visit(AppenderVisitor<R> visitor) {
+	// return visitor.apply(this);
+	// }
 
 	@Override
 	public String name() {
@@ -753,13 +759,20 @@ sealed interface BaseComposite<T extends InternalLogAppender> extends InternalLo
 	}
 
 	@Override
-	default boolean visit(AppenderVisitor visitor) {
-		for (var appender : components()) {
-			if (appender.visit(visitor)) {
-				return true;
+	default <R> Optional<R> visit(AppenderVisitor<R> visitor) {
+		lock().lock();
+		try {
+			for (var appender : components()) {
+				var o = appender.visit(visitor);
+				if (o.isPresent()) {
+					return o;
+				}
 			}
+			return Optional.empty();
 		}
-		return false;
+		finally {
+			lock().unlock();
+		}
 	}
 
 	@Override
@@ -833,6 +846,17 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 		}
 		catch (UncheckedIOException ioe) {
 			return List.of(new Response(LogOutput.class, name, Status.ErrorStatus.of(ioe)));
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public <R> Optional<R> visit(AppenderVisitor<R> visitor) {
+		lock.lock();
+		try {
+			return visitor.apply(this);
 		}
 		finally {
 			lock.unlock();

--- a/core/src/main/java/io/jstach/rainbowgum/LogOutputRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutputRegistry.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import io.jstach.rainbowgum.LogOutput.OutputProvider;
 import io.jstach.rainbowgum.output.FileOutput;
@@ -33,11 +35,26 @@ public sealed interface LogOutputRegistry extends OutputProvider permits Default
 	 * @param scheme URI scheme to match for.
 	 * @param provider provider for scheme.
 	 */
-	public void register(String scheme, OutputProvider provider);
+	void register(String scheme, OutputProvider provider);
 
 	/**
-	 * Finds an output by name.
-	 * @param name output name.
+	 * Allows you to perform a safe operation on the {@link LogOutput} corresponding to
+	 * the named appender by calling the function within the appender locking mechanism.
+	 * The output will not get any write calls through the publisher/appender while the
+	 * passed in function is being called.
+	 * @param <R> return type.
+	 * @param name the appender name.
+	 * @param action function to perform the operation. <strong>The function not share the
+	 * output outside.</strong> If the function returns <code>null</code> the returned
+	 * optional will always be empty but the function may have been applied so it is
+	 * recommend you do not do this.
+	 * @return user desired return if an appender is found.
+	 */
+	<R> Optional<? extends R> useOutput(String name, Function<? super LogOutput, ? extends R> action);
+
+	/**
+	 * Finds an output by name of the appender.
+	 * @param name of appender that owns output (and not the configuration name).
 	 * @return maybe an output.
 	 */
 	Optional<LogOutput> output(String name);
@@ -49,7 +66,7 @@ public sealed interface LogOutputRegistry extends OutputProvider permits Default
 	 * @return the output status of reopened outputs or an empty list if no outputs were
 	 * reopened.
 	 */
-	public List<LogResponse> reopen();
+	List<LogResponse> reopen();
 
 	/**
 	 * Attempts to flush all outputs usually for log rotation. This call will block if it
@@ -57,13 +74,13 @@ public sealed interface LogOutputRegistry extends OutputProvider permits Default
 	 * @return the output status of reopened outputs or an empty list if no outputs were
 	 * reopened.
 	 */
-	public List<LogResponse> flush();
+	List<LogResponse> flush();
 
 	/**
 	 * Will retrieve the status of all outputs usually for health checking.
 	 * @return list of status of outputs.
 	 */
-	public List<LogResponse> status();
+	List<LogResponse> status();
 
 }
 
@@ -107,6 +124,15 @@ final class DefaultOutputRegistry implements LogOutputRegistry {
 		return _request(LogAction.StandardAction.STATUS);
 	}
 
+	@Override
+	public <R> Optional<? extends R> useOutput(String name, Function<? super LogOutput, ? extends R> action) {
+		return findAppenders().map(a -> a.useOutput(name, action)).flatMap(o -> o.stream()).findFirst();
+	}
+
+	private Stream<InternalLogAppender> findAppenders() {
+		return serviceRegistry.find(LogAppender.class).stream().map(a -> InternalLogAppender.of(a));
+	}
+
 	private List<LogResponse> requestIO(LogAction action) {
 		if (reopenLock.tryLock()) {
 			try {
@@ -125,8 +151,7 @@ final class DefaultOutputRegistry implements LogOutputRegistry {
 		/*
 		 * TODO check rainbowgum is actually running.
 		 */
-		return Actor.act(serviceRegistry.find(LogAppender.class).stream().map(a -> InternalLogAppender.of(a)).toList(),
-				action);
+		return Actor.act(findAppenders().toList(), action);
 	}
 
 	@Override


### PR DESCRIPTION
This callback in the output registry allows one to safely perform operations on the `LogOutput` by using the appender lock mechanism to help continue keeping locking/reentry protection out of LogOutput.

Currently it only performs one operation on the named appender. Perhaps in the future we allow a callback that is `void` and is given more meta data about the appender but for now this will help meet the need of someone buffering a window LogOutput data to be fetched. See #269 .