### PR TITLE
Issue 276 allow null

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
@@ -40,7 +40,7 @@ public sealed interface LogEvent {
 	 * @see LevelResolver
 	 * @apiNote the message is already assumed to be formatted as no arguments are passed.
 	 */
-	public static LogEvent of(System.Logger.Level level, String loggerName, String formattedMessage,
+	public static LogEvent of(System.Logger.Level level, String loggerName, @Nullable String formattedMessage,
 			KeyValues keyValues, @Nullable Throwable throwable) {
 		Instant timeStamp = Instant.now();
 		Thread currentThread = Thread.currentThread();
@@ -62,7 +62,7 @@ public sealed interface LogEvent {
 	 * @see LevelResolver
 	 * @apiNote the message is already assumed to be formatted as no arguments are passed.
 	 */
-	static LogEvent of(System.Logger.Level level, String loggerName, String formattedMessage,
+	static LogEvent of(System.Logger.Level level, String loggerName, @Nullable String formattedMessage,
 			@Nullable Throwable throwable) {
 		return of(level, loggerName, formattedMessage, KeyValues.of(), throwable);
 	}
@@ -80,14 +80,18 @@ public sealed interface LogEvent {
 	 * @see LevelResolver
 	 * @see LogMessageFormatter
 	 */
-	public static LogEvent of(System.Logger.Level level, String loggerName, String message, KeyValues keyValues,
-			LogMessageFormatter messageFormatter, @Nullable Object arg1) {
+	public static LogEvent of(System.Logger.Level level, String loggerName, @Nullable String message,
+			KeyValues keyValues, LogMessageFormatter messageFormatter, @Nullable Object arg1) {
 		Instant timeStamp = Instant.now();
 		Thread currentThread = Thread.currentThread();
 		String threadName = currentThread.getName();
 		long threadId = currentThread.threadId();
 		if (arg1 instanceof Throwable t) {
 			return new DefaultLogEvent(timeStamp, threadName, threadId, level, loggerName, message, keyValues, t);
+		}
+		if (message == null) {
+			return new DefaultLogEvent(timeStamp, threadName, threadId, level, loggerName, message, keyValues, null);
+
 		}
 		return new OneArgLogEvent(timeStamp, threadName, threadId, level, loggerName, message, keyValues,
 				messageFormatter, null, arg1);
@@ -107,12 +111,15 @@ public sealed interface LogEvent {
 	 * @see LevelResolver
 	 * @see LogMessageFormatter
 	 */
-	public static LogEvent of(System.Logger.Level level, String loggerName, String message, KeyValues keyValues,
-			LogMessageFormatter messageFormatter, @Nullable Object arg1, @Nullable Object arg2) {
+	public static LogEvent of(System.Logger.Level level, String loggerName, @Nullable String message,
+			KeyValues keyValues, LogMessageFormatter messageFormatter, @Nullable Object arg1, @Nullable Object arg2) {
 		Instant timeStamp = Instant.now();
 		Thread currentThread = Thread.currentThread();
 		String threadName = currentThread.getName();
 		long threadId = currentThread.threadId();
+		if (message == null) {
+			return new DefaultLogEvent(timeStamp, threadName, threadId, level, loggerName, message, keyValues, null);
+		}
 		if (arg2 instanceof Throwable t) {
 			return new OneArgLogEvent(timeStamp, threadName, threadId, level, loggerName, message, keyValues,
 					messageFormatter, t, arg1);
@@ -164,7 +171,7 @@ public sealed interface LogEvent {
 	 * @see LogMessageFormatter
 	 */
 	public static LogEvent ofAll(Instant timestamp, String threadName, long threadId, System.Logger.Level level,
-			String loggerName, String message, KeyValues keyValues, @Nullable Throwable throwable,
+			String loggerName, @Nullable String message, KeyValues keyValues, @Nullable Throwable throwable,
 			LogMessageFormatter messageFormatter, @SuppressWarnings("exports") @Nullable List<@Nullable Object> args) {
 
 		if (args == null) {
@@ -176,6 +183,11 @@ public sealed interface LogEvent {
 			throwable = t;
 			length = length - 1;
 		}
+		if (message == null) {
+			return new DefaultLogEvent(timestamp, threadName, threadId, level, loggerName, message, keyValues,
+					throwable);
+		}
+
 		return switch (length) {
 			case 0 ->
 				new DefaultLogEvent(timestamp, threadName, threadId, level, loggerName, message, keyValues, throwable);
@@ -207,7 +219,7 @@ public sealed interface LogEvent {
 	 * @see LogMessageFormatter
 	 */
 	public static LogEvent ofAll(Instant timestamp, String threadName, long threadId, System.Logger.Level level,
-			String loggerName, String message, KeyValues keyValues, @Nullable Throwable throwable,
+			String loggerName, @Nullable String message, KeyValues keyValues, @Nullable Throwable throwable,
 			LogMessageFormatter messageFormatter, @SuppressWarnings("exports") @Nullable Object @Nullable [] args) {
 
 		if (args == null) {
@@ -219,6 +231,11 @@ public sealed interface LogEvent {
 			throwable = t;
 			length = length - 1;
 		}
+		if (message == null) {
+			return new DefaultLogEvent(timestamp, threadName, threadId, level, loggerName, message, keyValues,
+					throwable);
+		}
+
 		return switch (length) {
 			case 0 ->
 				new DefaultLogEvent(timestamp, threadName, threadId, level, loggerName, message, keyValues, throwable);
@@ -281,6 +298,15 @@ public sealed interface LogEvent {
 	 * @see #formattedMessage(StringBuilder)
 	 */
 	public String message();
+
+	/**
+	 * If the event has a message or not. Because the return of {@link #message()} is non
+	 * null there is no way to detect that a message is missing.
+	 * @return <code>true</code> if this event has a message.
+	 */
+	default public boolean hasMessage() {
+		return true;
+	}
 
 	/**
 	 * Appends the formatted message.
@@ -735,13 +761,13 @@ record OneArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 		@Nullable Object arg1) implements LogEvent {
 
 	OneArgLogEvent {
-		timestamp = Objects.requireNonNull(timestamp, "timestamp");
-		threadName = Objects.requireNonNull(threadName, "threadName");
-		level = Objects.requireNonNull(level, "level");
-		loggerName = Objects.requireNonNull(loggerName, "loggerName");
-		message = Objects.requireNonNull(message, "message");
-		keyValues = Objects.requireNonNull(keyValues, "keyValues");
-		messageFormatter = Objects.requireNonNull(messageFormatter, "messageFormatter");
+		Objects.requireNonNull(timestamp, "timestamp");
+		Objects.requireNonNull(threadName, "threadName");
+		Objects.requireNonNull(level, "level");
+		Objects.requireNonNull(loggerName, "loggerName");
+		Objects.requireNonNull(message, "message");
+		Objects.requireNonNull(keyValues, "keyValues");
+		Objects.requireNonNull(messageFormatter, "messageFormatter");
 	}
 
 	@Override
@@ -769,13 +795,13 @@ record TwoArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 		@Nullable Object arg1, @Nullable Object arg2) implements LogEvent {
 
 	TwoArgLogEvent {
-		timestamp = Objects.requireNonNull(timestamp, "timestamp");
-		threadName = Objects.requireNonNull(threadName, "threadName");
-		level = Objects.requireNonNull(level, "level");
-		loggerName = Objects.requireNonNull(loggerName, "loggerName");
-		message = Objects.requireNonNull(message, "message");
-		keyValues = Objects.requireNonNull(keyValues, "keyValues");
-		messageFormatter = Objects.requireNonNull(messageFormatter, "messageFormatter");
+		Objects.requireNonNull(timestamp, "timestamp");
+		Objects.requireNonNull(threadName, "threadName");
+		Objects.requireNonNull(level, "level");
+		Objects.requireNonNull(loggerName, "loggerName");
+		Objects.requireNonNull(message, "message");
+		Objects.requireNonNull(keyValues, "keyValues");
+		Objects.requireNonNull(messageFormatter, "messageFormatter");
 	}
 
 	@Override
@@ -803,13 +829,13 @@ record ArrayArgLogEvent(Instant timestamp, String threadName, long threadId, Sys
 		@Nullable Throwable throwableOrNull, @Nullable Object[] args, int length) implements LogEvent {
 
 	ArrayArgLogEvent {
-		timestamp = Objects.requireNonNull(timestamp, "timestamp");
-		threadName = Objects.requireNonNull(threadName, "threadName");
-		level = Objects.requireNonNull(level, "level");
-		loggerName = Objects.requireNonNull(loggerName, "loggerName");
-		message = Objects.requireNonNull(message, "message");
-		keyValues = Objects.requireNonNull(keyValues, "keyValues");
-		messageFormatter = Objects.requireNonNull(messageFormatter, "messageFormatter");
+		Objects.requireNonNull(timestamp, "timestamp");
+		Objects.requireNonNull(threadName, "threadName");
+		Objects.requireNonNull(level, "level");
+		Objects.requireNonNull(loggerName, "loggerName");
+		Objects.requireNonNull(message, "message");
+		Objects.requireNonNull(keyValues, "keyValues");
+		Objects.requireNonNull(messageFormatter, "messageFormatter");
 	}
 
 	@Override
@@ -837,16 +863,15 @@ record ArrayArgLogEvent(Instant timestamp, String threadName, long threadId, Sys
 }
 
 record DefaultLogEvent(Instant timestamp, String threadName, long threadId, System.Logger.Level level,
-		String loggerName, String formattedMessage, KeyValues keyValues,
+		String loggerName, @Nullable String formattedMessage, KeyValues keyValues,
 		@Nullable Throwable throwableOrNull) implements LogEvent {
 
 	DefaultLogEvent {
-		timestamp = Objects.requireNonNull(timestamp, "timestamp");
-		threadName = Objects.requireNonNull(threadName, "threadName");
-		level = Objects.requireNonNull(level, "level");
-		loggerName = Objects.requireNonNull(loggerName, "loggerName");
-		formattedMessage = Objects.requireNonNull(formattedMessage, "formattedMessage");
-		keyValues = Objects.requireNonNull(keyValues, "keyValues");
+		Objects.requireNonNull(timestamp, "timestamp");
+		Objects.requireNonNull(threadName, "threadName");
+		Objects.requireNonNull(level, "level");
+		Objects.requireNonNull(loggerName, "loggerName");
+		Objects.requireNonNull(keyValues, "keyValues");
 	}
 
 	@Override
@@ -856,7 +881,12 @@ record DefaultLogEvent(Instant timestamp, String threadName, long threadId, Syst
 
 	@Override
 	public String message() {
-		return this.formattedMessage;
+		return "" + this.formattedMessage;
+	}
+
+	@Override
+	public boolean hasMessage() {
+		return this.formattedMessage != null;
 	}
 
 	@Override

--- a/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
@@ -6,6 +6,7 @@ import java.lang.System.Logger.Level;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -733,6 +734,16 @@ record OneArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 		String message, KeyValues keyValues, LogMessageFormatter messageFormatter, @Nullable Throwable throwableOrNull,
 		@Nullable Object arg1) implements LogEvent {
 
+	OneArgLogEvent {
+		timestamp = Objects.requireNonNull(timestamp, "timestamp");
+		threadName = Objects.requireNonNull(threadName, "threadName");
+		level = Objects.requireNonNull(level, "level");
+		loggerName = Objects.requireNonNull(loggerName, "loggerName");
+		message = Objects.requireNonNull(message, "message");
+		keyValues = Objects.requireNonNull(keyValues, "keyValues");
+		messageFormatter = Objects.requireNonNull(messageFormatter, "messageFormatter");
+	}
+
 	@Override
 	public void formattedMessage(StringBuilder sb) {
 		messageFormatter.format(sb, message, arg1);
@@ -757,6 +768,16 @@ record TwoArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 		String message, KeyValues keyValues, LogMessageFormatter messageFormatter, @Nullable Throwable throwableOrNull,
 		@Nullable Object arg1, @Nullable Object arg2) implements LogEvent {
 
+	TwoArgLogEvent {
+		timestamp = Objects.requireNonNull(timestamp, "timestamp");
+		threadName = Objects.requireNonNull(threadName, "threadName");
+		level = Objects.requireNonNull(level, "level");
+		loggerName = Objects.requireNonNull(loggerName, "loggerName");
+		message = Objects.requireNonNull(message, "message");
+		keyValues = Objects.requireNonNull(keyValues, "keyValues");
+		messageFormatter = Objects.requireNonNull(messageFormatter, "messageFormatter");
+	}
+
 	@Override
 	public void formattedMessage(StringBuilder sb) {
 		messageFormatter.format(sb, message, arg1, arg2);
@@ -780,6 +801,16 @@ record TwoArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 record ArrayArgLogEvent(Instant timestamp, String threadName, long threadId, System.Logger.Level level,
 		String loggerName, String message, KeyValues keyValues, LogMessageFormatter messageFormatter,
 		@Nullable Throwable throwableOrNull, @Nullable Object[] args, int length) implements LogEvent {
+
+	ArrayArgLogEvent {
+		timestamp = Objects.requireNonNull(timestamp, "timestamp");
+		threadName = Objects.requireNonNull(threadName, "threadName");
+		level = Objects.requireNonNull(level, "level");
+		loggerName = Objects.requireNonNull(loggerName, "loggerName");
+		message = Objects.requireNonNull(message, "message");
+		keyValues = Objects.requireNonNull(keyValues, "keyValues");
+		messageFormatter = Objects.requireNonNull(messageFormatter, "messageFormatter");
+	}
 
 	@Override
 	public void formattedMessage(StringBuilder sb) {
@@ -808,6 +839,15 @@ record ArrayArgLogEvent(Instant timestamp, String threadName, long threadId, Sys
 record DefaultLogEvent(Instant timestamp, String threadName, long threadId, System.Logger.Level level,
 		String loggerName, String formattedMessage, KeyValues keyValues,
 		@Nullable Throwable throwableOrNull) implements LogEvent {
+
+	DefaultLogEvent {
+		timestamp = Objects.requireNonNull(timestamp, "timestamp");
+		threadName = Objects.requireNonNull(threadName, "threadName");
+		level = Objects.requireNonNull(level, "level");
+		loggerName = Objects.requireNonNull(loggerName, "loggerName");
+		formattedMessage = Objects.requireNonNull(formattedMessage, "formattedMessage");
+		keyValues = Objects.requireNonNull(keyValues, "keyValues");
+	}
 
 	@Override
 	public void formattedMessage(StringBuilder sb) {

--- a/rainbowgum-jdk/src/main/java/io/jstach/rainbowgum/jdk/jul/SystemLoggerQueueJULHandler.java
+++ b/rainbowgum-jdk/src/main/java/io/jstach/rainbowgum/jdk/jul/SystemLoggerQueueJULHandler.java
@@ -3,7 +3,6 @@ package io.jstach.rainbowgum.jdk.jul;
 import java.lang.System.Logger.Level;
 import java.time.Instant;
 import java.util.MissingResourceException;
-import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
@@ -81,7 +80,7 @@ final class SystemLoggerQueueJULHandler extends Handler {
 				args = null;
 			}
 			else {
-				msg = Objects.requireNonNullElse(rec.getMessage(), "");
+				msg = rec.getMessage();
 				args = rec.getParameters();
 			}
 

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/EventCreator.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/EventCreator.java
@@ -22,8 +22,7 @@ interface EventCreator<LEVEL> {
 		var sysLevel = translateLevel(level);
 		var loggerName = loggerName();
 		var keyValues = keyValues();
-		return LogEvent.of(sysLevel, loggerName, formattedMessage == null ? "" : formattedMessage, keyValues,
-				throwable);
+		return LogEvent.of(sysLevel, loggerName, formattedMessage, keyValues, throwable);
 	}
 
 	default LogEvent event0(LEVEL level, @Nullable String formattedMessage) {
@@ -34,23 +33,21 @@ interface EventCreator<LEVEL> {
 		var sysLevel = translateLevel(level);
 		var loggerName = loggerName();
 		var keyValues = keyValues();
-		return LogEvent.of(sysLevel, loggerName, message == null ? "" : message, keyValues, messageFormatter(), arg1);
+		return LogEvent.of(sysLevel, loggerName, message, keyValues, messageFormatter(), arg1);
 	}
 
 	default LogEvent event2(LEVEL level, @Nullable String message, Object arg1, Object arg2) {
 		var sysLevel = translateLevel(level);
 		var loggerName = loggerName();
 		var keyValues = keyValues();
-		return LogEvent.of(sysLevel, loggerName, message == null ? "" : message, keyValues, messageFormatter(), arg1,
-				arg2);
+		return LogEvent.of(sysLevel, loggerName, message, keyValues, messageFormatter(), arg1, arg2);
 	}
 
 	default LogEvent eventArray(LEVEL level, @Nullable String message, Object[] args) {
 		var sysLevel = translateLevel(level);
 		var loggerName = loggerName();
 		var keyValues = keyValues();
-		return LogEvent.ofArgs(sysLevel, loggerName, message == null ? "" : message, keyValues, messageFormatter(),
-				args);
+		return LogEvent.ofArgs(sysLevel, loggerName, message, keyValues, messageFormatter(), args);
 	}
 
 }

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilder.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilder.java
@@ -35,7 +35,7 @@ class RainbowGumEventBuilder implements LoggingEventBuilder, DepthAwareEventBuil
 
 	private final Level level;
 
-	private String message = "";
+	private @Nullable String message;
 
 	@Nullable
 	private Throwable throwable;
@@ -121,7 +121,7 @@ class RainbowGumEventBuilder implements LoggingEventBuilder, DepthAwareEventBuil
 
 	@Override
 	public LoggingEventBuilder setMessage(String message) {
-		this.message = Objects.requireNonNullElse(message, "");
+		this.message = message;
 		return this;
 	}
 

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerMethodTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerMethodTest.java
@@ -96,7 +96,7 @@ public class LoggerMethodTest {
 		@Override
 		public String test(Level level, Logger logger) {
 			method.nullMessageTest(level, logger);
-			return "";
+			return "null";
 		}
 
 		static LoggerMethod wrap(LoggingLoggerMethod m) {

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/LevelSystemLogger.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/LevelSystemLogger.java
@@ -3,6 +3,7 @@ package io.jstach.rainbowgum.systemlogger;
 import static java.util.Objects.requireNonNullElse;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.function.Supplier;
 
@@ -67,7 +68,7 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 	@Override
 	public void log(Level level, @Nullable String msg) {
 		if (isLoggable(level)) {
-			String formattedMessage = msg == null ? "" : msg;
+			String formattedMessage = msg;
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, null);
 			logger.log(event);
 		}
@@ -83,9 +84,11 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 	}
 
 	@Override
-	public void log(Level level, @Nullable Object obj) {
+	public void log(Level level, Object obj) {
+		// Technically we should check if obj is null first.
+		Objects.requireNonNull(obj, "obj");
 		if (isLoggable(level)) {
-			String formattedMessage = obj == null ? "" : obj.toString();
+			String formattedMessage = obj.toString();
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, null);
 			logger.log(event);
 		}
@@ -94,7 +97,7 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 	@Override
 	public void log(Level level, @Nullable String msg, @Nullable Throwable thrown) {
 		if (isLoggable(level)) {
-			String formattedMessage = requireNonNullElse(msg, "");
+			String formattedMessage = msg;
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, thrown);
 			logger.log(event);
 		}
@@ -103,7 +106,7 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 	@Override
 	public void log(Level level, Supplier<String> msgSupplier, Throwable thrown) {
 		if (isLoggable(level)) {
-			String formattedMessage = requireNonNullElse(msgSupplier.get(), "");
+			String formattedMessage = msgSupplier.get();
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, thrown);
 			logger.log(event);
 		}
@@ -116,7 +119,7 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 			Instant timestamp = Instant.now();
 			String threadName = currentThread.getName();
 			long threadId = currentThread.threadId();
-			String message = requireNonNullElse(format, "");
+			String message = format;
 			Throwable throwable = null;
 			LogEvent event = LogEvent.ofAll(timestamp, threadName, threadId, level, loggerName, message, KeyValues.of(),
 					throwable, StandardMessageFormatter.JUL, params);
@@ -127,7 +130,7 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 	@Override
 	public void log(Level level, @Nullable ResourceBundle bundle, @Nullable String msg, @Nullable Throwable thrown) {
 		if (isLoggable(level)) {
-			String formattedMessage = requireNonNullElse(msg, "");
+			String formattedMessage = msg;
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, thrown);
 			logger.log(event);
 		}
@@ -140,7 +143,7 @@ record LevelSystemLogger(String loggerName, int level, LogEventLogger logger) im
 			Instant timestamp = Instant.now();
 			String threadName = currentThread.getName();
 			long threadId = currentThread.threadId();
-			String message = requireNonNullElse(format, "");
+			String message = format;
 			Throwable throwable = null;
 			LogEvent event = LogEvent.ofAll(timestamp, threadName, threadId, level, loggerName, message, KeyValues.of(),
 					throwable, StandardMessageFormatter.JUL, params);

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLogger.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLogger.java
@@ -1,8 +1,7 @@
 package io.jstach.rainbowgum.systemlogger;
 
-import static java.util.Objects.requireNonNullElse;
-
 import java.time.Instant;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.function.Supplier;
 
@@ -72,6 +71,7 @@ public final class RainbowGumSystemLogger implements System.Logger {
 
 	@Override
 	public void log(Level level, Object obj) {
+		Objects.requireNonNull(obj, "obj");
 		level = fixLevel(level);
 		var route = router.route(loggerName, level);
 		if (route.isEnabled()) {
@@ -86,8 +86,7 @@ public final class RainbowGumSystemLogger implements System.Logger {
 		level = fixLevel(level);
 		var route = router.route(loggerName, level);
 		if (route.isEnabled()) {
-			String formattedMessage = requireNonNullElse(msg, "");
-			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, throwable);
+			LogEvent event = LogEvent.of(level, loggerName, msg, throwable);
 			route.log(event);
 		}
 	}
@@ -98,7 +97,7 @@ public final class RainbowGumSystemLogger implements System.Logger {
 		level = fixLevel(level);
 		var route = router.route(loggerName, level);
 		if (route.isEnabled()) {
-			String formattedMessage = requireNonNullElse(msgSupplier.get(), "");
+			String formattedMessage = msgSupplier.get();
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, throwable);
 			route.log(event);
 		}
@@ -123,7 +122,7 @@ public final class RainbowGumSystemLogger implements System.Logger {
 			Instant timestamp = Instant.now();
 			String threadName = Thread.currentThread().getName();
 			long threadId = Thread.currentThread().threadId();
-			String message = requireNonNullElse(format, "");
+			String message = format;
 			Throwable throwable = null;
 			LogEvent event = LogEvent.ofAll(timestamp, threadName, threadId, level, loggerName, message, KeyValues.of(),
 					throwable, StandardMessageFormatter.JUL, args);

--- a/test/rainbowgum-test-jdk/src/test/java/io/jstach/rainbowgum/test/jdk/JDKSetupTest.java
+++ b/test/rainbowgum-test-jdk/src/test/java/io/jstach/rainbowgum/test/jdk/JDKSetupTest.java
@@ -96,10 +96,10 @@ class JDKSetupTest {
 	@Order(5)
 	@ParameterizedTest
 	@MethodSource("provideLevels")
-	void testMessage(LoggerTester<?> tester, System.Logger.Level level, System.Logger.Level loggerLevel)
-			throws InterruptedException {
+	void testMessage(LoggerTester<?> tester, System.Logger.Level level, System.Logger.Level loggerLevel,
+			Message message) throws InterruptedException {
 		doInLock(() -> {
-			_testMessage(tester, level, loggerLevel);
+			_testMessage(tester, level, loggerLevel, message);
 		});
 
 	}
@@ -116,7 +116,7 @@ class JDKSetupTest {
 
 	@Order(7)
 	@ParameterizedTest
-	@MethodSource("provideOneArg")
+	@MethodSource("provideObject")
 	void testObject(LoggerTester<?> tester, System.Logger.Level level, System.Logger.Level loggerLevel, Arg arg)
 			throws InterruptedException {
 		doInLock(() -> {
@@ -263,6 +263,8 @@ class JDKSetupTest {
 			return false;
 		}
 
+		public boolean supportsObject();
+
 	}
 
 	enum JULLoggerTester implements LoggerTester<java.util.logging.Logger> {
@@ -290,6 +292,11 @@ class JDKSetupTest {
 
 		public void object(java.util.logging.Logger logger, System.Logger.Level level, Arg arg) {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean supportsObject() {
+			return false;
 		}
 
 		public void oneArg(java.util.logging.Logger logger, System.Logger.Level level, String message, Arg arg) {
@@ -427,7 +434,11 @@ class JDKSetupTest {
 		@Override
 		public void object(java.lang.System.Logger logger, Level level, Arg message) {
 			logger.log(level, message.arg);
+		}
 
+		@Override
+		public boolean supportsObject() {
+			return true;
 		}
 
 		@Override
@@ -464,9 +475,10 @@ class JDKSetupTest {
 		}
 	}
 
-	<T> void _testMessage(LoggerTester<T> tester, System.Logger.Level level, System.Logger.Level loggerLevel) {
+	<T> void _testMessage(LoggerTester<T> tester, System.Logger.Level level, System.Logger.Level loggerLevel,
+			Message mess) {
 		ListLogOutput output = new ListLogOutput();
-		String message = "Hello!";
+		String message = mess.value();
 
 		var logger = tester.beforeLoad();
 		try (var gum = tester.run(output, loggerLevel)) {
@@ -476,8 +488,8 @@ class JDKSetupTest {
 			String expected;
 			if (isEnabled(level, loggerLevel)) {
 				expected = """
-						00:00:00.000 [main] %s after.load - Hello!
-						""".formatted(levelString);
+						00:00:00.000 [main] %s after.load - %s
+						""".formatted(levelString, message);
 			}
 			else {
 				expected = "";
@@ -528,6 +540,10 @@ class JDKSetupTest {
 	}
 
 	<T> void _testObject(LoggerTester<T> tester, System.Logger.Level level, System.Logger.Level loggerLevel, Arg arg) {
+		if (!tester.supportsObject()) {
+			abort("no supported");
+			return;
+		}
 		ListLogOutput output = new ListLogOutput();
 		Object message = arg.arg;
 
@@ -536,6 +552,13 @@ class JDKSetupTest {
 			var _logger = logger = tester.afterLoad(logger);
 			if (arg == Arg.BAD && isEnabled(level, loggerLevel)) {
 				assertThrows(RuntimeException.class, () -> {
+					tester.object(_logger, level, arg);
+					fail("fuck");
+				});
+				return;
+			}
+			if (arg == Arg.NULL) {
+				assertThrows(NullPointerException.class, () -> {
 					tester.object(_logger, level, arg);
 				});
 				return;
@@ -711,7 +734,9 @@ class JDKSetupTest {
 		for (var tester : provideTesters()) {
 			for (var level : System.Logger.Level.values()) {
 				for (var loggerLevel : System.Logger.Level.values()) {
-					args.add(Arguments.of(tester, level, loggerLevel));
+					for (var message : Message.values()) {
+						args.add(Arguments.of(tester, level, loggerLevel, message));
+					}
 				}
 			}
 		}
@@ -721,6 +746,23 @@ class JDKSetupTest {
 	private static Stream<Arguments> provideOneArg() {
 		List<Arguments> args = new ArrayList<>();
 		for (var tester : provideTesters()) {
+			for (var level : System.Logger.Level.values()) {
+				for (var loggerLevel : System.Logger.Level.values()) {
+					for (var arg : Arg.values()) {
+						args.add(Arguments.of(tester, level, loggerLevel, arg));
+					}
+				}
+			}
+		}
+		return args.stream();
+	}
+
+	private static Stream<Arguments> provideObject() {
+		List<Arguments> args = new ArrayList<>();
+		for (var tester : provideTesters()) {
+			if (!tester.supportsObject()) {
+				continue;
+			}
 			for (var level : System.Logger.Level.values()) {
 				for (var loggerLevel : System.Logger.Level.values()) {
 					for (var arg : Arg.values()) {
@@ -798,11 +840,30 @@ class JDKSetupTest {
 
 	}
 
+	enum Message {
+
+		HELLO("Hello", "Hello"), NULL(null, "null");
+
+		private final @Nullable String value;
+
+		private final String expected;
+
+		private Message(@Nullable String value, String expected) {
+			this.value = value;
+			this.expected = expected;
+		}
+
+		public String value() {
+			return this.value;
+		}
+
+	}
+
 	@SuppressWarnings("ImmutableEnumChecker")
 	enum Arg {
 
 		BAD("[MessageFormat failed: expected]", new BadToString()), //
-		STRING("hello", "hello"), //
+		NULL("null", null), STRING("hello", "hello"), //
 		INTEGER("1", 1), //
 		;
 


### PR DESCRIPTION
This is a substantial change in that we now allow null messages to be tracked and distinguished from "".

Ultimately @Fleshgrinder and the preponderance of existing logging allowing null messages convinced me.

Null analysis still has to be improved in general but we added more testing for handling of null as well as null defensive programming that was not there before.