### PR TITLE
Escape JSON field names and stop RawJsonWriter throwing on bad surrogates

### DIFF
--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/JsonBuffer.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/JsonBuffer.java
@@ -233,16 +233,15 @@ public final class JsonBuffer implements Buffer {
 		}
 		if ((flag & EXTENDED_F) == EXTENDED_F) {
 			/*
-			 * TODO on minor version offer a prefix suffix write as this is probably less
-			 * efficient. https://github.com/jstachio/rainbowgum/issues/208
+			 * Field names come from application controlled data (e.g. MDC keys) and must
+			 * be JSON escaped just like values otherwise a key containing a quote can
+			 * break out of the field name and forge sibling fields.
+			 * https://github.com/jstachio/rainbowgum/issues/208
 			 */
-			jsonWriter.writeByte(RawJsonWriter.QUOTE);
-			jsonWriter.writeByte(extendedFieldPrefix.raw);
-			jsonWriter.writeAscii(k);
-			jsonWriter.writeByte(RawJsonWriter.QUOTE);
+			jsonWriter.writeString(((char) extendedFieldPrefix.raw) + k);
 		}
 		else {
-			jsonWriter.writeAsciiString(k);
+			jsonWriter.writeString(k);
 		}
 		jsonWriter.writeByte(SEMI);
 	}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/RawJsonWriter.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/RawJsonWriter.java
@@ -299,8 +299,15 @@ class RawJsonWriter {
 					_result[cur++] = (byte) (0x80 | (cp & 0x3F));
 				}
 				else {
-					throw new IllegalArgumentException(
-							"Unknown unicode codepoint in string! " + Integer.toHexString(cp));
+					/*
+					 * An unpaired UTF-16 surrogate (e.g. malformed input reaching a log
+					 * message or MDC value). A logging encoder must not throw on
+					 * adversarial/malformed input, so emit the Unicode replacement
+					 * character (U+FFFD) instead of a real codepoint for it.
+					 */
+					_result[cur++] = (byte) 0xEF;
+					_result[cur++] = (byte) 0xBF;
+					_result[cur++] = (byte) 0xBD;
 				}
 			}
 		}

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
@@ -150,6 +150,43 @@ class GelfEncoderTest {
 		}
 	}
 
+	@Test
+	void testMdcKeyIsEscaped() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(GelfEncoder.of(gelf -> gelf.host("somehost")));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			var kvs = MutableKeyValues.of().add("k\"1", "v1");
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "gelf", "hello", kvs, null).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"_k\\\"1\":\"v1\""),
+					"MDC key containing a quote must be escaped, not break out of the field name. Got: " + actual);
+		}
+	}
+
+	@Test
+	void testUnpairedSurrogateDoesNotThrow() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(GelfEncoder.of(gelf -> gelf.host("somehost")));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			// lone high surrogate with no matching low surrogate.
+			String malformed = "bad\uD800end";
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "gelf", malformed, null).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			// U+FFFD replacement character encoded as UTF-8.
+			assertTrue(actual.contains("bad�end"), "Got: " + actual);
+		}
+	}
+
 	@ParameterizedTest
 	@EnumSource(GelfTest.class)
 	void test(GelfTest test) throws Exception {


### PR DESCRIPTION
JsonBuffer._writeStartField wrote field keys via writeAscii/ writeAsciiString, which do no JSON escaping (values already went through the proper escaping writeString). Since GelfEncoder writes every MDC entry as an extended field using the MDC key verbatim, an application-controlled key containing a double quote could break out of the field name and forge sibling JSON fields. Field names now go through the same writeString escaping path as values.

Separately, RawJsonWriter threw IllegalArgumentException for an unpaired UTF-16 surrogate reaching the encoder (e.g. from malformed input in a log message or MDC value). A logging encoder should never throw on adversarial/malformed input, so it now emits the Unicode replacement character (U+FFFD) instead.

Added regression tests for both cases.