### PR TITLE
Never let appender encode/write failures propagate to the caller

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -880,20 +880,31 @@ final class DefaultLogAppender extends LockLogAppender implements InternalLogApp
 
 	@Override
 	public final void append(LogEvent event) {
-		try (var buffer = encoder.buffer(output.bufferHints())) {
-			encoder.encode(event, buffer);
-			if (!lock.tryLock()) {
-				return;
-			}
-			try {
-				output.write(event, buffer);
-				if (immediateFlush) {
-					output.flush();
+		/*
+		 * A log call must never throw back into caller code. Encoding or writing a single
+		 * event can fail for reasons entirely out of the caller's control (a bad MDC
+		 * value, a full disk, a dropped socket) so failures here are reported out-of-band
+		 * via MetaLog instead of propagating.
+		 */
+		try {
+			try (var buffer = encoder.buffer(output.bufferHints())) {
+				encoder.encode(event, buffer);
+				if (!lock.tryLock()) {
+					return;
+				}
+				try {
+					output.write(event, buffer);
+					if (immediateFlush) {
+						output.flush();
+					}
+				}
+				finally {
+					lock.unlock();
 				}
 			}
-			finally {
-				lock.unlock();
-			}
+		}
+		catch (Exception e) {
+			MetaLog.error(getClass(), "appender '" + name + "' failed to append event", e);
 		}
 	}
 
@@ -903,9 +914,15 @@ final class DefaultLogAppender extends LockLogAppender implements InternalLogApp
 			return;
 		}
 		try {
-			output.write(events, count, encoder);
-			if (immediateFlush) {
-				output.flush();
+			try {
+				output.write(events, count, encoder);
+				if (immediateFlush) {
+					output.flush();
+				}
+			}
+			catch (Exception e) {
+				MetaLog.error(getClass(), "appender '" + name + "' failed to append batch of " + count + " event(s)",
+						e);
 			}
 		}
 		finally {
@@ -944,11 +961,16 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 			return;
 		}
 		try {
-			buffer.clear();
-			encoder.encode(event, buffer);
-			output.write(event, buffer);
-			if (immediateFlush) {
-				output.flush();
+			try {
+				buffer.clear();
+				encoder.encode(event, buffer);
+				output.write(event, buffer);
+				if (immediateFlush) {
+					output.flush();
+				}
+			}
+			catch (Exception e) {
+				MetaLog.error(getClass(), "appender '" + name + "' failed to append event", e);
 			}
 		}
 		finally {
@@ -962,9 +984,15 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 			return;
 		}
 		try {
-			output.write(events, count, encoder, buffer);
-			if (immediateFlush) {
-				output.flush();
+			try {
+				output.write(events, count, encoder, buffer);
+				if (immediateFlush) {
+					output.flush();
+				}
+			}
+			catch (Exception e) {
+				MetaLog.error(getClass(), "appender '" + name + "' failed to append batch of " + count + " event(s)",
+						e);
 			}
 		}
 		finally {

--- a/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
@@ -238,10 +238,19 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 	 */
 	default void write(LogEvent[] events, int count, LogEncoder encoder, Buffer buffer) {
 		for (int i = 0; i < count; i++) {
-			buffer.clear();
 			var event = events[i];
-			encoder.encode(event, buffer);
-			write(event, buffer);
+			try {
+				buffer.clear();
+				encoder.encode(event, buffer);
+				write(event, buffer);
+			}
+			catch (Exception e) {
+				/*
+				 * One bad event (e.g. a value that fails encoding) should not take down
+				 * the rest of the batch.
+				 */
+				MetaLog.error(LogOutput.class, "failed to write event index=" + i + " of " + count + " in batch", e);
+			}
 		}
 	}
 


### PR DESCRIPTION
DefaultLogAppender/ReuseBufferLogAppender.append() had no exception boundary around encoder.encode()/output.write(), so a single bad event (e.g. a value that fails to encode) would throw straight back through the router into whatever application thread called logger.info(...). The batch write loop in LogOutput.write(events[], count, encoder, buffer) had the same problem at per-event granularity, so one bad event in a batch also took out the rest of that batch.

Catch Exception (not Throwable/Error) at both points and report via MetaLog, matching the existing out-of-band reporting convention and the LogOutput javadoc's stated intent that write methods are expected to be resilient on their own. Per-appender catches also preserve sibling delivery in composite (multi-output) routes.

Exploratory change for discussion, not a final review.