### PR TITLE
Fix OptionTokenizer crashing on a truncated escape in a quoted option

### DIFF
--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/internal/OptionTokenizer.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/internal/OptionTokenizer.java
@@ -109,6 +109,18 @@ class OptionTokenizer {
 					break;
 			}
 
+			/*
+			 * The switch above (specifically the QUOTED_COLLECTING_STATE escape handling)
+			 * can advance tokenStream.pointer past what the loop guard above already
+			 * validated, e.g. when the escaped character is the last character in the
+			 * whole pattern. Re-check bounds here instead of blindly fetching, otherwise
+			 * a truncated escape sequence throws an uncaught
+			 * StringIndexOutOfBoundsException instead of the intended ScanException
+			 * below.
+			 */
+			if (tokenStream.pointer >= patternLength) {
+				break;
+			}
 			c = pattern.charAt(tokenStream.pointer);
 			tokenStream.pointer++;
 		}

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/internal/ParserTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/internal/ParserTest.java
@@ -47,6 +47,23 @@ class ParserTest {
 				actual);
 	}
 
+	@Test
+	void testTruncatedEscapeInQuotedOptionThrowsScanException() {
+		/*
+		 * A quoted %keyword{'...'} option whose content ends in a two character escape
+		 * sequence (backslash + one char) that is also the very last thing in the whole
+		 * pattern string. This previously threw an uncaught
+		 * StringIndexOutOfBoundsException from OptionTokenizer instead of the intended
+		 * ScanException.
+		 */
+		Throwable e = assertThrows(ScanException.class, () -> {
+			String input = "%d{'\\c";
+			Parser parser = new Parser(input);
+			parser.parse();
+		});
+		assertEquals("Unexpected end of pattern string in OptionTokenizer", e.getMessage());
+	}
+
 }
 
 // @formatter:off


### PR DESCRIPTION
tokenize() processes the current character in a switch, then unconditionally fetches the next one at the bottom of the loop body with no bounds check. The QUOTED_COLLECTING_STATE escape branch calls escape(), which does its own separately-guarded read and can advance tokenStream.pointer to patternLength when the escaped character is the very last character in the pattern. The following unconditional fetch then throws StringIndexOutOfBoundsException instead of the intended ScanException, and since Parser's constructor only catches IllegalArgumentException, that exception is not caught either - it propagates raw and undeclared out of `new Parser(pattern)`.

A malformed/truncated pattern string in something like logging.encoder.console.pattern reached this from user config, so it would surface as an uncaught crash pointing into tokenizer internals instead of a clean "your pattern is malformed" error.

Guard the fetch the same way escape() already guards its own read, and break out of the loop when out of characters - the existing EOS handling immediately below already throws the correct ScanException for this case.