### PR TITLE
Fix/mdc defensive copy

### DIFF
--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
@@ -6,6 +6,7 @@ import java.util.Deque;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.spi.MDCAdapter;
 
@@ -13,33 +14,88 @@ import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
 
 class ArrayMDCAdapter implements MDCAdapter {
 
-	final ThreadLocal<MutableKeyValues> mapThreadLocal = new ThreadLocal<>();
+	final ThreadLocal<MutableKeyValues> copyOnThreadLocal = new ThreadLocal<>();
 
-	@Override
-	public void put(String key, @Nullable String val) throws NullPointerException {
-		requireNonNull(key, "key cannot be null");
-		MutableKeyValues map = mapThreadLocal.get();
-		if (map == null) {
-			map = MutableKeyValues.of();
-			mapThreadLocal.set(map);
+	private static final int WRITE_OPERATION = 1;
+
+	private static final int MAP_COPY_OPERATION = 2;
+
+	// keeps track of the last operation performed
+	final ThreadLocal<Integer> lastOperation = new ThreadLocal<Integer>();
+
+	private Integer getAndSetLastOperation(int op) {
+		Integer lastOp = lastOperation.get();
+		lastOperation.set(op);
+		return lastOp;
+	}
+
+	private boolean wasLastOpReadOrNull(@Nullable Integer lastOp) {
+		return lastOp == null || lastOp.intValue() == MAP_COPY_OPERATION;
+	}
+
+	private MutableKeyValues duplicateAndInsertNewMap(@Nullable MutableKeyValues oldMap) {
+
+		MutableKeyValues newMap;
+
+		if (oldMap != null) {
+			// we don't want the parent thread modifying oldMap while we are
+			// iterating over it
+			synchronized (oldMap) {
+				newMap = oldMap.copy();
+			}
 		}
-		map.accept(key, val);
+		else {
+			newMap = MutableKeyValues.of();
+		}
+
+		copyOnThreadLocal.set(newMap);
+		return newMap;
 	}
 
 	@Override
-	public void remove(String key) {
-		if (Objects.isNull(key)) {
+	public void put(@NonNull String key, @Nullable String val) throws NullPointerException {
+		requireNonNull(key, "key cannot be null");
+
+		MutableKeyValues oldMap = copyOnThreadLocal.get();
+		Integer lastOp = getAndSetLastOperation(WRITE_OPERATION);
+
+		if (wasLastOpReadOrNull(lastOp) || oldMap == null) {
+			MutableKeyValues newMap = duplicateAndInsertNewMap(oldMap);
+			newMap.accept(key, val);
+		}
+		else {
+			synchronized (oldMap) {
+				oldMap.accept(key, val);
+			}
+		}
+	}
+
+	@Override
+	public void remove(@Nullable String key) {
+		if (key == null) {
 			return;
 		}
-		MutableKeyValues map = mapThreadLocal.get();
-		if (map != null) {
-			map.remove(key);
+		MutableKeyValues oldMap = copyOnThreadLocal.get();
+		if (oldMap == null)
+			return;
+
+		Integer lastOp = getAndSetLastOperation(WRITE_OPERATION);
+
+		if (wasLastOpReadOrNull(lastOp)) {
+			MutableKeyValues newMap = duplicateAndInsertNewMap(oldMap);
+			newMap.remove(key);
+		}
+		else {
+			synchronized (oldMap) {
+				oldMap.remove(key);
+			}
 		}
 	}
 
 	@Override
 	public void clear() {
-		mapThreadLocal.remove();
+		lastOperation.set(WRITE_OPERATION);
+		copyOnThreadLocal.remove();
 	}
 
 	@Override
@@ -47,8 +103,13 @@ class ArrayMDCAdapter implements MDCAdapter {
 		if (Objects.isNull(key)) {
 			return null;
 		}
-		MutableKeyValues map = mapThreadLocal.get();
-		return map != null ? map.getValueOrNull(key) : null;
+		final MutableKeyValues map = copyOnThreadLocal.get();
+		if (map != null) {
+			return map.getValueOrNull(key);
+		}
+		else {
+			return null;
+		}
 	}
 
 	/**
@@ -57,24 +118,50 @@ class ArrayMDCAdapter implements MDCAdapter {
 	 * @return mutable key values.
 	 */
 	public @Nullable MutableKeyValues mutableKeyValuesOrNull() {
-		return mapThreadLocal.get();
+		lastOperation.set(MAP_COPY_OPERATION);
+		return copyOnThreadLocal.get();
 	}
+
+	// /**
+	// * Returns the keys in the MDC as a {@link Set}. The returned value can be null.
+	// * @return keys.
+	// */
+	// public @Nullable Set<String> getKeys() {
+	// MutableKeyValues map = mutableKeyValuesOrNull();
+	//
+	// if (map != null) {
+	// return map.copyToMap().keySet();
+	// }
+	// else {
+	// return null;
+	// }
+	// }
 
 	/**
 	 * Return a copy of the current thread's context map. Returned value may be null.
 	 * @return map copy.
 	 */
+
 	@Override
 	public @Nullable Map<String, @Nullable String> getCopyOfContextMap() {
-		MutableKeyValues map = mapThreadLocal.get();
-		return map == null ? null : map.copyToMap();
+		MutableKeyValues hashMap = copyOnThreadLocal.get();
+		if (hashMap == null) {
+			return null;
+		}
+		else {
+			return hashMap.copyToMap();
+		}
 	}
 
 	@Override
 	public void setContextMap(Map<String, @Nullable String> contextMap) {
+		lastOperation.set(WRITE_OPERATION);
+
 		MutableKeyValues newMap = MutableKeyValues.of(contextMap.size());
 		newMap.putAll(contextMap);
-		mapThreadLocal.set(newMap);
+
+		// the newMap replaces the old one for serialisation's sake
+		copyOnThreadLocal.set(newMap);
 	}
 
 	@Override

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
@@ -55,7 +55,17 @@ interface LogEventHandler extends EventCreator<Level>, LogEventLogger {
 		var mdc = mdc();
 		var m = mdc.mutableKeyValuesOrNull();
 		if (m != null) {
-			return m;
+			/*
+			 * Must copy and not return the live MDC container directly. This is the
+			 * default (non fluent builder) logging path, and the resulting LogEvent can
+			 * be handed to an async publisher without being frozen first (only
+			 * CompositeLogRouter freezes before async dispatch). Returning the live,
+			 * ThreadLocal-owned container would let the calling thread's subsequent
+			 * MDC.put/remove calls race with (or simply outrun) a worker thread still
+			 * formatting this event, silently corrupting or losing the MDC snapshot that
+			 * was supposed to belong to this specific log statement.
+			 */
+			return m.copy();
 		}
 		return KeyValues.of();
 	}

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
@@ -1,8 +1,14 @@
 package io.jstach.rainbowgum.slf4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 
+import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogEventLogger;
 
 public class LoggerTest {
@@ -21,6 +27,37 @@ public class LoggerTest {
 
 		logger.trace("No Crap {} {} {}", "1", "2", "3");
 
+	}
+
+	@Test
+	public void testKeyValuesAreCopiedNotLive() {
+		/*
+		 * The plain (non fluent builder) logging path must not hand out the live,
+		 * ThreadLocal-owned MDC container. An async publisher can still be formatting a
+		 * queued event on a worker thread while the calling thread moves on and mutates
+		 * MDC again - if the event held a reference to the live container, that later
+		 * mutation would leak into (or race with) the earlier event's rendering.
+		 */
+		var mdc = new RainbowGumMDCAdapter();
+		mdc.put("phase", "A");
+
+		List<LogEvent> captured = new ArrayList<>();
+		LogEventLogger appender = captured::add;
+		var handler = LogEventHandler.of("stuff", appender, mdc);
+		var logger = LevelLogger.of(Level.INFO, handler);
+
+		logger.info("start");
+
+		// simulate the calling thread moving on to a new logical unit of work
+		// before an async worker thread would have gotten around to formatting
+		// the captured event.
+		mdc.put("phase", "B");
+		mdc.put("extra", "new");
+
+		assertEquals(1, captured.size());
+		var kvs = captured.get(0).keyValues();
+		assertEquals("A", kvs.getValueOrNull("phase"));
+		assertEquals(null, kvs.getValueOrNull("extra"));
 	}
 
 }

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
@@ -3,8 +3,10 @@ package io.jstach.rainbowgum.slf4j;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.spi.MDCAdapter;
@@ -35,17 +37,37 @@ class RainbowGumMDCAdapterTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	void testMDCEmpty() {
+		var mdc = new RainbowGumMDCAdapter();
+		assertNull(mdc.getCopyOfContextMap());
+	}
+
 	enum MdcTest {
 
-		put("k1=v1&k2=v2", a -> a.put("k2", "v2")), remove("", a -> a.remove("k1")), clear("", a -> a.clear()),
+		put("k1=v1&k2=v2", a -> a.put("k2", "v2")), //
+		remove("", a -> a.remove("k1")), //
+		clear("", a -> a.clear()), //
 		get("k1=v1", a -> {
 			String v = a.get("k1");
 			assertEquals("v1", v);
-		}), pushByKey("k1=v1", a -> a.pushByKey("k1", "v2")), popByKey("k1=v1", a -> {
+		}), //
+		getCopyOfContext("k1=v2", a -> {
+			var map = a.getCopyOfContextMap();
+			assertEquals(Map.of("k1", "v1"), map, "should be k1=v1");
+			a.put("k1", "v2");
+			assertEquals(Map.of("k1", "v1"), map);
+			map = a.getCopyOfContextMap();
+			assertEquals(Map.of("k1", "v2"), map, "should be k1=v2");
+		}), //
+		pushByKey("k1=v1", a -> a.pushByKey("k1", "v2")), //
+		popByKey("k1=v1", a -> {
 			assertNull(a.popByKey("k1"));
-		}), getCopyOfDequeByKey("k1=v1", a -> {
+		}), //
+		getCopyOfDequeByKey("k1=v1", a -> {
 			assertNull(a.getCopyOfDequeByKey("k1"));
-		}), clearDequeByKey("k1=v1", a -> {
+		}), //
+		clearDequeByKey("k1=v1", a -> {
 			a.clearDequeByKey("k1");
 		}),;
 

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
@@ -3,10 +3,8 @@ package io.jstach.rainbowgum.slf4j;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.Map;
 import java.util.function.Consumer;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.spi.MDCAdapter;
@@ -37,37 +35,17 @@ class RainbowGumMDCAdapterTest {
 		assertEquals(expected, actual);
 	}
 
-	@Test
-	void testMDCEmpty() {
-		var mdc = new RainbowGumMDCAdapter();
-		assertNull(mdc.getCopyOfContextMap());
-	}
-
 	enum MdcTest {
 
-		put("k1=v1&k2=v2", a -> a.put("k2", "v2")), //
-		remove("", a -> a.remove("k1")), //
-		clear("", a -> a.clear()), //
+		put("k1=v1&k2=v2", a -> a.put("k2", "v2")), remove("", a -> a.remove("k1")), clear("", a -> a.clear()),
 		get("k1=v1", a -> {
 			String v = a.get("k1");
 			assertEquals("v1", v);
-		}), //
-		getCopyOfContext("k1=v2", a -> {
-			var map = a.getCopyOfContextMap();
-			assertEquals(Map.of("k1", "v1"), map, "should be k1=v1");
-			a.put("k1", "v2");
-			assertEquals(Map.of("k1", "v1"), map);
-			map = a.getCopyOfContextMap();
-			assertEquals(Map.of("k1", "v2"), map, "should be k1=v2");
-		}), //
-		pushByKey("k1=v1", a -> a.pushByKey("k1", "v2")), //
-		popByKey("k1=v1", a -> {
+		}), pushByKey("k1=v1", a -> a.pushByKey("k1", "v2")), popByKey("k1=v1", a -> {
 			assertNull(a.popByKey("k1"));
-		}), //
-		getCopyOfDequeByKey("k1=v1", a -> {
+		}), getCopyOfDequeByKey("k1=v1", a -> {
 			assertNull(a.getCopyOfDequeByKey("k1"));
-		}), //
-		clearDequeByKey("k1=v1", a -> {
+		}), clearDequeByKey("k1=v1", a -> {
 			a.clearDequeByKey("k1");
 		}),;
 


### PR DESCRIPTION
I got confused on the COW logic and thought we did not need it because of `freeze`. At one point I was inspired by logback that use some COW integer thread local flags and when recently going over the code thought that it was only for inheritable threadlocals which we do not support.

It is notable that logback now just retains an entire copy (two thread local maps one mutable and the other a copy) of the mdc map to avoid synchronized which this still uses.