### PR TITLE
Move the MDC defensive copy from every log call to only async dispatch

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -197,6 +197,17 @@ public sealed interface LogRouter extends LogLifecycle {
 
 		@Override
 		default void log(LogEvent event) {
+			/*
+			 * Only async publishers need a frozen (immutable, defensively copied) event.
+			 * A synchronous publisher fully encodes and writes the event on the calling
+			 * thread before this call returns, so there is no other thread that could
+			 * observe or race with further mutation (e.g. MDC.put/remove) of the live
+			 * event data - freezing there would just be wasted allocation on the hot
+			 * path. Freeze is a noop if the event is already frozen.
+			 */
+			if (!synchronous()) {
+				event = event.freeze();
+			}
 			publisher().log(event);
 		}
 

--- a/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
@@ -2,12 +2,16 @@ package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.System.Logger.Level;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
 
 class RouterTest {
 
@@ -62,6 +66,56 @@ class RouterTest {
 				results1);
 		assertEquals("[]", results2);
 
+	}
+
+	@Test
+	void testSyncRouterDoesNotFreezeEvent() throws Exception {
+		/*
+		 * A synchronous route fully encodes and writes the event on the calling thread
+		 * before log() returns, so there is no other thread that could race with further
+		 * mutation of the live key values. Freezing (and therefore defensively copying)
+		 * would just be wasted allocation here.
+		 */
+		var resolver = LevelResolver.builder().level(Level.DEBUG).build();
+		var publisher = new TestSyncPublisher();
+		@SuppressWarnings("resource")
+		var router = new SimpleRouter("1", publisher, resolver);
+		var route = router.route("stuff", Level.DEBUG);
+
+		var mkvs = MutableKeyValues.of().add("phase", "A");
+		TestEventBuilder.of().level(Level.DEBUG).to(route).event().keyValues(mkvs).message("msg").log();
+
+		assertEquals(1, publisher.events.size());
+		var captured = publisher.events.getFirst();
+		assertSame(mkvs, captured.keyValues());
+	}
+
+	@Test
+	void testAsyncRouterFreezesEvent() throws Exception {
+		/*
+		 * An async route hands the event to a worker thread and returns immediately, so
+		 * the calling thread can go on to mutate MDC (or any other mutable state backing
+		 * the event) before the worker gets around to it. The router must freeze
+		 * (defensively copy) the event before publishing it asynchronously.
+		 */
+		var resolver = LevelResolver.builder().level(Level.DEBUG).build();
+		var publisher = new TestAsyncPublisher();
+		@SuppressWarnings("resource")
+		var router = new SimpleRouter("1", publisher, resolver);
+		var route = router.route("stuff", Level.DEBUG);
+
+		var mkvs = MutableKeyValues.of().add("phase", "A");
+		TestEventBuilder.of().level(Level.DEBUG).to(route).event().keyValues(mkvs).message("msg").log();
+
+		assertEquals(1, publisher.events.size());
+		var captured = publisher.events.getFirst();
+		assertNotSame(mkvs, captured.keyValues());
+		assertFalse(captured.keyValues() instanceof MutableKeyValues);
+		assertEquals("A", captured.keyValues().getValueOrNull("phase"));
+
+		// mutating the original after the fact must not affect the captured snapshot.
+		mkvs.add("phase", "B");
+		assertEquals("A", captured.keyValues().getValueOrNull("phase"));
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/TestAsyncPublisher.java
+++ b/core/src/test/java/io/jstach/rainbowgum/TestAsyncPublisher.java
@@ -1,0 +1,25 @@
+package io.jstach.rainbowgum;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import io.jstach.rainbowgum.LogPublisher.AsyncLogPublisher;
+
+class TestAsyncPublisher implements AsyncLogPublisher {
+
+	public Deque<LogEvent> events = new ArrayDeque<>();
+
+	@Override
+	public void start(LogConfig config) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void log(LogEvent event) {
+		events.add(event);
+	}
+
+}

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
@@ -52,20 +52,18 @@ interface LogEventHandler extends EventCreator<Level>, LogEventLogger {
 
 	@Override
 	default KeyValues keyValues() {
+		/*
+		 * Do not copy here. The overwhelming majority of log calls use a synchronous
+		 * publisher, especially now that virtual threads make blocking IO cheap, and a
+		 * copy on every MDC-bearing log call would be pure garbage for that common case.
+		 * Router.log() (LogRouter.java) freezes the event - which defensively copies the
+		 * key values - only when the route is actually asynchronous, i.e. only when a
+		 * copy is ever needed at all.
+		 */
 		var mdc = mdc();
 		var m = mdc.mutableKeyValuesOrNull();
 		if (m != null) {
-			/*
-			 * Must copy and not return the live MDC container directly. This is the
-			 * default (non fluent builder) logging path, and the resulting LogEvent can
-			 * be handed to an async publisher without being frozen first (only
-			 * CompositeLogRouter freezes before async dispatch). Returning the live,
-			 * ThreadLocal-owned container would let the calling thread's subsequent
-			 * MDC.put/remove calls race with (or simply outrun) a worker thread still
-			 * formatting this event, silently corrupting or losing the MDC snapshot that
-			 * was supposed to belong to this specific log statement.
-			 */
-			return m.copy();
+			return m;
 		}
 		return KeyValues.of();
 	}

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
@@ -30,13 +30,15 @@ public class LoggerTest {
 	}
 
 	@Test
-	public void testKeyValuesAreCopiedNotLive() {
+	public void testKeyValuesUnaffectedByLaterMdcMutation() {
 		/*
-		 * The plain (non fluent builder) logging path must not hand out the live,
-		 * ThreadLocal-owned MDC container. An async publisher can still be formatting a
-		 * queued event on a worker thread while the calling thread moves on and mutates
-		 * MDC again - if the event held a reference to the live container, that later
-		 * mutation would leak into (or race with) the earlier event's rendering.
+		 * The plain (non fluent builder) logging path hands out the live,
+		 * ThreadLocal-owned MDC container as-is - no copy at this layer. What keeps a
+		 * previously handed-out reference safe from a later MDC.put/remove on the same
+		 * thread is ArrayMDCAdapter's own copy-on-write tracking:
+		 * mutableKeyValuesOrNull() marks the container as "just exposed", and the next
+		 * put/remove clones before mutating instead of mutating in place. This test is
+		 * really exercising that COW behavior through the handler, not a copy made here.
 		 */
 		var mdc = new RainbowGumMDCAdapter();
 		mdc.put("phase", "A");


### PR DESCRIPTION
LogEventHandler.keyValues() no longer copies unconditionally. That was paying an allocation on every MDC-bearing log call regardless of whether anything downstream could ever race with it - and the sync publisher, which never hands the event to another thread, is likely the dominant case in practice, especially now that virtual threads make blocking IO cheap enough that async publishing buys less than it used to.

Instead, Router.log() (the default method shared by every AbstractRouter, including the single-router-async topology that was the actual gap) now freezes the event only when the route is asynchronous:

    if (!synchronous()) {
        event = event.freeze();
    }

freeze() defensively copies the key values (and eagerly formats the message) and is a no-op if the event is already frozen, so it's safe regardless of topology - CompositeLogRouter's existing explicit freeze before dispatching to async sub-routers is now redundant but harmless.

The direct-handler slf4j test (LoggerTest) still passes and is kept, renamed to reflect what it actually verifies now: ArrayMDCAdapter's own copy-on-write tracking (mutableKeyValuesOrNull() marks the container as just-exposed; the next put/remove clones before mutating) independently protects a handed-out reference even when the caller doesn't copy and there's no router in the path at all. Added RouterTest coverage for the router-level guarantee itself: sync routing keeps the same live MutableKeyValues instance (no wasted copy), async routing produces a frozen, independent snapshot unaffected by later mutation of the original.