### PR TITLE
Split ArrayMDCAdapter's MDC accessor into read-only copy for mutation

### DIFF
--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
@@ -10,6 +10,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.spi.MDCAdapter;
 
+import io.jstach.rainbowgum.KeyValues;
 import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
 
 class ArrayMDCAdapter implements MDCAdapter {
@@ -113,13 +114,33 @@ class ArrayMDCAdapter implements MDCAdapter {
 	}
 
 	/**
-	 * Get the current thread's MDC as a map. This method is intended to be used
-	 * internally.
-	 * @return mutable key values.
+	 * Get the current thread's MDC. This method is intended to be used internally and the
+	 * returned value <strong>should not be mutated by the caller</strong>. Calling this
+	 * marks the returned instance (if any) as exposed so that the next
+	 * {@link #put(String, String)} or {@link #remove(String)} on this thread will
+	 * defensively copy before mutating instead of mutating in place.
+	 * @return key values or <code>null</code> if nothing has been put yet.
 	 */
-	public @Nullable MutableKeyValues mutableKeyValuesOrNull() {
+	public @Nullable KeyValues keyValuesOrNull() {
 		lastOperation.set(MAP_COPY_OPERATION);
 		return copyOnThreadLocal.get();
+	}
+
+	/**
+	 * Copies the current thread's MDC into a new, independent mutable buffer, or creates
+	 * an empty one if nothing has been put yet. The returned instance is never shared
+	 * with what MDC currently holds so it is safe for the caller to mutate it freely
+	 * (e.g. to seed a builder that will add more key values on top of a snapshot of MDC).
+	 * @return a new mutable key values, never <code>null</code>.
+	 */
+	public MutableKeyValues copyMutableKeyValues() {
+		MutableKeyValues oldMap = copyOnThreadLocal.get();
+		if (oldMap == null) {
+			return MutableKeyValues.of();
+		}
+		synchronized (oldMap) {
+			return oldMap.copy();
+		}
 	}
 
 	// /**
@@ -127,7 +148,7 @@ class ArrayMDCAdapter implements MDCAdapter {
 	// * @return keys.
 	// */
 	// public @Nullable Set<String> getKeys() {
-	// MutableKeyValues map = mutableKeyValuesOrNull();
+	// MutableKeyValues map = keyValuesOrNull();
 	//
 	// if (map != null) {
 	// return map.copyToMap().keySet();

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
@@ -39,11 +39,13 @@ class ArrayMDCAdapter implements MDCAdapter {
 		MutableKeyValues newMap;
 
 		if (oldMap != null) {
-			// we don't want the parent thread modifying oldMap while we are
-			// iterating over it
-			synchronized (oldMap) {
-				newMap = oldMap.copy();
-			}
+			/*
+			 * No synchronization needed here: copyOnThreadLocal is a plain (not
+			 * inheritable) ThreadLocal, so oldMap is never shared with another thread,
+			 * and nothing that reads a KeyValues elsewhere in the codebase synchronizes
+			 * on it either.
+			 */
+			newMap = oldMap.copy();
 		}
 		else {
 			newMap = MutableKeyValues.of();
@@ -65,9 +67,7 @@ class ArrayMDCAdapter implements MDCAdapter {
 			newMap.accept(key, val);
 		}
 		else {
-			synchronized (oldMap) {
-				oldMap.accept(key, val);
-			}
+			oldMap.accept(key, val);
 		}
 	}
 
@@ -87,9 +87,7 @@ class ArrayMDCAdapter implements MDCAdapter {
 			newMap.remove(key);
 		}
 		else {
-			synchronized (oldMap) {
-				oldMap.remove(key);
-			}
+			oldMap.remove(key);
 		}
 	}
 
@@ -140,9 +138,7 @@ class ArrayMDCAdapter implements MDCAdapter {
 		if (oldMap == null) {
 			return MutableKeyValues.of();
 		}
-		synchronized (oldMap) {
-			return oldMap.copy();
-		}
+		return oldMap.copy();
 	}
 
 	// /**

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ArrayMDCAdapter.java
@@ -114,16 +114,18 @@ class ArrayMDCAdapter implements MDCAdapter {
 	}
 
 	/**
-	 * Get the current thread's MDC. This method is intended to be used internally and the
-	 * returned value <strong>should not be mutated by the caller</strong>. Calling this
-	 * marks the returned instance (if any) as exposed so that the next
+	 * Get the current thread's MDC, or an empty {@link KeyValues} if nothing has been put
+	 * yet. This method is intended to be used internally and the returned value
+	 * <strong>should not be mutated by the caller</strong>. Calling this marks the
+	 * returned instance (if not empty) as exposed so that the next
 	 * {@link #put(String, String)} or {@link #remove(String)} on this thread will
 	 * defensively copy before mutating instead of mutating in place.
-	 * @return key values or <code>null</code> if nothing has been put yet.
+	 * @return key values, never <code>null</code>.
 	 */
-	public @Nullable KeyValues keyValuesOrNull() {
+	public KeyValues keyValues() {
 		lastOperation.set(MAP_COPY_OPERATION);
-		return copyOnThreadLocal.get();
+		var m = copyOnThreadLocal.get();
+		return m == null ? KeyValues.of() : m;
 	}
 
 	/**
@@ -148,7 +150,7 @@ class ArrayMDCAdapter implements MDCAdapter {
 	// * @return keys.
 	// */
 	// public @Nullable Set<String> getKeys() {
-	// MutableKeyValues map = keyValuesOrNull();
+	// MutableKeyValues map = keyValues();
 	//
 	// if (map != null) {
 	// return map.copyToMap().keySet();

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
@@ -60,12 +60,7 @@ interface LogEventHandler extends EventCreator<Level>, LogEventLogger {
 		 * key values - only when the route is actually asynchronous, i.e. only when a
 		 * copy is ever needed at all.
 		 */
-		var mdc = mdc();
-		var m = mdc.keyValuesOrNull();
-		if (m != null) {
-			return m;
-		}
-		return KeyValues.of();
+		return mdc().keyValues();
 	}
 
 	public RainbowGumMDCAdapter mdc();

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
@@ -61,7 +61,7 @@ interface LogEventHandler extends EventCreator<Level>, LogEventLogger {
 		 * copy is ever needed at all.
 		 */
 		var mdc = mdc();
-		var m = mdc.mutableKeyValuesOrNull();
+		var m = mdc.keyValuesOrNull();
 		if (m != null) {
 			return m;
 		}

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilder.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilder.java
@@ -66,14 +66,7 @@ class RainbowGumEventBuilder implements LoggingEventBuilder, DepthAwareEventBuil
 	MutableKeyValues kvs() {
 		var kvs = this.mutableKeyValues;
 		if (kvs == null) {
-			var copy = mdc.mutableKeyValuesOrNull();
-			if (copy == null) {
-				copy = MutableKeyValues.of();
-			}
-			else {
-				copy = copy.copy();
-			}
-			kvs = this.mutableKeyValues = copy;
+			kvs = this.mutableKeyValues = mdc.copyMutableKeyValues();
 		}
 		return kvs;
 	}
@@ -143,7 +136,7 @@ class RainbowGumEventBuilder implements LoggingEventBuilder, DepthAwareEventBuil
 		long threadId = thread.threadId();
 		KeyValues keyValues = this.mutableKeyValues;
 		if (keyValues == null) {
-			keyValues = mdc.mutableKeyValuesOrNull();
+			keyValues = mdc.keyValuesOrNull();
 			if (keyValues == null) {
 				keyValues = KeyValues.of();
 			}

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilder.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilder.java
@@ -136,10 +136,7 @@ class RainbowGumEventBuilder implements LoggingEventBuilder, DepthAwareEventBuil
 		long threadId = thread.threadId();
 		KeyValues keyValues = this.mutableKeyValues;
 		if (keyValues == null) {
-			keyValues = mdc.keyValuesOrNull();
-			if (keyValues == null) {
-				keyValues = KeyValues.of();
-			}
+			keyValues = mdc.keyValues();
 		}
 		var event = LogEvent.ofAll(timestamp, threadName, threadId, level, loggerName, message, keyValues, throwable,
 				messageFormatter, this.args);

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
@@ -35,8 +35,8 @@ public class LoggerTest {
 		 * The plain (non fluent builder) logging path hands out the live,
 		 * ThreadLocal-owned MDC container as-is - no copy at this layer. What keeps a
 		 * previously handed-out reference safe from a later MDC.put/remove on the same
-		 * thread is ArrayMDCAdapter's own copy-on-write tracking: keyValuesOrNull() marks
-		 * the container as "just exposed", and the next put/remove clones before mutating
+		 * thread is ArrayMDCAdapter's own copy-on-write tracking: keyValues() marks the
+		 * container as "just exposed", and the next put/remove clones before mutating
 		 * instead of mutating in place. This test is really exercising that COW behavior
 		 * through the handler, not a copy made here.
 		 */

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerTest.java
@@ -35,10 +35,10 @@ public class LoggerTest {
 		 * The plain (non fluent builder) logging path hands out the live,
 		 * ThreadLocal-owned MDC container as-is - no copy at this layer. What keeps a
 		 * previously handed-out reference safe from a later MDC.put/remove on the same
-		 * thread is ArrayMDCAdapter's own copy-on-write tracking:
-		 * mutableKeyValuesOrNull() marks the container as "just exposed", and the next
-		 * put/remove clones before mutating instead of mutating in place. This test is
-		 * really exercising that COW behavior through the handler, not a copy made here.
+		 * thread is ArrayMDCAdapter's own copy-on-write tracking: keyValuesOrNull() marks
+		 * the container as "just exposed", and the next put/remove clones before mutating
+		 * instead of mutating in place. This test is really exercising that COW behavior
+		 * through the handler, not a copy made here.
 		 */
 		var mdc = new RainbowGumMDCAdapter();
 		mdc.put("phase", "A");

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
@@ -26,7 +26,7 @@ class RainbowGumMDCAdapterTest {
 		mdc.put("k1", "v1");
 		test.run(mdc);
 		String expected = test.expected;
-		KeyValues kvs = mdc.mutableKeyValuesOrNull();
+		KeyValues kvs = mdc.keyValuesOrNull();
 		if (kvs == null) {
 			kvs = KeyValues.of();
 		}

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
@@ -26,10 +26,7 @@ class RainbowGumMDCAdapterTest {
 		mdc.put("k1", "v1");
 		test.run(mdc);
 		String expected = test.expected;
-		KeyValues kvs = mdc.keyValuesOrNull();
-		if (kvs == null) {
-			kvs = KeyValues.of();
-		}
+		KeyValues kvs = mdc.keyValues();
 		LogEvent event = LogEvent.of(System.Logger.Level.INFO, "test", "test", kvs, null);
 		StringBuilder sb = new StringBuilder();
 		formatter.format(sb, event);


### PR DESCRIPTION
mutableKeyValuesOrNull() had two different callers with two different needs, both papered over by one MutableKeyValues-returning method:

- LogEventHandler.keyValues() and RainbowGumEventBuilder's plain (non addKeyValue) fallback only ever treated the result as read-only KeyValues - they never called a MutableKeyValues-specific method on it.
- RainbowGumEventBuilder.kvs() (the addKeyValue(...) fluent builder path) needed a private mutable buffer seeded from MDC state, and had its own null-check-then-copy-or-MutableKeyValues.of() logic duplicated at the call site.

Renamed to keyValuesOrNull() returning KeyValues for the first case, and added copyMutableKeyValues() (never null: copies current state or builds an empty buffer) for the second, moving the copy-or-create decision into the adapter, which already owns the KeyValues implementation choice everywhere else. RainbowGumEventBuilder.kvs() is now a single line instead of a four line branch.