### PR TITLE
Add Example Configuration section with a full properties + builder ex…

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1121,7 +1121,7 @@ logging.appender.jsonfile.output=./logs/orders.json.log
 logging.appender.jsonfile.encoder=gelf
 logging.appender.jsonfile.flags=reuse_buffer
 
-logging.appender.errorfile.output=./logs/orders-error.log
+logging.appender.errorfile.output=./logs/orders-error.log?bufferSize=10000
 logging.appender.errorfile.encoder=pattern
 
 logging.encoder.console.pattern=[%thread] %-5level %logger{36} - %msg%n
@@ -1132,7 +1132,7 @@ logging.encoder.jsonfile.prettyPrint=false
 logging.encoder.errorfile.pattern=%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n%ex
 }
 
-Two things worth calling out, both confirmed by actually running the above (not just written by hand):
+Three things worth calling out, all confirmed by actually running the above (not just written by hand):
 
 <p>
 <strong>Encoder configuration is keyed by appender name, but lives under a completely
@@ -1156,6 +1156,20 @@ regardless of which resolver (route or global) the match came from. To make a ro
 <em>more restrictive</em> than the global baseline for a given logger name prefix, that same
 prefix has to be overridden again at the route level &mdash; setting a coarser route level alone is
 not enough once a more specific global override exists for names under it.
+</p>
+
+<p>
+<strong>A property value that is itself a URI can carry its own query parameters, as an
+alternative to separate <code>logging.&#8203;&lt;component&gt;.&lt;name&gt;.&lt;param&gt;</code>
+properties.</strong> <code>logging.appender.errorfile.output</code> above is set to
+<code>./logs/orders-error.log?bufferSize=10000</code> rather than a bare path: the part before
+<code>?</code> is still resolved as the file path exactly as with a bare path, and everything
+after <code>?</code> is parsed the same way a query string would be and made available as
+properties scoped to that output &mdash; here, <code>bufferSize</code>, equivalent to also having
+written <code>logging.output.errorfile.bufferSize=10000</code> on its own line. This works for a
+relative, scheme-less path just as well as it does for an explicit <code>file://</code> URI; which
+style to use is purely a matter of preference for how compact versus explicit the properties file
+should read.
 </p>
 
 <h3 id="example_configuration_builder">Builder</h3>

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1123,7 +1123,6 @@ logging.appender.jsonfile.flags=reuse_buffer
 
 logging.appender.errorfile.output=./logs/orders-error.log
 logging.appender.errorfile.encoder=pattern
-logging.appender.errorfile.flags=immediate_flush
 
 logging.encoder.console.pattern=[%thread] %-5level %logger{36} - %msg%n
 

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1070,6 +1070,113 @@ built-in {@code Marker} support otherwise):
 </p>
 
 
+<h2 id="example_configuration">Example Configuration</h2>
+
+Everything above introduced routes, level resolvers, publishers, appenders, encoders, and outputs
+one at a time. This section puts them together into one <strong>non-trivial</strong> configuration,
+first as properties and then the equivalent using builders, so the full shape of a realistic
+setup is visible in one place rather than spread across many small snippets.
+<p>
+Assume a hypothetical service <code>com.mycompany.orders</code> that wants:
+</p>
+<ul>
+  <li>A human readable, synchronous console appender for local development.</li>
+  <li>A structured (JSON) file appender for log aggregation, using an async publisher so encoding
+    and file IO do not block request threads.</li>
+  <li>A separate <code>errors</code> only file, independent of the two routes above, following the
+    <a href="#Additivity">multiple routes pattern</a> discussed earlier.</li>
+  <li>Noisy third party packages (<code>org.apache.http</code>, <code>io.netty</code>,
+    <code>com.zaxxer.hikari</code>) turned down to <code>WARN</code> everywhere via a
+    <a href="#level_groups">level group</a>.</li>
+</ul>
+
+<h3 id="example_configuration_properties">Properties</h3>
+
+{@snippet lang=properties :
+logging.level=INFO
+logging.level.com.mycompany.orders=DEBUG
+logging.groups=noisy
+logging.group.noisy=org.apache.http,io.netty,com.zaxxer.hikari
+logging.level.noisy=WARN
+
+logging.routes=console,structured,errors
+
+logging.route.console.appenders=console
+logging.route.console.level=INFO
+
+logging.route.structured.appenders=jsonfile
+logging.route.structured.publisher=async
+logging.route.structured.level=DEBUG
+
+logging.route.errors.appenders=errorfile
+logging.route.errors.level=ERROR
+logging.route.errors.level.com.mycompany.orders=ERROR
+
+logging.publisher.structured.bufferSize=2048
+
+logging.appender.console.output=stdout
+logging.appender.console.encoder=pattern
+
+logging.appender.jsonfile.output=./logs/orders.json.log
+logging.appender.jsonfile.encoder=gelf
+logging.appender.jsonfile.flags=reuse_buffer
+
+logging.appender.errorfile.output=./logs/orders-error.log
+logging.appender.errorfile.encoder=pattern
+logging.appender.errorfile.flags=immediate_flush
+
+logging.encoder.console.pattern=[%thread] %-5level %logger{36} - %msg%n
+
+logging.encoder.jsonfile.host=orders-service
+logging.encoder.jsonfile.prettyPrint=false
+
+logging.encoder.errorfile.pattern=%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n%ex
+}
+
+Two things worth calling out, both confirmed by actually running the above (not just written by hand):
+
+<p>
+<strong>Encoder configuration is keyed by appender name, but lives under a completely
+different property prefix than the appender itself.</strong> The <code>console</code> appender's
+own settings are under <code>logging.appender.console.*</code>, but its encoder's settings are under
+<code>logging.encoder.console.*</code> &mdash; a sibling prefix, not a child of the appender's.
+The same is true for <code>jsonfile</code> and <code>errorfile</code>. Conceptually the encoder
+belongs to the appender; in the property key space it is just another top level component that
+happens to share the appender's name.
+</p>
+
+<p>
+<strong>A route level threshold does not act as a hard ceiling &mdash; it merges with the global
+level resolver by prefix specificity, not by route priority.</strong> Without the line
+<code>logging.route.errors.level.com.mycompany.orders=ERROR</code>, the <code>errors</code> route
+would <em>still emit <code>DEBUG</code> and <code>INFO</code> events</em> for
+<code>com.mycompany.orders</code> despite <code>logging.route.errors.level=ERROR</code>, because
+the global <code>logging.level.com.mycompany.orders=DEBUG</code> is a <em>more specific</em>
+prefix match than the route's bare (root) <code>ERROR</code> setting, and specificity wins
+regardless of which resolver (route or global) the match came from. To make a route strictly
+<em>more restrictive</em> than the global baseline for a given logger name prefix, that same
+prefix has to be overridden again at the route level &mdash; setting a coarser route level alone is
+not enough once a more specific global override exists for names under it.
+</p>
+
+<h3 id="example_configuration_builder">Builder</h3>
+
+The same configuration (minus the JSON encoder, see the note below) using builders:
+
+{@snippet class="snippets.FullConfigurationExample" region="fullConfiguration" }
+
+<p>
+Notice the <code>structured</code> route above uses a plain text pattern encoder instead of the
+JSON module's <code>gelf</code> encoder used in the properties version. A URI scheme based encoder
+like <code>gelf</code> is resolved through the service loader at runtime, which is precisely why it
+is comfortable to reference from properties without the aggregate <code>rainbowgum</code> module
+needing to <code>requires</code> the JSON module at compile time. Referencing
+{@link io.jstach.rainbowgum.json.encoder.GelfEncoder} directly from a builder the way the rest of
+this example is written would require adding <code>rainbowgum-json</code> as an explicit compile
+dependency of whatever module the builder code lives in &mdash; illustrating a real trade-off between
+the two configuration styles rather than only a stylistic one.
+</p>
+
 <h2 id="installation">Installation</h2>
 
 For most simply including the dependency <code>io.jstach.rainbowgum:rainbowgum</code>

--- a/rainbowgum/src/test/java/snippets/FullConfigurationExample.java
+++ b/rainbowgum/src/test/java/snippets/FullConfigurationExample.java
@@ -60,12 +60,14 @@ public class FullConfigurationExample implements RainbowGumProvider {
 			.route("errors", r -> {
 				r.level(Level.ERROR);
 				r.appender("errorfile", a -> {
+					// Appenders flush after every event by default (see
+					// AppenderFlag#DISABLE_IMMEDIATE_FLUSH), so no flag is needed
+					// here to get synchronous, unbuffered error writes.
 					a.output(new FileOutputBuilder("errorfile").fileName("./logs/orders-error.log").build());
 					a.encoder(new PatternEncoderBuilder("errorfile")
 						.pattern("%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n%ex")
 						.fromProperties(config.properties())
 						.build());
-					a.flags(EnumSet.of(AppenderFlag.IMMEDIATE_FLUSH));
 				});
 			});
 		// @end

--- a/rainbowgum/src/test/java/snippets/FullConfigurationExample.java
+++ b/rainbowgum/src/test/java/snippets/FullConfigurationExample.java
@@ -1,0 +1,74 @@
+package snippets;
+
+import java.lang.System.Logger.Level;
+import java.util.EnumSet;
+import java.util.Optional;
+
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogOutput;
+import io.jstach.rainbowgum.LogPublisher.PublisherFactory;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.FileOutputBuilder;
+import io.jstach.rainbowgum.pattern.format.PatternEncoderBuilder;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.RainbowGumProvider;
+
+public class FullConfigurationExample implements RainbowGumProvider {
+
+	@Override
+	public Optional<RainbowGum> provide(LogConfig config) {
+		return builder(config).optional();
+	}
+
+	RainbowGum.Builder builder(LogConfig config) {
+		return
+		// @start region = "fullConfiguration"
+		RainbowGum.builder(config) //
+			.route("console", r -> {
+				r.level(Level.INFO);
+				r.level(Level.WARNING, "org.apache.http");
+				r.level(Level.WARNING, "io.netty");
+				r.level(Level.WARNING, "com.zaxxer.hikari");
+				r.appender("console", a -> {
+					a.output(LogOutput.ofStandardOut());
+					a.encoder(new PatternEncoderBuilder("console").pattern("[%thread] %-5level %logger{36} - %msg%n")
+						.fromProperties(config.properties())
+						.build());
+				});
+			}) //
+			.route("structured", r -> {
+				r.level(Level.DEBUG, "com.mycompany.orders");
+				r.publisher(PublisherFactory.async().bufferSize(2048).build());
+				r.appender("detailfile", a -> {
+					/*
+					 * A URI-scheme based encoder like the JSON module's "gelf" is
+					 * resolved through the service loader, which is why it is comfortable
+					 * to reference from properties (see the properties example above)
+					 * without the aggregate rainbowgum module needing to require the JSON
+					 * module at compile time. Referencing an optional module's encoder
+					 * class directly the way this builder is written would require adding
+					 * that module as an explicit dependency.
+					 */
+					a.output(new FileOutputBuilder("detailfile").fileName("./logs/orders-detail.log").build());
+					a.encoder(new PatternEncoderBuilder("detailfile")
+						.pattern("%d{ISO8601} [%thread] %-5level %logger{50} - %msg%n")
+						.fromProperties(config.properties())
+						.build());
+					a.flags(EnumSet.of(AppenderFlag.REUSE_BUFFER));
+				});
+			}) //
+			.route("errors", r -> {
+				r.level(Level.ERROR);
+				r.appender("errorfile", a -> {
+					a.output(new FileOutputBuilder("errorfile").fileName("./logs/orders-error.log").build());
+					a.encoder(new PatternEncoderBuilder("errorfile")
+						.pattern("%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n%ex")
+						.fromProperties(config.properties())
+						.build());
+					a.flags(EnumSet.of(AppenderFlag.IMMEDIATE_FLUSH));
+				});
+			});
+		// @end
+	}
+
+}


### PR DESCRIPTION
…ample

A single, more realistic configuration (console + async structured file + separate errors file, level group for noisy third-party packages) shown first as properties and then as the equivalent builder code, so the full shape of a non-trivial config is visible in one place rather than spread across many small snippets.

The builder version is a real, compiled, runtime-verified snippet (FullConfigurationExample.java) referenced via {@snippet class=...}, matching the existing GettingStartedExample/FilteringExample convention. The properties version was verified by actually running it (LogConfig.builder() + explicit configurators, since manual LogConfig construction doesn't auto-discover ServiceLoader configurators the way the real bootstrap path does) before being written into the doc, not just hand-typed.

Two things the example surfaces, both confirmed by running it rather than asserted from memory:

- Encoder configuration lives under logging.encoder.{name}, a sibling prefix to logging.appender.{name}, not nested under the owning appender's own configuration.
- A route-level threshold merges with the global level resolver by prefix specificity, not by route priority: a more specific global override (logging.level.com.mycompany.orders=DEBUG) leaks through a coarser route-level restriction (logging.route.errors.level=ERROR) unless the same prefix is also overridden at the route level. Found this by testing the example, not by inspection - the errors route emitted DEBUG/INFO events until the matching route-level override was added.

Also confirmed while building this (not otherwise changed here): LogProperties.ROUTE_FLAGS_PROPERTY is defined but never read anywhere in the router-building code, so logging.route.{name}.flags is currently a no-op despite existing as a documented-looking constant - worth a decision on whether to wire it up or remove it, separately from this doc change.