### PR TITLE
Route-level resolver takes priority over global per logger name

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -311,11 +311,22 @@ public interface LevelResolver {
 		 */
 		private final List<LevelResolver> levelResolvers = new ArrayList<>();
 
+		/**
+		 * lower priority fallback resolvers.
+		 */
+		private final List<LevelResolver> fallbacks = new ArrayList<>();
+
 		private Builder() {
 		}
 
 		/**
-		 * Builds a cached level resolver.
+		 * Builds a level resolver combining {@link #config(LevelConfig)},
+		 * {@link #level(Level, String)}, and {@link #resolver(LevelResolver)} into a
+		 * single resolver of equal priority (the highest severity/most restrictive level
+		 * found for a logger name wins), and, if any {@link #fallback(LevelResolver)
+		 * fallbacks} were added, wrapping that in a priority chain where the fallbacks
+		 * are only consulted for logger names the combined resolver above has no opinion
+		 * on (resolves to {@link Level#ALL}). The result is cached.
 		 * @return level resolver.
 		 */
 		public LevelResolver build() {
@@ -325,16 +336,43 @@ public interface LevelResolver {
 				copy.add(config);
 			}
 			copy.addAll(levelResolvers);
-			return cached(ofResolvers(copy));
+			LevelResolver resolver = ofResolvers(copy);
+			if (!fallbacks.isEmpty()) {
+				List<LevelResolver> priority = new ArrayList<>();
+				priority.add(resolver);
+				priority.addAll(fallbacks);
+				resolver = PriorityLevelResolver.of(priority);
+			}
+			return cached(resolver);
 		}
 
 		/**
-		 * Adds a level resolver to the end of the resolve list.
+		 * Adds a level resolver to the end of the resolve list. Resolvers added this way
+		 * are combined with equal priority: for a given logger name the most restrictive
+		 * level found across all of them (including {@link #config(LevelConfig)} /
+		 * {@link #level(Level, String)}) wins.
 		 * @param resolver level resolver.
 		 * @return this
 		 */
 		public Builder resolver(LevelResolver resolver) {
 			this.levelResolvers.add(resolver);
+			return this;
+		}
+
+		/**
+		 * Adds a lower priority fallback level resolver. Fallbacks are tried in the order
+		 * added and only consulted for a logger name if every resolver ahead of it
+		 * (everything from {@link #config(LevelConfig)}, {@link #level(Level, String)},
+		 * {@link #resolver(LevelResolver)}, and any earlier added fallback) has no
+		 * opinion for that name, i.e. resolves to {@link Level#ALL}. This is useful for
+		 * e.g. giving a route's own level configuration priority over a global level
+		 * resolver without a more specific match in the global resolver being able to
+		 * win.
+		 * @param resolver fallback level resolver.
+		 * @return this
+		 */
+		public Builder fallback(LevelResolver resolver) {
+			this.fallbacks.add(resolver);
 			return this;
 		}
 
@@ -542,32 +580,59 @@ record CompositeLevelResolver(LevelResolver[] resolvers, Level defaultLevel) imp
  * cached.
  */
 /*
- * Resolves against primary first; only consults fallback for a given name if primary has
- * no opinion at all for it (resolves to Level.ALL). This gives primary priority per
- * logger name rather than merging primary and fallback into one combined prefix walk,
- * where a more specific match in fallback could otherwise win over a coarser match in
- * primary regardless of which one is meant to take precedence.
+ * Resolves against resolvers in order and returns the first non ALL result. This gives
+ * earlier resolvers priority per logger name rather than merging all resolvers into one
+ * combined prefix walk, where a more specific match in a lower priority resolver could
+ * otherwise win over a coarser match in a higher priority one regardless of which is
+ * meant to take precedence.
  */
-record PriorityLevelResolver(LevelResolver primary, LevelResolver fallback) implements LevelResolver {
+@SuppressWarnings("ArrayRecordComponent")
+record PriorityLevelResolver(LevelResolver[] resolvers) implements LevelResolver {
+
+	public static LevelResolver of(Collection<? extends LevelResolver> resolvers) {
+		List<LevelResolver> resolved = new ArrayList<>();
+		for (var r : resolvers) {
+			if (r instanceof PriorityLevelResolver pr) {
+				for (var j : pr.resolvers()) {
+					resolved.add(j);
+				}
+			}
+			else {
+				resolved.add(r);
+			}
+		}
+		if (resolved.isEmpty()) {
+			return StaticLevelResolver.ALL;
+		}
+		if (resolved.size() == 1) {
+			return resolved.get(0);
+		}
+		@SuppressWarnings("null") // TODO eclipse bug
+		LevelResolver @NonNull [] array = resolved.toArray(new LevelResolver[] {});
+		return new PriorityLevelResolver(array);
+	}
 
 	@Override
 	public Level resolveLevel(String name) {
-		var level = primary.resolveLevel(name);
-		if (level == Level.ALL) {
-			return fallback.resolveLevel(name);
+		for (var resolver : resolvers) {
+			var level = resolver.resolveLevel(name);
+			if (level != Level.ALL) {
+				return level;
+			}
 		}
-		return level;
+		return Level.ALL;
 	}
 
 	@Override
 	public void clear() {
-		primary.clear();
-		fallback.clear();
+		for (var resolver : resolvers) {
+			resolver.clear();
+		}
 	}
 
 	@Override
 	public String toString() {
-		return this.getClass().getSimpleName() + "[primary=" + primary + ", fallback=" + fallback + "]";
+		return this.getClass().getSimpleName() + Arrays.asList(resolvers);
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -540,6 +540,37 @@ record CompositeLevelResolver(LevelResolver[] resolvers, Level defaultLevel) imp
  * Luckily level resolution is only called when a logger is created and the loggers are
  * cached.
  */
+/*
+ * Resolves against primary first; only consults fallback for a given name if primary has
+ * no opinion at all for it (resolves to Level.ALL). This gives primary priority per
+ * logger name rather than merging primary and fallback into one combined prefix walk,
+ * where a more specific match in fallback could otherwise win over a coarser match in
+ * primary regardless of which one is meant to take precedence.
+ */
+record PriorityLevelResolver(LevelResolver primary, LevelResolver fallback) implements LevelResolver {
+
+	@Override
+	public Level resolveLevel(String name) {
+		var level = primary.resolveLevel(name);
+		if (level == Level.ALL) {
+			return fallback.resolveLevel(name);
+		}
+		return level;
+	}
+
+	@Override
+	public void clear() {
+		primary.clear();
+		fallback.clear();
+	}
+
+	@Override
+	public String toString() {
+		return this.getClass().getSimpleName() + "[primary=" + primary + ", fallback=" + fallback + "]";
+	}
+
+}
+
 final class CachedLevelResolver implements LevelResolver {
 
 	private final LevelResolver levelResolver;

--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -29,9 +29,10 @@ import io.jstach.rainbowgum.LogProperty.PropertyGetter;
 public interface LevelResolver {
 
 	/**
-	 * Determines what level the logger should be at.
+	 * Determines what level the logger should be at. {@linkplain Level#ALL} is to signal
+	 * that nothing was resolved.
 	 * @param name logger name.
-	 * @return level.
+	 * @return resolved level or {@link Level#ALL} if unable to resolve.
 	 */
 	public Level resolveLevel(String name);
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -376,25 +376,18 @@ public sealed interface LogRouter extends LogLifecycle {
 					routeLevelResolverBuilder.config(currentConfig);
 				}
 				routeLevelResolverBuilder.config(config.properties(), routerLevelPrefix);
-				var routeLevelResolver = routeLevelResolverBuilder.build();
-
-				LevelResolver levelResolver;
-				if (flags.contains(RouteFlag.IGNORE_GLOBAL_LEVEL_RESOLVER)) {
-					levelResolver = routeLevelResolver;
+				/*
+				 * config.levelResolver() (the global resolver) has no caching of its own
+				 * - the previous single merged CompositeLevelConfig relied on being
+				 * wrapped in one outer cache for the whole route+global composition.
+				 * LevelResolver.Builder.build() restores that guarantee (level resolvers
+				 * are cached / static, see LevelResolver's class documentation) for the
+				 * combined route+global resolver below.
+				 */
+				if (!flags.contains(RouteFlag.IGNORE_GLOBAL_LEVEL_RESOLVER)) {
+					routeLevelResolverBuilder.fallback(config.levelResolver());
 				}
-				else {
-					/*
-					 * config.levelResolver() (the global resolver) has no caching of its
-					 * own - the previous single merged CompositeLevelConfig relied on
-					 * being wrapped in one outer cache for the whole route+global
-					 * composition. Since route and global are now resolved as two
-					 * separate steps, that same guarantee (level resolvers are cached /
-					 * static, see LevelResolver's class documentation) has to be restored
-					 * explicitly here.
-					 */
-					levelResolver = new CachedLevelResolver(
-							new PriorityLevelResolver(routeLevelResolver, config.levelResolver()));
-				}
+				var levelResolver = routeLevelResolverBuilder.build();
 
 				if (currentConfig == null) {
 					/*
@@ -409,8 +402,10 @@ public sealed interface LogRouter extends LogLifecycle {
 						 * configured. This is a bug if this happens as the builders and
 						 * other places will turn ALL -> TRACE.
 						 */
-						levelResolver = new CachedLevelResolver(
-								new PriorityLevelResolver(levelResolver, StaticLevelResolver.INFO));
+						levelResolver = LevelResolver.builder()
+							.resolver(levelResolver)
+							.fallback(StaticLevelResolver.INFO)
+							.build();
 						// throw new IllegalStateException("Global Level Resolver should
 						// not resolve to Level.ALL");
 					}

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -358,16 +358,44 @@ public sealed interface LogRouter extends LogLifecycle {
 			Router build(RouterFactory factory) {
 				String name = this.name;
 				String routerLevelPrefix = LogProperties.interpolateNamedKey(LogProperties.ROUTE_LEVEL_PREFIX, name);
-				var levelResolverBuilder = LevelResolver.builder();
+
+				/*
+				 * The route's own level config is resolved in isolation from the global
+				 * level resolver so that a route level override takes priority per logger
+				 * name instead of merging with global by prefix specificity (a more
+				 * specific global override would otherwise win over a coarser route
+				 * override even though the route is meant to take precedence). If the
+				 * route has no opinion at all for a given name (resolves to Level.ALL)
+				 * resolution falls through to the global resolver for that name, unless
+				 * IGNORE_GLOBAL_LEVEL_RESOLVER is set in which case global is never
+				 * consulted.
+				 */
+				var routeLevelResolverBuilder = LevelResolver.builder();
 				var currentConfig = buildLevelConfigOrNull();
 				if (currentConfig != null) {
-					levelResolverBuilder.config(currentConfig);
+					routeLevelResolverBuilder.config(currentConfig);
 				}
-				levelResolverBuilder.config(config.properties(), routerLevelPrefix);
-				if (!flags.contains(RouteFlag.IGNORE_GLOBAL_LEVEL_RESOLVER)) {
-					levelResolverBuilder.config(config.levelResolver());
+				routeLevelResolverBuilder.config(config.properties(), routerLevelPrefix);
+				var routeLevelResolver = routeLevelResolverBuilder.build();
+
+				LevelResolver levelResolver;
+				if (flags.contains(RouteFlag.IGNORE_GLOBAL_LEVEL_RESOLVER)) {
+					levelResolver = routeLevelResolver;
 				}
-				var levelResolver = levelResolverBuilder.build();
+				else {
+					/*
+					 * config.levelResolver() (the global resolver) has no caching of its
+					 * own - the previous single merged CompositeLevelConfig relied on
+					 * being wrapped in one outer cache for the whole route+global
+					 * composition. Since route and global are now resolved as two
+					 * separate steps, that same guarantee (level resolvers are cached /
+					 * static, see LevelResolver's class documentation) has to be restored
+					 * explicitly here.
+					 */
+					levelResolver = new CachedLevelResolver(
+							new PriorityLevelResolver(routeLevelResolver, config.levelResolver()));
+				}
+
 				if (currentConfig == null) {
 					/*
 					 * If no config is provided in this route the global level might not
@@ -377,12 +405,12 @@ public sealed interface LogRouter extends LogLifecycle {
 					Objects.requireNonNull(level);
 					if (level == System.Logger.Level.ALL) {
 						/*
-						 * The global root level was not set or set to ALL. This is a bug
-						 * if this happens as the builders and other places will turn ALL
-						 * -> TRACE.
+						 * Neither the route nor the global level resolver have anything
+						 * configured. This is a bug if this happens as the builders and
+						 * other places will turn ALL -> TRACE.
 						 */
-						levelResolverBuilder.config(StaticLevelResolver.INFO);
-						levelResolver = levelResolverBuilder.build();
+						levelResolver = new CachedLevelResolver(
+								new PriorityLevelResolver(levelResolver, StaticLevelResolver.INFO));
 						// throw new IllegalStateException("Global Level Resolver should
 						// not resolve to Level.ALL");
 					}

--- a/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
@@ -57,27 +57,25 @@ class LevelResolverTest {
 				String expected = """
 						CachedLevelResolver[
 							PriorityLevelResolver[
-								primary=CachedLevelResolver[
+								CachedLevelResolver[
 									PriorityLevelResolver[
-										primary=CachedLevelResolver[
-											CompositeLevelConfig[
-												ConfigLevelResolver[
-													prefix=logging.route.default.level,
-													properties=MapLogProperties[
-														description='test_props',
-														order=0
-													]
-												],
-												GroupLevelResolver[
-													groupLevelPrefix=logging.route.default.level,
-													properties=MapLogProperties[
-														description='test_props',
-														order=0
-													]
+										CompositeLevelConfig[
+											ConfigLevelResolver[
+												prefix=logging.route.default.level,
+												properties=MapLogProperties[
+													description='test_props',
+													order=0
+												]
+											],
+											GroupLevelResolver[
+												groupLevelPrefix=logging.route.default.level,
+												properties=MapLogProperties[
+													description='test_props',
+													order=0
 												]
 											]
 										],
-										fallback=CompositeLevelConfig[
+										CompositeLevelConfig[
 											ConfigLevelResolver[
 												prefix=logging.level,
 												properties=MapLogProperties[
@@ -95,7 +93,7 @@ class LevelResolverTest {
 										]
 									]
 								],
-								fallback=INFO
+								INFO
 							]
 						]""";
 				assertEquals(expected, actual);
@@ -183,27 +181,25 @@ class LevelResolverTest {
 							CompositeLevelResolver[
 								CachedLevelResolver[
 									PriorityLevelResolver[
-										primary=CachedLevelResolver[
+										CachedLevelResolver[
 											PriorityLevelResolver[
-												primary=CachedLevelResolver[
-													CompositeLevelConfig[
-														ConfigLevelResolver[
-															prefix=logging.route.default.level,
-															properties=MapLogProperties[
-																description='test_props',
-																order=0
-															]
-														],
-														GroupLevelResolver[
-															groupLevelPrefix=logging.route.default.level,
-															properties=MapLogProperties[
-																description='test_props',
-																order=0
-															]
+												CompositeLevelConfig[
+													ConfigLevelResolver[
+														prefix=logging.route.default.level,
+														properties=MapLogProperties[
+															description='test_props',
+															order=0
+														]
+													],
+													GroupLevelResolver[
+														groupLevelPrefix=logging.route.default.level,
+														properties=MapLogProperties[
+															description='test_props',
+															order=0
 														]
 													]
 												],
-												fallback=CompositeLevelConfig[
+												CompositeLevelConfig[
 													ConfigLevelResolver[
 														prefix=logging.level,
 														properties=MapLogProperties[
@@ -221,7 +217,7 @@ class LevelResolverTest {
 												]
 											]
 										],
-										fallback=INFO
+										INFO
 									]
 								],
 								CachedLevelResolver[

--- a/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
@@ -56,36 +56,46 @@ class LevelResolverTest {
 				String actual = reformatToString(lr.toString());
 				String expected = """
 						CachedLevelResolver[
-							CompositeLevelConfig[
-								ConfigLevelResolver[
-									prefix=logging.route.default.level,
-									properties=MapLogProperties[
-										description='test_props',
-										order=0
+							PriorityLevelResolver[
+								primary=CachedLevelResolver[
+									PriorityLevelResolver[
+										primary=CachedLevelResolver[
+											CompositeLevelConfig[
+												ConfigLevelResolver[
+													prefix=logging.route.default.level,
+													properties=MapLogProperties[
+														description='test_props',
+														order=0
+													]
+												],
+												GroupLevelResolver[
+													groupLevelPrefix=logging.route.default.level,
+													properties=MapLogProperties[
+														description='test_props',
+														order=0
+													]
+												]
+											]
+										],
+										fallback=CompositeLevelConfig[
+											ConfigLevelResolver[
+												prefix=logging.level,
+												properties=MapLogProperties[
+													description='test_props',
+													order=0
+												]
+											],
+											GroupLevelResolver[
+												groupLevelPrefix=logging.level,
+												properties=MapLogProperties[
+													description='test_props',
+													order=0
+												]
+											]
+										]
 									]
 								],
-								GroupLevelResolver[
-									groupLevelPrefix=logging.route.default.level,
-									properties=MapLogProperties[
-										description='test_props',
-										order=0
-									]
-								],
-								ConfigLevelResolver[
-									prefix=logging.level,
-									properties=MapLogProperties[
-										description='test_props',
-										order=0
-									]
-								],
-								GroupLevelResolver[
-									groupLevelPrefix=logging.level,
-									properties=MapLogProperties[
-										description='test_props',
-										order=0
-									]
-								],
-								INFO
+								fallback=INFO
 							]
 						]""";
 				assertEquals(expected, actual);
@@ -172,36 +182,46 @@ class LevelResolverTest {
 						CachedLevelResolver[
 							CompositeLevelResolver[
 								CachedLevelResolver[
-									CompositeLevelConfig[
-										ConfigLevelResolver[
-											prefix=logging.route.default.level,
-											properties=MapLogProperties[
-												description='test_props',
-												order=0
+									PriorityLevelResolver[
+										primary=CachedLevelResolver[
+											PriorityLevelResolver[
+												primary=CachedLevelResolver[
+													CompositeLevelConfig[
+														ConfigLevelResolver[
+															prefix=logging.route.default.level,
+															properties=MapLogProperties[
+																description='test_props',
+																order=0
+															]
+														],
+														GroupLevelResolver[
+															groupLevelPrefix=logging.route.default.level,
+															properties=MapLogProperties[
+																description='test_props',
+																order=0
+															]
+														]
+													]
+												],
+												fallback=CompositeLevelConfig[
+													ConfigLevelResolver[
+														prefix=logging.level,
+														properties=MapLogProperties[
+															description='test_props',
+															order=0
+														]
+													],
+													GroupLevelResolver[
+														groupLevelPrefix=logging.level,
+														properties=MapLogProperties[
+															description='test_props',
+															order=0
+														]
+													]
+												]
 											]
 										],
-										GroupLevelResolver[
-											groupLevelPrefix=logging.route.default.level,
-											properties=MapLogProperties[
-												description='test_props',
-												order=0
-											]
-										],
-										ConfigLevelResolver[
-											prefix=logging.level,
-											properties=MapLogProperties[
-												description='test_props',
-												order=0
-											]
-										],
-										GroupLevelResolver[
-											groupLevelPrefix=logging.level,
-											properties=MapLogProperties[
-												description='test_props',
-												order=0
-											]
-										],
-										INFO
+										fallback=INFO
 									]
 								],
 								CachedLevelResolver[

--- a/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
@@ -118,4 +118,58 @@ class RouterTest {
 		assertEquals("A", captured.keyValues().getValueOrNull("phase"));
 	}
 
+	@Test
+	void testRouteLevelTakesPriorityOverGlobalForCoveredNames() throws Exception {
+		/*
+		 * The global resolver has a MORE specific override for com.mycompany.orders
+		 * (DEBUG) than the route's bare root override (ERROR). Before route-level
+		 * priority, the more specific global match would win during the merged prefix
+		 * walk despite the route being meant to restrict to ERROR. Now the route's own
+		 * resolver is tried first and wins for any name it has an opinion about.
+		 */
+		var props = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.level.com.mycompany.orders", "DEBUG");
+		var config = LogConfig.builder().properties(props).build();
+
+		var gum = RainbowGum.builder(config).route("errors", r -> {
+			r.level(Level.ERROR);
+			r.appender("out", a -> a.output(LogOutput.ofStandardOut()));
+		}).build();
+
+		try (var g = gum) {
+			var route = g.router().route("com.mycompany.orders.OrderService", Level.DEBUG);
+			assertFalse(route.isEnabled(), "route level ERROR should win over the more specific global DEBUG override");
+
+			assertTrue(g.router().route("com.mycompany.orders.OrderService", Level.ERROR).isEnabled());
+		}
+	}
+
+	@Test
+	void testRouteLevelFallsThroughToGlobalForUncoveredNames() throws Exception {
+		/*
+		 * A route with only a narrow override must not shadow global for every other name
+		 * too - only the names it actually has an opinion about.
+		 */
+		var props = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.level.com.mycompany.orders", "DEBUG");
+		var config = LogConfig.builder().properties(props).build();
+
+		var gum = RainbowGum.builder(config).route("errors", r -> {
+			r.level(Level.ERROR, "com.mycompany.orders");
+			r.appender("out", a -> a.output(LogOutput.ofStandardOut()));
+		}).build();
+
+		try (var g = gum) {
+			// covered name: route's own ERROR override wins over global's DEBUG.
+			assertFalse(g.router().route("com.mycompany.orders.OrderService", Level.DEBUG).isEnabled());
+
+			// uncovered name: route has no opinion, falls through to whatever global
+			// resolves (unset here, so the framework default applies) rather than
+			// being silently shadowed by the route having some unrelated config.
+			assertTrue(g.router().route("com.other.thing", Level.INFO).isEnabled());
+		}
+	}
+
 }

--- a/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
@@ -172,4 +172,36 @@ class RouterTest {
 		}
 	}
 
+	@Test
+	void testRouteLevelChangePropagatesAndInvalidatesCache() throws Exception {
+		/*
+		 * The route's own level resolver is wrapped in its own CachedLevelResolver (see
+		 * PriorityLevelResolver / Router.Builder.build()). Level resolvers are documented
+		 * as cached/static by default, so a property change alone does nothing until
+		 * ChangePublisher.publish() is called - this is a regression test that publish()
+		 * actually reaches down and invalidates the route-level cache too, not just the
+		 * global one.
+		 */
+		var props = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.global.change", "true")
+			.put("logging.route.errors.level.com.mycompany", "ERROR");
+		var config = LogConfig.builder().properties(props).build();
+
+		var gum = RainbowGum.builder(config).route("errors", r -> {
+			r.appender("out", a -> a.output(LogOutput.ofStandardOut()));
+		}).build();
+
+		try (var g = gum) {
+			assertFalse(g.router().route("com.mycompany.OrderService", Level.WARNING).isEnabled(),
+					"route configured to ERROR should not let WARNING through before the change");
+
+			props.put("logging.route.errors.level.com.mycompany", "WARNING");
+			config.changePublisher().publish();
+
+			assertTrue(g.router().route("com.mycompany.OrderService", Level.WARNING).isEnabled(),
+					"route level cache should have been invalidated by publish() and re-resolved to WARNING");
+		}
+	}
+
 }

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -402,9 +402,35 @@ and <code>com.mycompany.bar</code> will resolve to <code>INFO</code>
 and anything not prefixed with <code>com.mycompany</code> will resolve to <code>ERROR</code>.
 An analog is to think of the "<code>.</code>" as directory path separators like in filesystems
 and resolution happens by going up the directories.
-This behavior is stated more formally in 
+This behavior is stated more formally in
 <a href="https://logback.qos.ch/manual/architecture.html#effectiveLevel">Logback's Effective Level</a>
 which is what Rainbow Gum follows as well.
+</p>
+
+<h4 id="route_level_priority">Route Level Priority</h4>
+
+<p>
+A router's {@linkplain io.jstach.rainbowgum.LevelResolver level resolver} is actually a chain: the
+route's <em>own</em> level configuration is checked first, and only if the route has no opinion for a
+particular logger name does resolution fall through to the global level resolver. This means a route's
+level configuration always takes priority over the global configuration for any logger name the route
+has configured — regardless of whether the global resolver has a deeper/more specific prefix match for
+that same name.
+</p>
+
+{@snippet lang=properties :
+logging.level.com.mycompany.orders=DEBUG   # global: specific override
+logging.route.errors.level=ERROR           # route "errors": broad override
+}
+
+<p>
+Without this priority rule a naive merge of the two resolvers into one combined prefix walk would let the
+more specific global entry (<code>com.mycompany.orders=DEBUG</code>) win, silently defeating the route's
+intent to restrict itself to <code>ERROR</code> and above. Because the route's resolver is consulted
+first and independently of the global one, the <em>"errors"</em> route above correctly resolves
+<code>com.mycompany.orders</code> to <code>ERROR</code> no matter what the global resolver says about
+that name. A route only falls back to the global resolver for logger names it has not configured an
+opinion about itself.
 </p>
 
 <p>

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -407,6 +407,29 @@ This behavior is stated more formally in
 which is what Rainbow Gum follows as well.
 </p>
 
+<h4 id="changing_reesolving">Changing Levels</h4>
+
+<p>
+  Rainbow Gum
+  <strong>
+    by default assumes Level Resolvers are cached or static and will never change.
+  </strong>
+  This is a critical feature of Rainbow Gum as it <em>allows facade loggers like in SLF4J to be 
+  lower overhead than almost all other logging frameworks!</em>
+  That being said RainbowGum allows levels to be changed if the backing configuration framework
+  supports reloading and the logger name is allowed to be changed.
+</p>
+
+Below is an example of configuring to allow <em>"changing" loggers</em>
+
+{@snippet lang=properties :
+logging.global.change=true          # this is required to turn on level changing. 
+logging.change.com.mycompany=level  # only logger names starting with com.mycompany can have their levels changed.
+}
+
+To fire off that configuration has changed the {@link io.jstach.rainbowgum.LogConfig.ChangePublisher}
+is used and depending on configuration backend may require a manual {@link io.jstach.rainbowgum.LogConfig.ChangePublisher publish call}.
+
 <h4 id="route_level_priority">Route Level Priority</h4>
 
 <p>
@@ -414,7 +437,7 @@ A router's {@linkplain io.jstach.rainbowgum.LevelResolver level resolver} is act
 route's <em>own</em> level configuration is checked first, and only if the route has no opinion for a
 particular logger name does resolution fall through to the global level resolver. This means a route's
 level configuration always takes priority over the global configuration for any logger name the route
-has configured — regardless of whether the global resolver has a deeper/more specific prefix match for
+has configured regardless of whether the global resolver has a deeper/more specific prefix match for
 that same name.
 </p>
 
@@ -432,24 +455,6 @@ first and independently of the global one, the <em>"errors"</em> route above cor
 that name. A route only falls back to the global resolver for logger names it has not configured an
 opinion about itself.
 </p>
-
-<p>
-  An important consideration is that Rainbow Gum
-  <strong>
-    by default assumes Level Resolvers are cached or static and will never change.
-  </strong>
-  This is a critical feature of Rainbow Gum as it <em>allows facade loggers like in SLF4J to be 
-  lower overhead than almost all other logging frameworks!</em>
-  That being said RainbowGum allows levels to be changed if the backing configuration framework
-  supports reloading and the logger name is allowed to be changed.
-</p>
-
-Below is an example of configuring to allow <em>"changing" loggers</em>
-
-{@snippet lang=properties :
-logging.global.change=true          # this is required to turn on level changing. 
-logging.change.com.mycompany=level  # only logger names starting with com.mycompany can have their levels changed.
-}
 
 <h4 id="level_groups">Level Groups</h4>
 


### PR DESCRIPTION
A route level override used to be merged with the global resolver into one CompositeLevelConfig and walked by prefix specificity, so a MORE specific global override (logging.level.com.mycompany.orders=DEBUG) could win over a coarser route-level restriction
(logging.route.errors.level=ERROR) even though the route was meant to take precedence - the doc's Example Configuration section needed a workaround override to get the intended behavior.

Router.Builder.build() now resolves the route's own level config in isolation first. Only when the route has no opinion at all for a given name (resolves to Level.ALL) does resolution fall through to the global resolver for that specific name - not per-route as a whole, so a route with a single narrow override does not also shadow global for every other unrelated logger name on that route. Implemented via a new PriorityLevelResolver(primary, fallback) combinator in LevelResolver.java. IGNORE_GLOBAL_LEVEL_RESOLVER still works unchanged (route resolver used directly, global never consulted).

Caught along the way: the previous single merged CompositeLevelConfig relied on being wrapped in one outer CachedLevelResolver for the whole composition - config.levelResolver() (global) has no caching of its own. Splitting route and global into two separately-resolved steps silently dropped that caching guarantee (LevelResolver's own class javadoc promises resolvers are cached/static). Restored by wrapping the composed PriorityLevelResolver in a fresh CachedLevelResolver. Found via LevelResolverTest's existing (admittedly blunt) toString structural assertions - not a great testing pattern in general, but it caught a real regression the parameterized behavioral assertions further down in the same test also caught, once traced.

Updated LevelResolverTest's toString golden strings to match the new composition shape, and added RouterTest coverage for both directions: a route-level override wins for the names it covers, and correctly falls through to global for names it doesn't - verified independently against the exact scenario from the Example Configuration doc section (logging.route.errors.level=ERROR alone, without the workaround override, now correctly suppresses DEBUG/INFO).