### PR TITLE
Upgrade checkerframework to 4.2.2 and fix missing javac.parser export

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -600,7 +600,7 @@ public sealed interface LogProperty {
 			@Override
 			public T value(@SuppressWarnings("exports") Supplier<? extends @Nullable T> fallback)
 					throws NoSuchElementException {
-				var v = fallback.get();
+				T v = fallback.get();
 				if (v != null) {
 					return v;
 				}
@@ -1543,7 +1543,7 @@ record FallbackGetter<T>(PropertyGetter<T> parent, Supplier<? extends T> fallbac
 					yield s;
 				}
 				String key = keys.getFirst();
-				var f = fallback.get();
+				T f = fallback.get();
 				if (f == null) {
 					yield PropertyGetter.findRoot(parent) //
 						.errorResult(props, keys.get(0),

--- a/core/src/main/java/io/jstach/rainbowgum/ServiceRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/ServiceRegistry.java
@@ -166,7 +166,13 @@ final class DefaultServiceRegistry implements ServiceRegistry {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T putIfAbsent(Class<T> type, String name, Supplier<T> supplier) {
-		var t = (T) services.computeIfAbsent(new ServiceKey(type, name), k -> Objects.requireNonNull(supplier.get()));
+		var t = (T) services.computeIfAbsent(new ServiceKey(type, name), k -> {
+			T v = supplier.get();
+			if (v == null) {
+				throw new NullPointerException("supplier returned null. type: " + type);
+			}
+			return v;
+		});
 		return t;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
     <plexus-compiler-eclipse.version>2.15.0</plexus-compiler-eclipse.version>
     <error-prone.version>2.36.0</error-prone.version>
     <nullaway.version>0.13.8</nullaway.version>
-    <checkerframework.version>3.42.0</checkerframework.version>
+    <checkerframework.version>4.2.2</checkerframework.version>
+
 
     <pistachio.version>0.1.2</pistachio.version>
     <jstachio.version>1.3.7</jstachio.version>
@@ -1030,6 +1031,7 @@
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>


### PR DESCRIPTION
4.2.2's dataflow postcondition parsing (org.plumelib.javacparse.JavacParse) needs com.sun.tools.javac.parser.ParserFactory, which the checkerframework profile's -J--add-exports list never granted (the sibling errorprone profile already had it). Without it the checker crashes with IllegalAccessError instead of actually type-checking anything.

With that fixed, 4.2.2 surfaces two genuine new findings 3.42.0 missed:

- LogProperty.java: `var v = fallback.get()` / `var f = fallback.get()` let var infer a wildcard-capture type from `Supplier<? extends @Nullable T>` that doesn't line up with the declared T on later use. Declaring the locals as T directly sidesteps the capture mismatch.
- ServiceRegistry.putIfAbsent: Objects.requireNonNull(supplier.get()) inside the computeIfAbsent lambda confused 4.2.2's generic nullness inference (found @Nullable T where @NonNull T was required, for the exact same expression that was fine under 3.42.0). Replaced with an explicit local and null check instead of routing the unbounded generic through Objects.requireNonNull.

Verified: bin/analyze.sh checkerframework goes from a crash to BUILD SUCCESS on both JDK 21 and JDK 25 (with a local, uncommitted <release> compiler swap to reproduce the JDK 25 repro path - not part of this commit). errorprone profile and full core test suite still pass untouched. The pre-existing eclipse-profile FileOutputBuilder failure (rainbowgum-apt not running under that profile) reproduces identically on unmodified main and is unrelated to this change.