### PR TITLE
Add working NullAway profile via JSpecifyMode

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
@@ -119,7 +119,6 @@ public sealed interface LogFormatter {
 			StaticFormatter current = null;
 			for (var f : flattened) {
 				if (f.isNoop()) {
-					continue;
 				}
 				else if (current == null && f instanceof StaticFormatter sf) {
 					current = sf;

--- a/core/src/test/java/io/jstach/rainbowgum/LogMessageFormatterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogMessageFormatterTest.java
@@ -75,7 +75,7 @@ class LogMessageFormatterTest {
 		assertTwoArg(expected, arg1, arg2, message);
 	}
 
-	@SuppressWarnings({ "null", "nullness" })
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	private void assertTwoArg(String expected, Arg arg1, Arg arg2, String message) {
 		StringBuilder builder = new StringBuilder();
 		formatter.format(builder, message, arg1.arg, arg2.arg);

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,10 @@
 
     <ecj.version>3.39.0</ecj.version>
     <plexus-compiler-eclipse.version>2.15.0</plexus-compiler-eclipse.version>
-    <error-prone.version>2.35.1</error-prone.version>
+    <error-prone.version>2.36.0</error-prone.version>
+    <nullaway.version>0.13.8</nullaway.version>
     <checkerframework.version>3.42.0</checkerframework.version>
-    
+
     <pistachio.version>0.1.2</pistachio.version>
     <jstachio.version>1.3.7</jstachio.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -933,6 +934,7 @@
               <fork>true</fork>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
+                <arg>-XDshould-stop.ifError=FLOW</arg>
                 <arg>-Xplugin:ErrorProne</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
@@ -955,6 +957,53 @@
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
                   <version>${error-prone.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>nullaway</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-XDshould-stop.ifError=FLOW</arg>
+                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=io.jstach -XepOpt:NullAway:JSpecifyMode=true</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+               <path>
+                  <groupId>io.jstach.rainbowgum</groupId>
+                  <artifactId>rainbowgum-apt</artifactId>
+                  <version>${project.version}</version>
+                </path>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+                <path>
+                  <groupId>com.uber.nullaway</groupId>
+                  <artifactId>nullaway</artifactId>
+                  <version>${nullaway.version}</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>


### PR DESCRIPTION
New `nullaway` Maven profile (separate from `errorprone`, though it rides the same Error Prone plugin infrastructure) running NullAway 0.13.8 with -XepOpt:NullAway:JSpecifyMode=true against io.jstach.

The earlier attempt (PR #129) hit uber/NullAway#1008, a JSpecifyMode crash on generic wildcard array types - already fixed upstream (uber/NullAway#1009, released in 0.11.1) but that attempt also suppressed a pile of what looked like false positives on @Nullable generic type arguments (Map<String, @Nullable String>, BiFunction<..., @Nullable T>, etc) across KeyValues/LogEvent/ LogMessageFormatter/LogProperties/LogProperty. With current NullAway (0.13.8) and JSpecifyMode on, none of those are needed - JSpecifyMode's proper generic nullness handling is what actually resolves that whole class of finding, not a suppression-worthy bug.

Two other things needed to get here:
- Bumped error-prone.version 2.35.1 -> 2.36.0 (minimum NullAway 0.13.x requires) and added -XDshould-stop.ifError=FLOW, which 2.36 now requires alongside -XDcompilePolicy=simple. This also affects the existing errorprone profile; verified it still passes, and fixed one new genuine finding it surfaced (LogFormatter.java: a redundant continue in an if/else-if chain where nothing follows the chain in the loop body - RedundantControlFlow).
- JSpecifyMode requires either JDK 22+ or -XDaddTypeAnnotationsToSymbol=true on older JDKs; added the latter since the project targets JDK 21.

With that, core's 44 main source files compile with zero NullAway findings against the existing org.eclipse.jdt.annotation @Nullable usage - no JSpecify jar migration needed for this to work, confirming that can be a later, separate step. Only the test sources had two real findings, both in LogMessageFormatterTest.assertTwoArg, which already deliberately passes null to test null-message handling and already carries @SuppressWarnings({"null", "nullness"}) for the same reason under other checkers - added "NullAway" to that list.

Verified: bin/analyze.sh nullaway is BUILD SUCCESS (main + test compile), bin/analyze.sh errorprone and checkerframework still pass, and the full core test suite passes.