### PR TITLE
Build with JDK 26, keep releasing JDK 21-compatible bytecode

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 26
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '26'
           distribution: 'temurin'
           cache: 'maven'
       - name: Install maven modules

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Set up JDK 21
+      - name: Set up JDK 26
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '26'
           distribution: 'temurin'
           cache: 'maven'
       - name: mvn install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 26
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '26'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build and Test with Maven

--- a/core/src/main/java/io/jstach/rainbowgum/KeyValues.java
+++ b/core/src/main/java/io/jstach/rainbowgum/KeyValues.java
@@ -267,6 +267,7 @@ public sealed interface KeyValues {
 	 * @param kvs second.
 	 * @return true if equal.
 	 */
+	@SuppressWarnings("ReferenceEquality")
 	static boolean equals(KeyValues self, KeyValues kvs) {
 		if (self == kvs)
 			return true;
@@ -617,6 +618,7 @@ final class ArrayKeyValues extends AbstractArrayKeyValues implements MutableKeyV
 	 * We implement BiConsumer to avoid garbage like entry set and iterators
 	 */
 	@Override
+	@SuppressWarnings("ReferenceEquality")
 	public void putKeyValue(String key, @Nullable String value) {
 		Objects.requireNonNull(key);
 		if (kvs == EMPTY) {
@@ -647,6 +649,7 @@ final class ArrayKeyValues extends AbstractArrayKeyValues implements MutableKeyV
 	}
 
 	@Override
+	@SuppressWarnings("ReferenceEquality")
 	public void remove(final String key) {
 		if (kvs == EMPTY) {
 			return;

--- a/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
@@ -995,6 +995,7 @@ record StackFrameLogEvent(LogEvent event, Caller callerOrNull) implements LogEve
 	}
 
 	@Override
+	@SuppressWarnings("ReferenceEquality")
 	public LogEvent freeze() {
 		var e = event.freeze();
 		var info = callerOrNull.freeze();
@@ -1006,6 +1007,7 @@ record StackFrameLogEvent(LogEvent event, Caller callerOrNull) implements LogEve
 	}
 
 	@Override
+	@SuppressWarnings("ReferenceEquality")
 	public LogEvent freeze(Instant timestamp) {
 		var e = event.freeze(timestamp);
 		var info = callerOrNull.freeze();

--- a/core/src/main/java/io/jstach/rainbowgum/LogLifecycle.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogLifecycle.java
@@ -61,6 +61,7 @@ final class ShutdownManager {
 		}
 	}
 
+	@SuppressWarnings("ReferenceEquality")
 	static void removeShutdownHook(AutoCloseable hook) {
 		staticLock.writeLock().lock();
 		try {

--- a/core/src/main/java/io/jstach/rainbowgum/LogMessageFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogMessageFormatter.java
@@ -297,29 +297,29 @@ final class SLF4JMessageFormatter {
 		else {
 			// check for primitive array types because they
 			// unfortunately cannot be cast to Object[]
-			if (o instanceof boolean[]) {
-				booleanArrayAppend(sbuf, (boolean[]) o);
+			if (o instanceof boolean[] array) {
+				booleanArrayAppend(sbuf, array);
 			}
-			else if (o instanceof byte[]) {
-				byteArrayAppend(sbuf, (byte[]) o);
+			else if (o instanceof byte[] array) {
+				byteArrayAppend(sbuf, array);
 			}
-			else if (o instanceof char[]) {
-				charArrayAppend(sbuf, (char[]) o);
+			else if (o instanceof char[] array) {
+				charArrayAppend(sbuf, array);
 			}
-			else if (o instanceof short[]) {
-				shortArrayAppend(sbuf, (short[]) o);
+			else if (o instanceof short[] array) {
+				shortArrayAppend(sbuf, array);
 			}
-			else if (o instanceof int[]) {
-				intArrayAppend(sbuf, (int[]) o);
+			else if (o instanceof int[] array) {
+				intArrayAppend(sbuf, array);
 			}
-			else if (o instanceof long[]) {
-				longArrayAppend(sbuf, (long[]) o);
+			else if (o instanceof long[] array) {
+				longArrayAppend(sbuf, array);
 			}
-			else if (o instanceof float[]) {
-				floatArrayAppend(sbuf, (float[]) o);
+			else if (o instanceof float[] array) {
+				floatArrayAppend(sbuf, array);
 			}
-			else if (o instanceof double[]) {
-				doubleArrayAppend(sbuf, (double[]) o);
+			else if (o instanceof double[] array) {
+				doubleArrayAppend(sbuf, array);
 			}
 			else {
 				if (seenMap == null) {

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
@@ -781,7 +781,7 @@ public interface LogProperties {
 
 			private final Function<String, @Nullable String> func;
 
-			public DefaultLogProperties(Function<String, @Nullable String> func, String description,
+			DefaultLogProperties(Function<String, @Nullable String> func, String description,
 					Function<String, String> renameKey, int order) {
 				super(description, renameKey, order);
 				this.func = func;
@@ -890,7 +890,7 @@ public interface LogProperties {
 
 				private final Map<String, String> map;
 
-				public MapLogProperties(Map<String, String> map, String description, Function<String, String> renameKey,
+				MapLogProperties(Map<String, String> map, String description, Function<String, String> renameKey,
 						int order) {
 					super(description, renameKey, order);
 					this.map = map;

--- a/core/src/test/java/io/jstach/rainbowgum/spi/RainbowGumServiceProviderTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/spi/RainbowGumServiceProviderTest.java
@@ -90,7 +90,7 @@ class RainbowGumServiceProviderTest {
 
 		int succeedAfter = 1;
 
-		public FakeConfigurator(String name, int succeedAfter) {
+		FakeConfigurator(String name, int succeedAfter) {
 			super();
 			this.name = name;
 			this.succeedAfter = succeedAfter;

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
     as well as let dependabot check for maven updates. 
     -->
     <maven.core.version>3.9.16</maven.core.version>
-    <jdk.release.version>21.0.2</jdk.release.version>
+    <jdk.release.version>26.0.2</jdk.release.version>
 
     <ecj.version>3.39.0</ecj.version>
     <plexus-compiler-eclipse.version>2.15.0</plexus-compiler-eclipse.version>
-    <error-prone.version>2.36.0</error-prone.version>
+    <error-prone.version>2.45.0</error-prone.version>
     <nullaway.version>0.13.8</nullaway.version>
     <checkerframework.version>4.2.2</checkerframework.version>
 
@@ -286,8 +286,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.0</version>
           <configuration>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
+            <release>${java.version}</release>
             <encoding>${project.build.sourceEncoding}</encoding>
             <showWarnings>true</showWarnings>
             <failOnWarning>true</failOnWarning>
@@ -1093,8 +1092,6 @@
               </compilerArguments>
               <compilerArgs combine.self="override">
               </compilerArgs>
-              <source>${java.version}</source>
-              <target>${java.version}</target>
               <annotationProcessorPaths>
                   <path>
                     <groupId>io.jstach.rainbowgum</groupId>


### PR DESCRIPTION
CI now sets up JDK 26 (maven.yml, analyze.yml, apidoc.yml) and jdk.release.version is pinned to the exact Temurin 26.0.2 patch so the deploy-release enforcer profile stays reproducible on the new build JDK.

The compiler plugin config switches from <source>/<target> to <release>${java.version}</release> (still 21, unchanged): compiling on JDK 26 with plain -source/-target 21 doesn't set the system-modules location, so javac warns "class files ... cannot run on JDK 21" and the build fails under -Werror. --release uses the JDK's ct.sym data to properly restrict the API surface to Java 21, which is what actually guarantees the 21 compat the project wants regardless of which JDK compiles it. Removed the now-conflicting duplicate <source>/<target> in the eclipse profile so it inherits the same <release> setting.

Bumped error-prone from 2.36.0 to 2.45.0 (the first release with fixes for JDK 26 EA builds) to fix a hard crash of the errorprone/nullaway profiles under JDK 26. That version bump surfaced several new, real findings against core, fixed here: pattern-matching instanceof for the primitive array branches in LogMessageFormatter, dropping public/protected modifiers on two constructors that are effectively private (their enclosing classes are private), and @SuppressWarnings("ReferenceEquality") on identity-check fast paths (KeyValues equals()/EMPTY-array sentinel checks, LogEvent freeze() no-op checks, and shutdown hook removal by instance) that are intentional, not bugs.

Verified: full clean verify passes on both JDK 21 and JDK 26 (compiled bytecode identical either way since --release pins the target), and all three analyze.sh profiles (checkerframework, errorprone, nullaway) are clean against core under JDK 26.