### PR TITLE
Expose the built-in TTLL encoder through a URI schema

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -117,7 +117,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 
 		var encoderProperty = encoderProperty(LogAppender.APPENDER_ENCODER_PROPERTY, name, config);
 
-		var encoder = resolveEncoder(config, output, encoderProperty).value();
+		var encoder = resolveEncoder(name, config, output, encoderProperty).value();
 
 		var flags = resolveFlags(config, name);
 
@@ -175,9 +175,9 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 		if (output instanceof LogEncoder e) {
 			encoder = e;
 		}
-		encoder = resolveEncoder(config, output, encoderProperty).override(encoder);
-
 		String name = appenderConfig.name();
+
+		encoder = resolveEncoder(name, config, output, encoderProperty).override(encoder);
 
 		@Nullable
 		Set<LogAppender.AppenderFlag> flags = appenderConfig.flags();
@@ -188,11 +188,11 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 		return DirectLogAppender.of(name, output, encoder, flags);
 	}
 
-	private static PropertyValue<LogEncoder> resolveEncoder(LogConfig config, LogOutput output,
+	private static PropertyValue<LogEncoder> resolveEncoder(String name, LogConfig config, LogOutput output,
 			PropertyValue<LogEncoder> encoderProperty) {
 		return encoderProperty.or(() -> {
 			var encoderRegistry = config.encoderRegistry();
-			return encoderRegistry.encoderForOutputType(output.type());
+			return encoderRegistry.encoderForOutputType(output.type()).provide(name, config);
 		});
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import io.jstach.rainbowgum.LogEncoder.AbstractEncoder;
 import io.jstach.rainbowgum.LogEncoder.Buffer.StringBuilderBuffer;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.format.AbstractStandardEventFormatter;
 
 /**
  * Encodes a {@link LogEvent} into a buffer of its choosing. While the {@link Buffer} does
@@ -81,6 +82,14 @@ public interface LogEncoder {
 	}
 
 	/**
+	 * Provides the standard TTLL encoder.
+	 * @return provider of encoder.
+	 */
+	public static LogProvider<LogEncoder> ofTTLL() {
+		return of(LogProviderRef.of(URI.create(AbstractStandardEventFormatter.SCHEMA)));
+	}
+
+	/**
 	 * Provides a lazy loaded encoder from a provider ref.
 	 * @param ref uri.
 	 * @return provider of output.
@@ -104,6 +113,15 @@ public interface LogEncoder {
 		 * @throws LogProviderRef.NotFoundException if there is no registered provider.
 		 */
 		LogProvider<LogEncoder> provide(LogProviderRef ref) throws LogProviderRef.NotFoundException;
+
+		/**
+		 * Convenience method to register encoders that require no configuration.
+		 * @param encoder already configured encoder.
+		 * @return encoder provider.
+		 */
+		static EncoderProvider of(LogEncoder encoder) {
+			return ref -> LogProvider.of(encoder);
+		}
 
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/format/AbstractStandardEventFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/format/AbstractStandardEventFormatter.java
@@ -1,5 +1,8 @@
 package io.jstach.rainbowgum.format;
 
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEncoder.EncoderProvider;
+import io.jstach.rainbowgum.LogEncoderRegistry;
 import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogFormatter;
 
@@ -25,6 +28,13 @@ import io.jstach.rainbowgum.LogFormatter;
  * @see AbstractBuilder
  */
 public class AbstractStandardEventFormatter implements LogFormatter.EventFormatter {
+
+	/**
+	 * Recommended URI schema for this type of encoder.
+	 * @see LogEncoderRegistry#register(String,
+	 * io.jstach.rainbowgum.LogEncoder.EncoderProvider)
+	 */
+	public static final String SCHEMA = "ttll";
 
 	/**
 	 * immutable field
@@ -296,6 +306,24 @@ public class AbstractStandardEventFormatter implements LogFormatter.EventFormatt
 			return self();
 		}
 
+	}
+
+	/**
+	 * Convenience to register the encoder.
+	 * @return encoder provider.
+	 * @see AbstractStandardEventFormatter#SCHEMA
+	 */
+	public EncoderProvider toEncoderProvider() {
+		return EncoderProvider.of(LogEncoder.of(eventFormatter));
+	}
+
+	/**
+	 * Will register this TTLL like encoder with the uri schema {@value #SCHEMA} and will
+	 * be used as the default encoder if other encoders are not found.
+	 * @param registry encoder registry.
+	 */
+	public void register(LogEncoderRegistry registry) {
+		registry.register(SCHEMA, toEncoderProvider());
 	}
 
 	@Override

--- a/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
@@ -75,7 +75,7 @@ class LogEncoderRegistryTest {
 			config.encoderRegistry().register("custom", provider);
 			config.encoderRegistry()
 				.setEncoderForOutputType(OutputType.MEMORY,
-						() -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder());
+						(name, c) -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder());
 			return true;
 		}
 

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
@@ -8,6 +8,7 @@ import io.jstach.rainbowgum.LogEncoder;
 import io.jstach.rainbowgum.LogOutput.OutputType;
 import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.LogProperty.Property;
+import io.jstach.rainbowgum.LogProvider;
 import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
 import io.jstach.svc.ServiceProvider;
 
@@ -43,9 +44,13 @@ public class JAnsiConfigurator implements RainbowGumServiceProvider.Configurator
 	}
 
 	void installJansiLogFormatter(LogConfig config, boolean disableAnsi) {
+		/*
+		 * TODO probably get rid of this. Most will be using the pattern formatter anyway
+		 * if they want colors.
+		 */
+		var jansiFormatter = JansiLogFormatter.builder().disableAnsi(disableAnsi).build();
 		config.encoderRegistry()
-			.setEncoderForOutputType(OutputType.CONSOLE_OUT,
-					() -> LogEncoder.of(JansiLogFormatter.builder().disableAnsi(disableAnsi).build()));
+			.setEncoderForOutputType(OutputType.CONSOLE_OUT, LogProvider.of(LogEncoder.of(jansiFormatter)));
 	}
 
 	boolean installJansi(LogConfig config) {

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JansiLogFormatter.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JansiLogFormatter.java
@@ -8,6 +8,7 @@ import io.jstach.rainbowgum.LogFormatter;
 import io.jstach.rainbowgum.format.AbstractStandardEventFormatter;
 import io.jstach.rainbowgum.format.StandardEventFormatter;
 
+// TODO deprecate
 /**
  * Jansi TTLL formater.
  */

--- a/spring/rainbowgum-spring-boot/src/main/java/io/jstach/rainbowgum/spring/boot/RainbowGumLoggingSystemFactory.java
+++ b/spring/rainbowgum-spring-boot/src/main/java/io/jstach/rainbowgum/spring/boot/RainbowGumLoggingSystemFactory.java
@@ -188,16 +188,13 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 				.build();
 			LogProperties patternProperties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 			Patterns patterns = new Patterns(patternProperties);
-			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern())
-				.build()
-				.provide("console", config);
 
-			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern())
-				.build()
-				.provide("file", config);
+			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern()).build();
 
-			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, () -> consoleEncoder);
-			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, () -> fileEncoder);
+			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern()).build();
+
+			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, consoleEncoder);
+			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, fileEncoder);
 			rainbowGum = findAndSet(config, classLoader, initializationContext.getEnvironment());
 		}
 


### PR DESCRIPTION
Split out of PR #268 (untangling three unrelated changes bundled together). This is the "TTLL encoder available through URI" piece.

Adds LogEncoder.ofTTLL() and AbstractStandardEventFormatter.SCHEMA ("ttll")/register(LogEncoderRegistry) so the always-shipped default TTLL formatter can be referenced and registered like any other encoder instead of only being reachable as the registry's internal fallback.

LogEncoderRegistry.encoderForOutputType/setEncoderForOutputType now work in terms of LogProvider<? extends LogEncoder> instead of eagerly built LogEncoder / Supplier, so the TTLL default is expressed as a lazy, URI-resolvable provider like everything else the registry hands out; DefaultEncoderRegistry.of() registers it under the "ttll" scheme by default. LogAppenderRegistry.resolveEncoder now threads the appender name through to LogProvider.provide(name, config) since encoders are no longer resolved eagerly.

JAnsiConfigurator and the Spring Boot RainbowGumLoggingSystemFactory are updated for the new LogProvider-based setEncoderForOutputType signature; no behavior change there.

Original commits: 17bca9d (Make pattern encoder default #266), 4c45e94 (Fix spring boot with encoder registry fix), by agentgt.