### PR TITLE
Support %ex{depth} and frame exclusion in the Throwable formatter

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
@@ -10,7 +10,12 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -326,6 +331,18 @@ public sealed interface LogFormatter {
 		}
 
 		/**
+		 * Appends the events throwable stack trace using a custom
+		 * {@link ThrowableFormatter} (e.g. one created with
+		 * {@link ThrowableFormatter#of(int, List)}).
+		 * @param throwableFormatter formatter to use.
+		 * @return this.
+		 */
+		public Builder throwable(ThrowableFormatter throwableFormatter) {
+			formatters.add(throwableFormatter);
+			return this;
+		}
+
+		/**
 		 * Will create a generic log formatter that has the inner formatters coalesced if
 		 * possible and will noop if there are no formatters.
 		 * @return flattened formatter.
@@ -535,10 +552,43 @@ public sealed interface LogFormatter {
 
 		/**
 		 * Default implementation uses {@link Throwable#printStackTrace(PrintWriter)}.
+		 * This formatter is equivalent to {@code of(Integer.MAX_VALUE, List.of())} except
+		 * that it defers entirely to {@link Throwable#printStackTrace()} and thus will
+		 * respect any override of that method a particular {@link Throwable} subclass
+		 * might have.
 		 * @return formatter.
 		 */
 		public static ThrowableFormatter of() {
 			return DefaultThrowableFormatter.INSTANT;
+		}
+
+		/**
+		 * Creates a throwable formatter that limits the number of stack frame lines shown
+		 * for each throwable in the cause/suppressed chain and can exclude frames
+		 * matching regular expressions. The output is otherwise formatted like
+		 * {@link Throwable#printStackTrace()}: common frames shared with the enclosing
+		 * throwable are elided the same way (e.g. <code>"... 6 more"</code>) as long as
+		 * the depth limit was not what stopped printing; if the depth limit is what
+		 * stopped printing a <code>"... N frames truncated"</code> line is emitted
+		 * instead.
+		 * @param maxLines maximum number of stack frame ("at ...") lines printed per
+		 * throwable in the chain. Use {@link Integer#MAX_VALUE} for no limit (matches
+		 * {@link #of()} for well behaved throwables). {@code 0} prints just the throwable
+		 * header lines (class and message) for the whole chain with no frames at all.
+		 * @param excludes regular expressions matched with {@link Matcher#find()} against
+		 * each frame's {@link StackTraceElement#toString()}. A frame matching any of
+		 * these is omitted entirely and does not count against {@code maxLines}. May be
+		 * empty for no filtering.
+		 * @return formatter.
+		 * @apiNote unlike {@link #of()} this implementation walks
+		 * {@link Throwable#getCause()}/{@link Throwable#getSuppressed()}/
+		 * {@link Throwable#getStackTrace()} directly instead of calling
+		 * {@link Throwable#printStackTrace()} and thus will not honor a custom override
+		 * of that method.
+		 */
+		public static ThrowableFormatter of(int maxLines, List<String> excludes) {
+			List<Pattern> compiled = excludes.isEmpty() ? List.of() : excludes.stream().map(Pattern::compile).toList();
+			return new StandardThrowableFormatter(maxLines, compiled);
 		}
 
 		/**
@@ -804,6 +854,125 @@ enum DefaultThrowableFormatter implements ThrowableFormatter {
 	@Override
 	public void formatThrowable(StringBuilder output, Throwable throwable) {
 		ThrowableFormatter.appendThrowable(output, throwable);
+	}
+
+}
+
+/**
+ * Reimplements {@link Throwable#printStackTrace()}'s algorithm (header line, frames,
+ * common-frame elision against the enclosing trace, "Caused by:"/"Suppressed:" sections,
+ * circular reference guard) so that a max line count and frame exclusion patterns can be
+ * applied while printing.
+ */
+final class StandardThrowableFormatter implements ThrowableFormatter {
+
+	private static final String CAUSE_CAPTION = "Caused by: ";
+
+	private static final String SUPPRESSED_CAPTION = "Suppressed: ";
+
+	private final int maxLines;
+
+	private final List<Pattern> excludes;
+
+	StandardThrowableFormatter(int maxLines, List<Pattern> excludes) {
+		this.maxLines = maxLines;
+		this.excludes = excludes;
+	}
+
+	@Override
+	public void formatThrowable(StringBuilder output, Throwable throwable) {
+		Set<Throwable> dejaVu = Collections.newSetFromMap(new IdentityHashMap<>());
+		dejaVu.add(throwable);
+		var trace = throwable.getStackTrace();
+		output.append(throwable).append(System.lineSeparator());
+		printFrames(output, trace, trace.length, "");
+		for (var suppressed : throwable.getSuppressed()) {
+			printEnclosed(output, suppressed, trace, SUPPRESSED_CAPTION, "\t", dejaVu);
+		}
+		var cause = throwable.getCause();
+		if (cause != null) {
+			printEnclosed(output, cause, trace, CAUSE_CAPTION, "", dejaVu);
+		}
+	}
+
+	private void printEnclosed(StringBuilder output, Throwable throwable, StackTraceElement[] enclosingTrace,
+			String caption, String prefix, Set<Throwable> dejaVu) {
+		if (!dejaVu.add(throwable)) {
+			output.append(prefix)
+				.append("[CIRCULAR REFERENCE: ")
+				.append(throwable)
+				.append(']')
+				.append(System.lineSeparator());
+			return;
+		}
+		var trace = throwable.getStackTrace();
+		int m = trace.length - 1;
+		int n = enclosingTrace.length - 1;
+		while (m >= 0 && n >= 0 && trace[m].equals(enclosingTrace[n])) {
+			m--;
+			n--;
+		}
+		int framesInCommon = trace.length - 1 - m;
+		output.append(prefix).append(caption).append(throwable).append(System.lineSeparator());
+		boolean truncated = printFrames(output, trace, m + 1, prefix);
+		if (!truncated && framesInCommon > 0) {
+			output.append(prefix)
+				.append("\t... ")
+				.append(framesInCommon)
+				.append(" more")
+				.append(System.lineSeparator());
+		}
+		for (var suppressed : throwable.getSuppressed()) {
+			printEnclosed(output, suppressed, trace, SUPPRESSED_CAPTION, prefix + "\t", dejaVu);
+		}
+		var cause = throwable.getCause();
+		if (cause != null) {
+			printEnclosed(output, cause, trace, CAUSE_CAPTION, prefix, dejaVu);
+		}
+	}
+
+	/*
+	 * Prints frames trace[0..count) filtered by excludes and capped at maxLines. Returns
+	 * true if there were excluded-filtered frames beyond maxLines (i.e. the output was
+	 * cut short because of maxLines rather than ending naturally).
+	 */
+	private boolean printFrames(StringBuilder output, StackTraceElement[] trace, int count, String prefix) {
+		int printed = 0;
+		int available = 0;
+		for (int i = 0; i < count; i++) {
+			var element = trace[i];
+			if (isExcluded(element)) {
+				continue;
+			}
+			available++;
+			if (printed < maxLines) {
+				output.append(prefix).append("\tat ").append(element).append(System.lineSeparator());
+				printed++;
+			}
+		}
+		if (available > maxLines) {
+			output.append(prefix)
+				.append("\t... ")
+				.append(available - maxLines)
+				.append(" frames truncated")
+				.append(System.lineSeparator());
+			return true;
+		}
+		return false;
+	}
+
+	private boolean isExcluded(StackTraceElement element) {
+		if (excludes.isEmpty()) {
+			return false;
+		}
+		String s = element.toString();
+		for (var p : excludes) {
+			Matcher matcher = p.matcher(s);
+			if (matcher.find()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogFormatterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogFormatterTest.java
@@ -1,8 +1,15 @@
 package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogFormatter.ThrowableFormatter;
 
 class LogFormatterTest {
 
@@ -15,6 +22,157 @@ class LogFormatterTest {
 		LogFormatter.builder().throwable().build().format(sb, event);
 		String actual = sb.toString().split("\n")[0];
 		assertEquals("java.lang.RuntimeException: expected", actual);
+	}
+
+	private static StackTraceElement frame(String method, int line) {
+		return new StackTraceElement("com.example.App", method, "App.java", line);
+	}
+
+	private static String format(Throwable t, ThrowableFormatter formatter) {
+		StringBuilder sb = new StringBuilder();
+		formatter.formatThrowable(sb, t);
+		return sb.toString();
+	}
+
+	@SuppressWarnings("StringSplitter")
+	private static String[] lines(String s) {
+		return s.split(System.lineSeparator());
+	}
+
+	@Test
+	void testMaxLinesTruncatesAndCountsCorrectly() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame("a", 1), frame("b", 2), frame("c", 3), frame("d", 4) });
+
+		String actual = format(t, ThrowableFormatter.of(2, List.of()));
+		String[] lines = lines(actual);
+
+		assertEquals("java.lang.RuntimeException: boom", lines[0]);
+		assertEquals("\tat com.example.App.a(App.java:1)", lines[1]);
+		assertEquals("\tat com.example.App.b(App.java:2)", lines[2]);
+		assertEquals("\t... 2 frames truncated", lines[3]);
+		assertEquals(4, lines.length);
+	}
+
+	@Test
+	void testMaxLinesUnlimitedMatchesFullStack() {
+		var t = new RuntimeException("boom");
+		var frames = new StackTraceElement[] { frame("a", 1), frame("b", 2), frame("c", 3) };
+		t.setStackTrace(frames);
+
+		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String[] lines = lines(actual);
+
+		assertEquals(1 + frames.length, lines.length);
+		for (int i = 0; i < frames.length; i++) {
+			assertEquals("\tat " + frames[i], lines[i + 1]);
+		}
+	}
+
+	@Test
+	void testZeroMaxLinesPrintsOnlyHeaderAndTruncationNote() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame("a", 1), frame("b", 2) });
+
+		String actual = format(t, ThrowableFormatter.of(0, List.of()));
+		String[] lines = lines(actual);
+
+		assertEquals("java.lang.RuntimeException: boom", lines[0]);
+		assertEquals("\t... 2 frames truncated", lines[1]);
+		assertEquals(2, lines.length);
+	}
+
+	@Test
+	void testExcludesFilterFramesAndDoNotCountAgainstMaxLines() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame("keepA", 1), frame("noisyReflect", 2), frame("keepB", 3) });
+
+		String actual = format(t, ThrowableFormatter.of(2, List.of("noisyReflect")));
+		String[] lines = lines(actual);
+
+		assertEquals("java.lang.RuntimeException: boom", lines[0]);
+		assertEquals("\tat com.example.App.keepA(App.java:1)", lines[1]);
+		assertEquals("\tat com.example.App.keepB(App.java:3)", lines[2]);
+		assertEquals(3, lines.length, "excluded frame should not appear and should not trigger truncation");
+	}
+
+	@Test
+	void testCauseChainElidesCommonFramesWhenNotTruncated() {
+		var common = new StackTraceElement[] { frame("shared1", 10), frame("shared2", 11) };
+		var causeFrames = new StackTraceElement[] { frame("causeOnly", 5), common[0], common[1] };
+		var outerFrames = new StackTraceElement[] { frame("outerOnly", 20), common[0], common[1] };
+
+		var cause = new RuntimeException("root cause");
+		cause.setStackTrace(causeFrames);
+		var outer = new RuntimeException("wrapper", cause);
+		outer.setStackTrace(outerFrames);
+
+		String actual = format(outer, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String[] lines = lines(actual);
+
+		assertEquals("java.lang.RuntimeException: wrapper", lines[0]);
+		assertEquals("\tat com.example.App.outerOnly(App.java:20)", lines[1]);
+		assertEquals("\tat com.example.App.shared1(App.java:10)", lines[2]);
+		assertEquals("\tat com.example.App.shared2(App.java:11)", lines[3]);
+		assertEquals("Caused by: java.lang.RuntimeException: root cause", lines[4]);
+		assertEquals("\tat com.example.App.causeOnly(App.java:5)", lines[5]);
+		assertEquals("\t... 2 more", lines[6]);
+		assertEquals(7, lines.length);
+	}
+
+	@Test
+	void testMaxLinesSuppressesCommonFrameNoteWhenTruncationAlreadyHappened() {
+		var common = new StackTraceElement[] { frame("shared1", 10), frame("shared2", 11) };
+		var causeFrames = new StackTraceElement[] { frame("c1", 1), frame("c2", 2), common[0], common[1] };
+		var outerFrames = new StackTraceElement[] { frame("outerOnly", 20), common[0], common[1] };
+
+		var cause = new RuntimeException("root cause");
+		cause.setStackTrace(causeFrames);
+		var outer = new RuntimeException("wrapper", cause);
+		outer.setStackTrace(outerFrames);
+
+		String actual = format(outer, ThrowableFormatter.of(1, List.of()));
+		String[] lines = lines(actual);
+
+		assertEquals("Caused by: java.lang.RuntimeException: root cause", lines[3]);
+		assertEquals("\tat com.example.App.c1(App.java:1)", lines[4]);
+		assertEquals("\t... 1 frames truncated", lines[5],
+				"common-frame elision already reduced the considered range to [c1, c2] before maxLines applies");
+		assertFalse(actual.contains("more"), "should not also print the common-frame elision note");
+	}
+
+	static final class CyclicThrowable extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		private transient @Nullable Throwable causeOverride;
+
+		CyclicThrowable(String message) {
+			super(message, null, false, false);
+		}
+
+		void setCauseUnsafe(Throwable t) {
+			this.causeOverride = t;
+		}
+
+		@Override
+		public synchronized @Nullable Throwable getCause() {
+			return causeOverride;
+		}
+
+	}
+
+	@Test
+	void testCircularCauseChainDoesNotInfiniteLoop() {
+		var a = new CyclicThrowable("a");
+		a.setStackTrace(new StackTraceElement[] { frame("a", 1) });
+		var b = new CyclicThrowable("b");
+		b.setStackTrace(new StackTraceElement[] { frame("b", 2) });
+		a.setCauseUnsafe(b);
+		b.setCauseUnsafe(a);
+
+		String actual = format(a, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		assertTrue(actual.contains("CIRCULAR REFERENCE"), "expected circular reference guard to trigger:\n" + actual);
 	}
 
 }

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -25,6 +25,7 @@ import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_WHITE;
 import java.lang.System.Logger.Level;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Locale;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -33,6 +34,7 @@ import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogEvent.Caller;
 import io.jstach.rainbowgum.LogFormatter;
 import io.jstach.rainbowgum.LogFormatter.EventFormatter;
+import io.jstach.rainbowgum.LogFormatter.ThrowableFormatter;
 import io.jstach.rainbowgum.pattern.Padding;
 import io.jstach.rainbowgum.pattern.PatternKeyword;
 import io.jstach.rainbowgum.pattern.format.PatternFormatterFactory.CompositeFactory;
@@ -225,6 +227,31 @@ enum StandardKeywordFactory implements KeywordFactory {
 				return LogFormatter.noop();
 			}
 			return LogFormatter.builder().text("[").text(v).text("]").build();
+		}
+
+	},
+	/**
+	 * <code>%ex</code>, <code>%ex{full}</code>, <code>%ex{short}</code>,
+	 * <code>%ex{N}</code>, <code>%ex{N, regex1, regex2, ...}</code>.
+	 */
+	THROWABLE() {
+
+		@Override
+		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
+			String depth = node.optOrNull(0);
+			int maxLines;
+			if (depth == null || depth.equalsIgnoreCase("full")) {
+				maxLines = Integer.MAX_VALUE;
+			}
+			else if (depth.equalsIgnoreCase("short")) {
+				maxLines = 0;
+			}
+			else {
+				maxLines = Integer.parseInt(depth);
+			}
+			var options = node.optionList();
+			List<String> excludes = options.size() > 1 ? options.subList(1, options.size()) : List.of();
+			return ThrowableFormatter.of(maxLines, excludes);
 		}
 
 	};

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
@@ -400,7 +400,7 @@ final class DefaultPatternRegistry implements PatternRegistry {
 				case MDC -> StandardKeywordFactory.MDC;
 				case MICROS -> KeywordFactory.of(LogFormatter.TimestampFormatter.ofMicros());
 				case THREAD -> KeywordFactory.of(LogFormatter.builder().threadName().build());
-				case THROWABLE -> KeywordFactory.of(LogFormatter.ThrowableFormatter.of());
+				case THROWABLE -> StandardKeywordFactory.THROWABLE;
 				case CLASS -> KeywordFactory.of(CallerInfoFormatter.CLASS);
 				case FILE -> KeywordFactory.of(CallerInfoFormatter.FILE);
 				case LINE -> KeywordFactory.of(CallerInfoFormatter.LINE);

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
@@ -165,6 +165,34 @@ class CompilerTest {
 				return Stream.of(output.split("\n")).limit(1).findFirst().orElse("FAIL");
 			}
 		},
+		THROWABLE_MAX_LINES(List.of("%ex{2}"),
+				"java.lang.RuntimeException: boom\n" + "\tat com.example.App.a(App.java:1)\n"
+						+ "\tat com.example.App.b(App.java:2)\n" + "\t... 2 frames truncated\n") {
+			LogEvent event() {
+				Throwable throwable = throwableWithFrames("boom", "a", "b", "c", "d");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
+		THROWABLE_SHORT(List.of("%ex{short}"), "java.lang.RuntimeException: boom\n\t... 2 frames truncated\n") {
+			LogEvent event() {
+				Throwable throwable = throwableWithFrames("boom", "a", "b");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
+		THROWABLE_FULL(List.of("%ex{full}"), "java.lang.RuntimeException: boom\n"
+				+ "\tat com.example.App.a(App.java:1)\n" + "\tat com.example.App.b(App.java:2)\n") {
+			LogEvent event() {
+				Throwable throwable = throwableWithFrames("boom", "a", "b");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
+		THROWABLE_EXCLUDE(List.of("%ex{full, noisyReflect}"), "java.lang.RuntimeException: boom\n"
+				+ "\tat com.example.App.keepA(App.java:1)\n" + "\tat com.example.App.keepB(App.java:3)\n") {
+			LogEvent event() {
+				Throwable throwable = throwableWithFrames("boom", "keepA", "noisyReflect", "keepB");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
 		LINESEP("%n", "\n") {
 		},
 		LOGGER_LEFT_PAD("%20logger", "    io.jstach.logger") {
@@ -400,6 +428,16 @@ class CompilerTest {
 
 		LogEvent event() {
 			return LogEvent.of(level(), logger(), message(), keyValues(), null).freeze(Instant.EPOCH);
+		}
+
+		static Throwable throwableWithFrames(String message, String... methodNames) {
+			var throwable = new RuntimeException(message);
+			var frames = new StackTraceElement[methodNames.length];
+			for (int i = 0; i < methodNames.length; i++) {
+				frames[i] = new StackTraceElement("com.example.App", methodNames[i], "App.java", i + 1);
+			}
+			throwable.setStackTrace(frames);
+			return throwable;
 		}
 
 	}


### PR DESCRIPTION
ThrowableFormatter.of() previously only wrapped Throwable#printStackTrace() verbatim, and the pattern module's %ex/%exception/%throwable keyword used the generic padding-only KeywordFactory adapter, so any {...} options on %ex were silently discarded. This was the first of several Throwable pattern gaps noted while comparing against logback's %ex family.

LogFormatter.ThrowableFormatter gets a new of(int maxLines, List<String> excludes) factory, backed by a new StandardThrowableFormatter that reimplements Throwable#printStackTrace()'s algorithm directly (header line, frames, common-frame elision against the enclosing trace via the same "... N more" note, "Caused by:"/"Suppressed:" sections, circular reference guard) instead of delegating to printStackTrace(), so maxLines and exclude patterns can be applied while walking the chain:

 - maxLines caps the "at ..." lines printed per throwable in the chain. If the cap is what stopped printing, a "... N frames truncated" line is emitted instead of (not in addition to) the usual common-frame elision note, since that note isn't meaningful once truncation already cut printing short.
 - excludes are regexes matched with find() against each frame's toString(); matching frames are dropped entirely and don't count against maxLines.

of() (no args) is unchanged and still delegates to printStackTrace() directly, so it keeps honoring any custom override a particular Throwable subclass has; the new engine is only used when maxLines/excludes are actually configured. Builder.throwable(ThrowableFormatter) was added so a configured formatter can be reused outside of patterns too.

The pattern module's THROWABLE keyword moved from the fixed KeywordFactory.of(...) into StandardKeywordFactory so it can parse its own options: %ex{N}, %ex{full}, %ex{short} (maxLines=0), and %ex{N, regex1, regex2, ...} / %ex{full, regex...} for exclusions.

Follow-up work not in this branch: %rEx (root-cause-first), %xEx (packaging data), %nopex, and Spring Boot's %wEx.