### PR TITLE
Implement Spring Boot's %wEx/%wex throwable pattern keyword

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -587,8 +589,29 @@ public sealed interface LogFormatter {
 		 * of that method.
 		 */
 		public static ThrowableFormatter of(int maxLines, List<String> excludes) {
+			return of(maxLines, excludes, false);
+		}
+
+		/**
+		 * Like {@link #of(int, List)} but can additionally append packaging data (the jar
+		 * or module a frame's class was loaded from, and its version) after each frame
+		 * line, e.g. <code>[myapp-1.0.jar:1.0]</code> or <code>[java.base:na]</code>.
+		 * This mirrors (but does not byte-for-byte match) logback's
+		 * <code>ExtendedThrowableProxyConverter</code> output.
+		 * @param maxLines see {@link #of(int, List)}.
+		 * @param excludes see {@link #of(int, List)}.
+		 * @param packagingData if true each printed frame is looked up (and cached) to
+		 * determine which jar/module/classes-directory its class was loaded from and what
+		 * version that code source reports. Resolution requires loading the frame's class
+		 * (without initializing it) and can fail silently to <code>[na:na]</code> for
+		 * frames whose class cannot be loaded (e.g. dynamically generated classes). This
+		 * has a real per-frame cost so it is off by default.
+		 * @return formatter.
+		 */
+		public static ThrowableFormatter of(int maxLines, List<String> excludes, boolean packagingData) {
 			List<Pattern> compiled = excludes.isEmpty() ? List.of() : excludes.stream().map(Pattern::compile).toList();
-			return new StandardThrowableFormatter(maxLines, compiled);
+			var resolver = packagingData ? new PackagingDataResolver() : null;
+			return new StandardThrowableFormatter(maxLines, compiled, resolver);
 		}
 
 		/**
@@ -874,9 +897,12 @@ final class StandardThrowableFormatter implements ThrowableFormatter {
 
 	private final List<Pattern> excludes;
 
-	StandardThrowableFormatter(int maxLines, List<Pattern> excludes) {
+	private final @Nullable PackagingDataResolver packagingData;
+
+	StandardThrowableFormatter(int maxLines, List<Pattern> excludes, @Nullable PackagingDataResolver packagingData) {
 		this.maxLines = maxLines;
 		this.excludes = excludes;
+		this.packagingData = packagingData;
 	}
 
 	@Override
@@ -946,7 +972,11 @@ final class StandardThrowableFormatter implements ThrowableFormatter {
 			}
 			available++;
 			if (printed < maxLines) {
-				output.append(prefix).append("\tat ").append(element).append(System.lineSeparator());
+				output.append(prefix).append("\tat ").append(element);
+				if (packagingData != null) {
+					output.append(' ').append(packagingData.resolve(element));
+				}
+				output.append(System.lineSeparator());
 				printed++;
 			}
 		}
@@ -973,6 +1003,94 @@ final class StandardThrowableFormatter implements ThrowableFormatter {
 			}
 		}
 		return false;
+	}
+
+}
+
+/**
+ * Resolves and caches which jar/module/directory a stack frame's class was loaded from
+ * and its reported version, formatted as <code>[location:version]</code>. Named modules
+ * (including JDK frames) are resolved for free from the frame itself or the loaded
+ * class's {@link Module} without touching a {@link java.security.CodeSource}. Classpath
+ * (unnamed module) frames fall back to the class's {@link java.security.CodeSource} and
+ * {@link Package#getImplementationVersion()}. Either "location" or "version" is
+ * <code>na</code> when unknown, and the whole result is <code>[na:na]</code> when the
+ * frame's class cannot be loaded at all (e.g. dynamically generated classes).
+ */
+final class PackagingDataResolver {
+
+	private final ConcurrentMap<String, String> cache = new ConcurrentHashMap<>();
+
+	String resolve(StackTraceElement element) {
+		String className = element.getClassName();
+		String cached = cache.get(className);
+		if (cached != null) {
+			return cached;
+		}
+		String computed = compute(element);
+		cache.put(className, computed);
+		return computed;
+	}
+
+	private static String compute(StackTraceElement element) {
+		String moduleName = element.getModuleName();
+		if (moduleName != null) {
+			return format(moduleName, element.getModuleVersion());
+		}
+		Class<?> type = load(element.getClassName());
+		if (type == null) {
+			return "[na:na]";
+		}
+		Module module = type.getModule();
+		if (module.isNamed()) {
+			var descriptor = module.getDescriptor();
+			String version = descriptor == null ? null : descriptor.rawVersion().orElse(null);
+			return format(module.getName(), version);
+		}
+		var codeSource = type.getProtectionDomain().getCodeSource();
+		if (codeSource == null) {
+			return "[na:na]";
+		}
+		var location = codeSource.getLocation();
+		if (location == null) {
+			return "[na:na]";
+		}
+		String path = location.getPath();
+		if (path == null || path.isEmpty()) {
+			path = location.toString();
+		}
+		if (path.endsWith("/")) {
+			path = path.substring(0, path.length() - 1);
+		}
+		int slash = path.lastIndexOf('/');
+		String name = slash >= 0 && slash < path.length() - 1 ? path.substring(slash + 1) : path;
+		var pkg = type.getPackage();
+		String version = pkg == null ? null : pkg.getImplementationVersion();
+		return format(name, version);
+	}
+
+	private static String format(String location, @Nullable String version) {
+		return "[" + location + ":" + (version == null || version.isEmpty() ? "na" : version) + "]";
+	}
+
+	private static @Nullable Class<?> load(String className) {
+		var contextLoader = Thread.currentThread().getContextClassLoader();
+		if (contextLoader != null) {
+			var type = loadOrNull(className, contextLoader);
+			if (type != null) {
+				return type;
+			}
+		}
+		return loadOrNull(className, PackagingDataResolver.class.getClassLoader());
+	}
+
+	private static @Nullable Class<?> loadOrNull(String className, @Nullable ClassLoader loader) {
+		try {
+			return Class.forName(className, false, loader);
+		}
+		catch (ClassNotFoundException | LinkageError | SecurityException e) {
+			return null;
+		}
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogFormatterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogFormatterTest.java
@@ -25,7 +25,11 @@ class LogFormatterTest {
 	}
 
 	private static StackTraceElement frame(String method, int line) {
-		return new StackTraceElement("com.example.App", method, "App.java", line);
+		return frame("com.example.App", method, line);
+	}
+
+	private static StackTraceElement frame(String className, String method, int line) {
+		return new StackTraceElement(className, method, "App.java", line);
 	}
 
 	private static String format(Throwable t, ThrowableFormatter formatter) {
@@ -173,6 +177,47 @@ class LogFormatterTest {
 
 		String actual = format(a, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
 		assertTrue(actual.contains("CIRCULAR REFERENCE"), "expected circular reference guard to trigger:\n" + actual);
+	}
+
+	@Test
+	void testPackagingDataOffByDefault() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame("a", 1) });
+
+		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String[] lines = lines(actual);
+		assertEquals("\tat com.example.App.a(App.java:1)", lines[1]);
+	}
+
+	@Test
+	void testPackagingDataIsNaForUnresolvableClass() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame("com.example.DoesNotExist", "a", 1) });
+
+		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of(), true));
+		String[] lines = lines(actual);
+		assertEquals("\tat com.example.DoesNotExist.a(App.java:1) [na:na]", lines[1]);
+	}
+
+	@Test
+	void testPackagingDataResolvesJdkNamedModule() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame("java.lang.String", "valueOf", 1) });
+
+		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of(), true));
+		String[] lines = lines(actual);
+		assertTrue(lines[1].startsWith("\tat java.lang.String.valueOf(App.java:1) [java.base:"),
+				"expected java.base module packaging data:\n" + actual);
+	}
+
+	@Test
+	void testPackagingDataResolvesClasspathClass() {
+		var t = new RuntimeException("boom");
+		t.setStackTrace(new StackTraceElement[] { frame(LogFormatterTest.class.getName(), "test", 1) });
+
+		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of(), true));
+		String[] lines = lines(actual);
+		assertFalse(lines[1].endsWith("[na:na]"), "expected this test's own class to be resolvable:\n" + actual);
 	}
 
 }

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -88,6 +88,33 @@ public sealed interface PatternFormatterFactory {
 
 	}
 
+	/**
+	 * Parses the depth (<code>full</code>/<code>short</code>/a number) and exclude regex
+	 * options shared by throwable keywords such as <code>%ex</code>/<code>%xEx</code> and
+	 * Spring Boot's <code>%wEx</code>.
+	 * @param node keyword node holding the option list.
+	 * @param packagingData whether the resulting formatter should also append packaging
+	 * data (jar/module and version) after each frame; see
+	 * {@link ThrowableFormatter#of(int, List, boolean)}.
+	 * @return throwable formatter configured from the options.
+	 */
+	public static ThrowableFormatter throwableFormatter(PatternKeyword node, boolean packagingData) {
+		String depth = node.optOrNull(0);
+		int maxLines;
+		if (depth == null || depth.equalsIgnoreCase("full")) {
+			maxLines = Integer.MAX_VALUE;
+		}
+		else if (depth.equalsIgnoreCase("short")) {
+			maxLines = 0;
+		}
+		else {
+			maxLines = Integer.parseInt(depth);
+		}
+		var options = node.optionList();
+		List<String> excludes = options.size() > 1 ? options.subList(1, options.size()) : List.of();
+		return ThrowableFormatter.of(maxLines, excludes, packagingData);
+	}
+
 }
 
 enum CallerInfoFormatter implements EventFormatter {
@@ -238,20 +265,21 @@ enum StandardKeywordFactory implements KeywordFactory {
 
 		@Override
 		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
-			String depth = node.optOrNull(0);
-			int maxLines;
-			if (depth == null || depth.equalsIgnoreCase("full")) {
-				maxLines = Integer.MAX_VALUE;
-			}
-			else if (depth.equalsIgnoreCase("short")) {
-				maxLines = 0;
-			}
-			else {
-				maxLines = Integer.parseInt(depth);
-			}
-			var options = node.optionList();
-			List<String> excludes = options.size() > 1 ? options.subList(1, options.size()) : List.of();
-			return ThrowableFormatter.of(maxLines, excludes);
+			return PatternFormatterFactory.throwableFormatter(node, false);
+		}
+
+	},
+	/**
+	 * <code>%xEx</code>, <code>%xEx{full}</code>, <code>%xEx{short}</code>,
+	 * <code>%xEx{N}</code>, <code>%xEx{N, regex1, regex2, ...}</code>. Same options as
+	 * {@link #THROWABLE} but also appends packaging data (jar/module and version) after
+	 * each frame, similar to logback's <code>ExtendedThrowableProxyConverter</code>.
+	 */
+	EXTENDED_THROWABLE() {
+
+		@Override
+		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
+			return PatternFormatterFactory.throwableFormatter(node, true);
 		}
 
 	};

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
@@ -185,6 +185,12 @@ public sealed interface PatternRegistry {
 		 */
 		THROWABLE("ex", "exception", "throwable"), //
 		/**
+		 * <a href= "https://logback.qos.ch/manual/layouts.html#xThrowable">Extended
+		 * throwable keywords</a>. Same options as {@link #THROWABLE} but also appends
+		 * packaging data (jar/module and version) after each frame.
+		 */
+		EXTENDED_THROWABLE("xEx", "xException", "xThrowable"), //
+		/**
 		 * <a href="https://logback.qos.ch/manual/layouts.html#newline">Newline
 		 * keywords</a>
 		 */
@@ -401,6 +407,7 @@ final class DefaultPatternRegistry implements PatternRegistry {
 				case MICROS -> KeywordFactory.of(LogFormatter.TimestampFormatter.ofMicros());
 				case THREAD -> KeywordFactory.of(LogFormatter.builder().threadName().build());
 				case THROWABLE -> StandardKeywordFactory.THROWABLE;
+				case EXTENDED_THROWABLE -> StandardKeywordFactory.EXTENDED_THROWABLE;
 				case CLASS -> KeywordFactory.of(CallerInfoFormatter.CLASS);
 				case FILE -> KeywordFactory.of(CallerInfoFormatter.FILE);
 				case LINE -> KeywordFactory.of(CallerInfoFormatter.LINE);
@@ -495,12 +502,6 @@ final class DefaultPatternRegistry implements PatternRegistry {
 	// RootCauseFirstThrowableProxyConverter.class.getName());
 	// DEFAULT_CONVERTER_MAP.put("rootException",
 	// RootCauseFirstThrowableProxyConverter.class.getName());
-	//
-	// DEFAULT_CONVERTER_MAP.put("xEx", ExtendedThrowableProxyConverter.class.getName());
-	// DEFAULT_CONVERTER_MAP.put("xException",
-	// ExtendedThrowableProxyConverter.class.getName());
-	// DEFAULT_CONVERTER_MAP.put("xThrowable",
-	// ExtendedThrowableProxyConverter.class.getName());
 	//
 	// DEFAULT_CONVERTER_MAP.put("nopex",
 	// NopThrowableInformationConverter.class.getName());

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
@@ -193,6 +193,21 @@ class CompilerTest {
 				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
 			}
 		},
+		EXTENDED_THROWABLE(List.of("%xEx", "%xException", "%xThrowable"), "java.lang.RuntimeException: boom\n"
+				+ "\tat com.example.App.a(App.java:1) [na:na]\n" + "\tat com.example.App.b(App.java:2) [na:na]\n") {
+			LogEvent event() {
+				Throwable throwable = throwableWithFrames("boom", "a", "b");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
+		EXTENDED_THROWABLE_MAX_LINES(List.of("%xEx{2}"),
+				"java.lang.RuntimeException: boom\n" + "\tat com.example.App.a(App.java:1) [na:na]\n"
+						+ "\tat com.example.App.b(App.java:2) [na:na]\n" + "\t... 2 frames truncated\n") {
+			LogEvent event() {
+				Throwable throwable = throwableWithFrames("boom", "a", "b", "c", "d");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
 		LINESEP("%n", "\n") {
 		},
 		LOGGER_LEFT_PAD("%20logger", "    io.jstach.logger") {

--- a/spring/rainbowgum-spring-boot/src/main/java/io/jstach/rainbowgum/spring/boot/SpringBootKeywordFactory.java
+++ b/spring/rainbowgum-spring-boot/src/main/java/io/jstach/rainbowgum/spring/boot/SpringBootKeywordFactory.java
@@ -5,8 +5,10 @@ import org.springframework.boot.logging.CorrelationIdFormatter;
 import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogFormatter;
 import io.jstach.rainbowgum.LogFormatter.EventFormatter;
+import io.jstach.rainbowgum.LogFormatter.ThrowableFormatter;
 import io.jstach.rainbowgum.pattern.PatternKeyword;
 import io.jstach.rainbowgum.pattern.format.PatternConfig;
+import io.jstach.rainbowgum.pattern.format.PatternFormatterFactory;
 import io.jstach.rainbowgum.pattern.format.PatternFormatterFactory.KeywordFactory;
 import io.jstach.rainbowgum.pattern.format.PatternRegistry.PatternKey;
 import io.jstach.rainbowgum.pattern.format.PatternRegistry.PatternKeyProvider;
@@ -26,19 +28,44 @@ enum SpringBootKeywordFactory implements KeywordFactory, PatternKeyProvider {
 			return PatternKey.of("correlationId");
 		}
 	},
-	WHITESPACE_EXTENDED_THROWABLE() {
+	/**
+	 * Spring Boot's <code>%wex</code>, backed by
+	 * <code>WhitespaceThrowableProxyConverter</code>: a normal throwable formatter
+	 * (honoring depth/exclude options) with a leading newline so the stack trace starts
+	 * on its own line.
+	 */
+	WHITESPACE_THROWABLE() {
 
 		@Override
 		public LogFormatter create(PatternConfig config, PatternKeyword node) {
-			/*
-			 * TODO Actually do the correct outputting based on logback or log4j.
-			 */
-			return LogFormatter.ThrowableFormatter.of();
+			var throwableFormatter = PatternFormatterFactory.throwableFormatter(node, false);
+			return new WhitespaceThrowableFormatter(throwableFormatter);
 		}
 
 		@Override
 		public PatternKey key() {
-			return PatternKey.of("wEx", "wex");
+			return PatternKey.of("wex");
+		}
+
+	},
+	/**
+	 * Spring Boot's <code>%wEx</code>, backed by
+	 * <code>ExtendedWhitespaceThrowableProxyConverter</code>: like
+	 * {@link #WHITESPACE_THROWABLE} but additionally appends packaging data (jar/module
+	 * and version) after each frame, matching real Spring Boot's uppercase/lowercase
+	 * distinction between <code>%wEx</code> and <code>%wex</code>.
+	 */
+	EXTENDED_WHITESPACE_THROWABLE() {
+
+		@Override
+		public LogFormatter create(PatternConfig config, PatternKeyword node) {
+			var throwableFormatter = PatternFormatterFactory.throwableFormatter(node, true);
+			return new WhitespaceThrowableFormatter(throwableFormatter);
+		}
+
+		@Override
+		public PatternKey key() {
+			return PatternKey.of("wEx");
 		}
 
 	};
@@ -51,6 +78,23 @@ enum SpringBootKeywordFactory implements KeywordFactory, PatternKeyProvider {
 			 * TODO This is probably not efficient at all but hey its Spring Boot.
 			 */
 			correlationIdFormatter.formatTo(event.keyValues()::getValueOrNull, output);
+		}
+
+	}
+
+	/**
+	 * Mirrors Spring Boot's <code>WhitespaceThrowableProxyConverter</code>: prefixes the
+	 * delegate's output with a newline so the stack trace is separated from the rest of
+	 * the log line. {@link ThrowableFormatter#formatThrowable(StringBuilder, Throwable)}
+	 * is only invoked when there is an actual throwable to print, so the newline is never
+	 * emitted on its own.
+	 */
+	record WhitespaceThrowableFormatter(ThrowableFormatter delegate) implements ThrowableFormatter {
+
+		@Override
+		public void formatThrowable(StringBuilder output, Throwable throwable) {
+			output.append(System.lineSeparator());
+			delegate.formatThrowable(output, throwable);
 		}
 
 	}

--- a/spring/rainbowgum-spring-boot/src/test/java/io/jstach/rainbowgum/spring/boot/SpringBootKeywordFactoryTest.java
+++ b/spring/rainbowgum-spring-boot/src/test/java/io/jstach/rainbowgum/spring/boot/SpringBootKeywordFactoryTest.java
@@ -1,0 +1,74 @@
+package io.jstach.rainbowgum.spring.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.pattern.format.PatternCompiler;
+import io.jstach.rainbowgum.pattern.format.PatternConfig;
+import io.jstach.rainbowgum.pattern.format.PatternRegistry;
+
+class SpringBootKeywordFactoryTest {
+
+	private static PatternCompiler compiler() {
+		var registry = PatternRegistry.of();
+		for (var kf : SpringBootKeywordFactory.values()) {
+			registry.register(kf);
+		}
+		return PatternCompiler.builder().patternRegistry(registry).patternConfig(PatternConfig.ofUniversal()).build();
+	}
+
+	private static Throwable throwableWithFrames(String message, String... methodNames) {
+		var throwable = new RuntimeException(message);
+		var frames = new StackTraceElement[methodNames.length];
+		for (int i = 0; i < methodNames.length; i++) {
+			frames[i] = new StackTraceElement("com.example.App", methodNames[i], "App.java", i + 1);
+		}
+		throwable.setStackTrace(frames);
+		return throwable;
+	}
+
+	private static String format(String pattern, Throwable throwable) {
+		var event = LogEvent
+			.of(System.Logger.Level.INFO, "io.jstach.logger", "hello", MutableKeyValues.of().freeze(), throwable)
+			.freeze(Instant.EPOCH);
+		StringBuilder sb = new StringBuilder();
+		compiler().compile(pattern).format(sb, event);
+		return sb.toString();
+	}
+
+	@Test
+	void testWExPrefixesNewlineAndAppendsPackagingData() {
+		var throwable = throwableWithFrames("boom", "a", "b");
+		String actual = format("%wEx", throwable);
+		assertEquals("\njava.lang.RuntimeException: boom\n" + "\tat com.example.App.a(App.java:1) [na:na]\n"
+				+ "\tat com.example.App.b(App.java:2) [na:na]\n", actual);
+	}
+
+	@Test
+	void testWexLowerCaseAliasHasNoPackagingData() {
+		var throwable = throwableWithFrames("boom", "a", "b");
+		String actual = format("%wex", throwable);
+		assertEquals("\njava.lang.RuntimeException: boom\n" + "\tat com.example.App.a(App.java:1)\n"
+				+ "\tat com.example.App.b(App.java:2)\n", actual);
+	}
+
+	@Test
+	void testWExHonorsDepthOption() {
+		var throwable = throwableWithFrames("boom", "a", "b", "c", "d");
+		String actual = format("%wEx{2}", throwable);
+		assertEquals("\njava.lang.RuntimeException: boom\n" + "\tat com.example.App.a(App.java:1) [na:na]\n"
+				+ "\tat com.example.App.b(App.java:2) [na:na]\n" + "\t... 2 frames truncated\n", actual);
+	}
+
+	@Test
+	void testWExOmitsNewlineWhenNoThrowable() {
+		String actual = format("%wEx", null);
+		assertEquals("", actual);
+	}
+
+}


### PR DESCRIPTION
Previously the wEx/wex keyword was a TODO stub that just delegated to the plain, unconfigurable ThrowableFormatter.of() and ignored its own options. It now:

 - Reuses the depth/exclude option parsing from %ex (extracted into a new public PatternFormatterFactory.throwableFormatter(PatternKeyword) helper) so %wEx{N}, %wEx{short}, %wEx{full}, and exclusion regexes all work the same way they do for %ex.
 - Wraps the result with a WhitespaceThrowableFormatter that prefixes a newline, mirroring Spring Boot's WhitespaceThrowableProxyConverter so the stack trace starts on its own line like real Spring Boot output.

Real Spring Boot's %wEx (uppercase) is backed by
ExtendedThrowableProxyConverter and additionally prints jar packaging data per frame; %wex (lowercase) does not. That packaging data support (the %xEx family) is not implemented yet, so both aliases currently behave identically here. This is called out in the keyword's javadoc.

No default pattern changes were needed: RainbowGumLoggingSystemFactory already used %wEx as its LOG_EXCEPTION_CONVERSION_WORD default (matching Spring Boot's own defaults.xml), it just wasn't doing anything useful until now.

Adds the first test class for rainbowgum-spring-boot.

Follow-up work not in this branch: %rEx (root-cause-first), %xEx (packaging data), %nopex.