### PR TITLE
Replace ThrowableFormatter's 2/3-arg static factories with a builder

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
@@ -335,7 +335,7 @@ public sealed interface LogFormatter {
 		/**
 		 * Appends the events throwable stack trace using a custom
 		 * {@link ThrowableFormatter} (e.g. one created with
-		 * {@link ThrowableFormatter#of(int, List)}).
+		 * {@link ThrowableFormatter#builder()}).
 		 * @param throwableFormatter formatter to use.
 		 * @return this.
 		 */
@@ -565,53 +565,24 @@ public sealed interface LogFormatter {
 		}
 
 		/**
-		 * Creates a throwable formatter that limits the number of stack frame lines shown
-		 * for each throwable in the cause/suppressed chain and can exclude frames
-		 * matching regular expressions. The output is otherwise formatted like
-		 * {@link Throwable#printStackTrace()}: common frames shared with the enclosing
-		 * throwable are elided the same way (e.g. <code>"... 6 more"</code>) as long as
-		 * the depth limit was not what stopped printing; if the depth limit is what
-		 * stopped printing a <code>"... N frames truncated"</code> line is emitted
-		 * instead.
-		 * @param maxLines maximum number of stack frame ("at ...") lines printed per
-		 * throwable in the chain. Use {@link Integer#MAX_VALUE} for no limit (matches
-		 * {@link #of()} for well behaved throwables). {@code 0} prints just the throwable
-		 * header lines (class and message) for the whole chain with no frames at all.
-		 * @param excludes regular expressions matched with {@link Matcher#find()} against
-		 * each frame's {@link StackTraceElement#toString()}. A frame matching any of
-		 * these is omitted entirely and does not count against {@code maxLines}. May be
-		 * empty for no filtering.
-		 * @return formatter.
-		 * @apiNote unlike {@link #of()} this implementation walks
+		 * Creates a builder for a throwable formatter that can limit the number of stack
+		 * frame lines shown for each throwable in the cause/suppressed chain, exclude
+		 * frames matching regular expressions, and append packaging data. The output is
+		 * otherwise formatted like {@link Throwable#printStackTrace()}: common frames
+		 * shared with the enclosing throwable are elided the same way (e.g.
+		 * <code>"... 6 more"</code>) as long as the depth limit was not what stopped
+		 * printing; if the depth limit is what stopped printing a
+		 * <code>"... N frames truncated"</code> line is emitted instead.
+		 * @return builder.
+		 * @apiNote a builder left at its defaults (no max lines, exclusions, or packaging
+		 * data) builds {@link #of()} itself; otherwise the built formatter walks
 		 * {@link Throwable#getCause()}/{@link Throwable#getSuppressed()}/
 		 * {@link Throwable#getStackTrace()} directly instead of calling
 		 * {@link Throwable#printStackTrace()} and thus will not honor a custom override
 		 * of that method.
 		 */
-		public static ThrowableFormatter of(int maxLines, List<String> excludes) {
-			return of(maxLines, excludes, false);
-		}
-
-		/**
-		 * Like {@link #of(int, List)} but can additionally append packaging data (the jar
-		 * or module a frame's class was loaded from, and its version) after each frame
-		 * line, e.g. <code>[myapp-1.0.jar:1.0]</code> or <code>[java.base:na]</code>.
-		 * This mirrors (but does not byte-for-byte match) logback's
-		 * <code>ExtendedThrowableProxyConverter</code> output.
-		 * @param maxLines see {@link #of(int, List)}.
-		 * @param excludes see {@link #of(int, List)}.
-		 * @param packagingData if true each printed frame is looked up (and cached) to
-		 * determine which jar/module/classes-directory its class was loaded from and what
-		 * version that code source reports. Resolution requires loading the frame's class
-		 * (without initializing it) and can fail silently to <code>[na:na]</code> for
-		 * frames whose class cannot be loaded (e.g. dynamically generated classes). This
-		 * has a real per-frame cost so it is off by default.
-		 * @return formatter.
-		 */
-		public static ThrowableFormatter of(int maxLines, List<String> excludes, boolean packagingData) {
-			List<Pattern> compiled = excludes.isEmpty() ? List.of() : excludes.stream().map(Pattern::compile).toList();
-			var resolver = packagingData ? new PackagingDataResolver() : null;
-			return new StandardThrowableFormatter(maxLines, compiled, resolver);
+		public static Builder builder() {
+			return new Builder();
 		}
 
 		/**
@@ -625,6 +596,87 @@ public sealed interface LogFormatter {
 			 * TODO optimize
 			 */
 			t.printStackTrace(Internal.StringBuilderPrintWriter.of(b));
+		}
+
+		/**
+		 * Builds a configurable {@link ThrowableFormatter}.
+		 *
+		 * @see ThrowableFormatter#builder()
+		 */
+		public final class Builder {
+
+			private int maxLines = Integer.MAX_VALUE;
+
+			private List<String> excludes = List.of();
+
+			private boolean packagingData = false;
+
+			private Builder() {
+			}
+
+			/**
+			 * Maximum number of stack frame ("at ...") lines printed per throwable in the
+			 * chain. Use {@link Integer#MAX_VALUE} for no limit (the default, and matches
+			 * {@link ThrowableFormatter#of()} for well behaved throwables). {@code 0}
+			 * prints just the throwable header lines (class and message) for the whole
+			 * chain with no frames at all.
+			 * @param maxLines maximum stack frame lines per throwable.
+			 * @return this builder.
+			 */
+			public Builder maxLines(int maxLines) {
+				this.maxLines = maxLines;
+				return this;
+			}
+
+			/**
+			 * Regular expressions matched with {@link Matcher#find()} against each
+			 * frame's {@link StackTraceElement#toString()}. A frame matching any of these
+			 * is omitted entirely and does not count against {@link #maxLines(int)}.
+			 * Defaults to empty (no filtering).
+			 * @param excludes exclude patterns.
+			 * @return this builder.
+			 */
+			public Builder excludes(List<String> excludes) {
+				this.excludes = excludes;
+				return this;
+			}
+
+			/**
+			 * Whether to append packaging data (the jar or module a frame's class was
+			 * loaded from, and its version) after each frame line, e.g.
+			 * <code>[myapp-1.0.jar:1.0]</code> or <code>[java.base:na]</code>. This
+			 * mirrors (but does not byte-for-byte match) logback's
+			 * <code>ExtendedThrowableProxyConverter</code> output. Resolution requires
+			 * loading the frame's class (without initializing it) and can fail silently
+			 * to <code>[na:na]</code> for frames whose class cannot be loaded (e.g.
+			 * dynamically generated classes). This has a real per-frame cost so it
+			 * defaults to <code>false</code>.
+			 * @param packagingData true to append packaging data.
+			 * @return this builder.
+			 */
+			public Builder packagingData(boolean packagingData) {
+				this.packagingData = packagingData;
+				return this;
+			}
+
+			/**
+			 * Builds the formatter. If none of {@link #maxLines(int)},
+			 * {@link #excludes(List)}, or {@link #packagingData(boolean)} were set away
+			 * from their defaults, returns {@link ThrowableFormatter#of()} (i.e. plain
+			 * {@link Throwable#printStackTrace()} behavior) instead of constructing a
+			 * formatter that walks the throwable manually for no reason.
+			 * @return formatter.
+			 */
+			public ThrowableFormatter build() {
+				if (maxLines == Integer.MAX_VALUE && excludes.isEmpty() && !packagingData) {
+					return ThrowableFormatter.of();
+				}
+				List<Pattern> compiled = excludes.isEmpty() ? List.of()
+						: excludes.stream().map(Pattern::compile).toList();
+				var resolver = packagingData ? new PackagingDataResolver() : null;
+				return new StandardThrowableFormatter(maxLines, compiled, resolver);
+			}
+
 		}
 
 	}

--- a/core/src/test/java/io/jstach/rainbowgum/LogFormatterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogFormatterTest.java
@@ -2,6 +2,7 @@ package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -38,6 +39,14 @@ class LogFormatterTest {
 		return sb.toString();
 	}
 
+	private static ThrowableFormatter of(int maxLines, List<String> excludes) {
+		return ThrowableFormatter.builder().maxLines(maxLines).excludes(excludes).build();
+	}
+
+	private static ThrowableFormatter of(int maxLines, List<String> excludes, boolean packagingData) {
+		return ThrowableFormatter.builder().maxLines(maxLines).excludes(excludes).packagingData(packagingData).build();
+	}
+
 	@SuppressWarnings("StringSplitter")
 	private static String[] lines(String s) {
 		return s.split(System.lineSeparator());
@@ -48,7 +57,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame("a", 1), frame("b", 2), frame("c", 3), frame("d", 4) });
 
-		String actual = format(t, ThrowableFormatter.of(2, List.of()));
+		String actual = format(t, of(2, List.of()));
 		String[] lines = lines(actual);
 
 		assertEquals("java.lang.RuntimeException: boom", lines[0]);
@@ -64,7 +73,7 @@ class LogFormatterTest {
 		var frames = new StackTraceElement[] { frame("a", 1), frame("b", 2), frame("c", 3) };
 		t.setStackTrace(frames);
 
-		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String actual = format(t, of(Integer.MAX_VALUE, List.of()));
 		String[] lines = lines(actual);
 
 		assertEquals(1 + frames.length, lines.length);
@@ -78,7 +87,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame("a", 1), frame("b", 2) });
 
-		String actual = format(t, ThrowableFormatter.of(0, List.of()));
+		String actual = format(t, of(0, List.of()));
 		String[] lines = lines(actual);
 
 		assertEquals("java.lang.RuntimeException: boom", lines[0]);
@@ -91,7 +100,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame("keepA", 1), frame("noisyReflect", 2), frame("keepB", 3) });
 
-		String actual = format(t, ThrowableFormatter.of(2, List.of("noisyReflect")));
+		String actual = format(t, of(2, List.of("noisyReflect")));
 		String[] lines = lines(actual);
 
 		assertEquals("java.lang.RuntimeException: boom", lines[0]);
@@ -111,7 +120,7 @@ class LogFormatterTest {
 		var outer = new RuntimeException("wrapper", cause);
 		outer.setStackTrace(outerFrames);
 
-		String actual = format(outer, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String actual = format(outer, of(Integer.MAX_VALUE, List.of()));
 		String[] lines = lines(actual);
 
 		assertEquals("java.lang.RuntimeException: wrapper", lines[0]);
@@ -135,7 +144,7 @@ class LogFormatterTest {
 		var outer = new RuntimeException("wrapper", cause);
 		outer.setStackTrace(outerFrames);
 
-		String actual = format(outer, ThrowableFormatter.of(1, List.of()));
+		String actual = format(outer, of(1, List.of()));
 		String[] lines = lines(actual);
 
 		assertEquals("Caused by: java.lang.RuntimeException: root cause", lines[3]);
@@ -175,8 +184,14 @@ class LogFormatterTest {
 		a.setCauseUnsafe(b);
 		b.setCauseUnsafe(a);
 
-		String actual = format(a, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String actual = format(a, of(Integer.MAX_VALUE, List.of()));
 		assertTrue(actual.contains("CIRCULAR REFERENCE"), "expected circular reference guard to trigger:\n" + actual);
+	}
+
+	@Test
+	void testBuilderWithNoCustomizationReturnsDefaultFormatter() {
+		assertSame(ThrowableFormatter.of(), ThrowableFormatter.builder().build(),
+				"a builder left at its defaults should not construct a StandardThrowableFormatter");
 	}
 
 	@Test
@@ -184,7 +199,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame("a", 1) });
 
-		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of()));
+		String actual = format(t, of(Integer.MAX_VALUE, List.of()));
 		String[] lines = lines(actual);
 		assertEquals("\tat com.example.App.a(App.java:1)", lines[1]);
 	}
@@ -194,7 +209,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame("com.example.DoesNotExist", "a", 1) });
 
-		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of(), true));
+		String actual = format(t, of(Integer.MAX_VALUE, List.of(), true));
 		String[] lines = lines(actual);
 		assertEquals("\tat com.example.DoesNotExist.a(App.java:1) [na:na]", lines[1]);
 	}
@@ -204,7 +219,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame("java.lang.String", "valueOf", 1) });
 
-		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of(), true));
+		String actual = format(t, of(Integer.MAX_VALUE, List.of(), true));
 		String[] lines = lines(actual);
 		assertTrue(lines[1].startsWith("\tat java.lang.String.valueOf(App.java:1) [java.base:"),
 				"expected java.base module packaging data:\n" + actual);
@@ -215,7 +230,7 @@ class LogFormatterTest {
 		var t = new RuntimeException("boom");
 		t.setStackTrace(new StackTraceElement[] { frame(LogFormatterTest.class.getName(), "test", 1) });
 
-		String actual = format(t, ThrowableFormatter.of(Integer.MAX_VALUE, List.of(), true));
+		String actual = format(t, of(Integer.MAX_VALUE, List.of(), true));
 		String[] lines = lines(actual);
 		assertFalse(lines[1].endsWith("[na:na]"), "expected this test's own class to be resolvable:\n" + actual);
 	}

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -95,7 +95,7 @@ public sealed interface PatternFormatterFactory {
 	 * @param node keyword node holding the option list.
 	 * @param packagingData whether the resulting formatter should also append packaging
 	 * data (jar/module and version) after each frame; see
-	 * {@link ThrowableFormatter#of(int, List, boolean)}.
+	 * {@link ThrowableFormatter.Builder#packagingData(boolean)}.
 	 * @return throwable formatter configured from the options.
 	 */
 	public static ThrowableFormatter throwableFormatter(PatternKeyword node, boolean packagingData) {
@@ -112,7 +112,7 @@ public sealed interface PatternFormatterFactory {
 		}
 		var options = node.optionList();
 		List<String> excludes = options.size() > 1 ? options.subList(1, options.size()) : List.of();
-		return ThrowableFormatter.of(maxLines, excludes, packagingData);
+		return ThrowableFormatter.builder().maxLines(maxLines).excludes(excludes).packagingData(packagingData).build();
 	}
 
 }


### PR DESCRIPTION
RainbowGum prefers builders over multi-arg static factories. Replaces ThrowableFormatter.of(int, List) and of(int, List, boolean) with ThrowableFormatter.builder().maxLines(...).excludes(...).packagingData(...).build().

The builder is smart: build() with everything left at its defaults returns ThrowableFormatter.of() itself (the printStackTrace-based formatter) instead of constructing a StandardThrowableFormatter for no reason.

ThrowableFormatter.of() (no-arg) is unchanged.