### PR TITLE
Support %r/%relative pattern keyword (elapsed milliseconds since start)

### DIFF
--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfig.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfig.java
@@ -1,5 +1,6 @@
 package io.jstach.rainbowgum.pattern.format;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.function.Function;
@@ -62,6 +63,15 @@ public sealed interface PatternConfig extends Configurator {
 	public Function<String, @Nullable String> propertyFunction();
 
 	/**
+	 * The baseline instant used by <code>%r</code>/<code>%relative</code> to compute
+	 * elapsed milliseconds. Captured once (e.g. when this config is built) rather than
+	 * recomputed, the same way logback's <code>RelativeTimeConverter</code> captures its
+	 * start time once when constructed.
+	 * @return start time.
+	 */
+	public Instant startTime();
+
+	/**
 	 * Creates a builder to create formatter config.
 	 * @return builder.
 	 * @apiNote {@link PatternConfig} implements {@link Configurator} so it can be
@@ -93,6 +103,7 @@ public sealed interface PatternConfig extends Configurator {
 		builder.lineSeparator(config.lineSeparator());
 		builder.zoneId(config.zoneId());
 		builder.propertyFunction(config.propertyFunction());
+		builder.startTime(config.startTime());
 		return builder;
 	}
 
@@ -175,6 +186,17 @@ non-sealed interface DefaultFormatterConfig extends PatternConfig {
 		return StandardPropertyFunction.INSTANCE;
 	}
 
+	/**
+	 * Captured once when this interface is first loaded so all default configs share a
+	 * single start time approximating application/logging startup.
+	 */
+	Instant DEFAULT_START_TIME = Instant.now();
+
+	@Override
+	default Instant startTime() {
+		return DEFAULT_START_TIME;
+	}
+
 	enum StandardPropertyFunction implements Function<String, @Nullable String> {
 
 		INSTANCE;
@@ -206,11 +228,16 @@ enum StandardFormatterConfig implements DefaultFormatterConfig {
 		public boolean ansiDisabled() {
 			return true;
 		}
+
+		@Override
+		public Instant startTime() {
+			return Instant.EPOCH;
+		}
 	};
 
 }
 
 record SimpleFormatterConfig(ZoneId zoneId, String lineSeparator, boolean ansiDisabled,
-		Function<String, @Nullable String> propertyFunction) implements PatternConfig {
+		Function<String, @Nullable String> propertyFunction, Instant startTime) implements PatternConfig {
 
 }

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -1,5 +1,6 @@
 package io.jstach.rainbowgum.pattern.format;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.function.Function;
 
@@ -96,13 +97,15 @@ public final class PatternConfigurator implements Configurator {
 			@ConvertParameter("convertZoneId") @Nullable ZoneId zoneId, //
 			@Nullable String lineSeparator, //
 			@Nullable Boolean ansiDisabled, //
-			@PassThroughParameter @Nullable Function<String, @Nullable String> propertyFunction) {
+			@PassThroughParameter @Nullable Function<String, @Nullable String> propertyFunction, //
+			@PassThroughParameter @Nullable Instant startTime) {
 		PatternConfig dc = PatternConfig.of();
 		ansiDisabled = ansiDisabled == null ? dc.ansiDisabled() : ansiDisabled;
 		lineSeparator = lineSeparator == null ? dc.lineSeparator() : lineSeparator;
 		zoneId = zoneId == null ? dc.zoneId() : zoneId;
 		propertyFunction = propertyFunction == null ? StandardPropertyFunction.INSTANCE : propertyFunction;
-		return new SimpleFormatterConfig(zoneId, lineSeparator, ansiDisabled, propertyFunction);
+		startTime = startTime == null ? Instant.now() : startTime;
+		return new SimpleFormatterConfig(zoneId, lineSeparator, ansiDisabled, propertyFunction, startTime);
 
 	}
 

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -23,6 +23,8 @@ import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_CYAN;
 import static io.jstach.rainbowgum.pattern.format.ANSIConstants.BRIGHT_WHITE;
 
 import java.lang.System.Logger.Level;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -181,6 +183,18 @@ enum StandardKeywordFactory implements KeywordFactory {
 			return LogFormatter.TimestampFormatter.of(dtf);
 		}
 	},
+	/**
+	 * <code>%r</code>, <code>%relative</code>: milliseconds elapsed since
+	 * {@link PatternConfig#startTime()}.
+	 */
+	RELATIVE() {
+
+		@Override
+		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
+			return new RelativeTimeFormatter(config.startTime());
+		}
+
+	},
 	LOGGER() {
 
 		@Override
@@ -313,6 +327,16 @@ enum StandardKeywordFactory implements KeywordFactory {
 			String out = abbreviator.abbreviate(event.loggerName());
 			output.append(out);
 
+		}
+
+	}
+
+	record RelativeTimeFormatter(Instant startTime) implements LogFormatter.EventFormatter {
+
+		@Override
+		public void format(StringBuilder output, LogEvent event) {
+			long millis = Duration.between(startTime, event.timestamp()).toMillis();
+			output.append(millis);
 		}
 
 	}

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
@@ -138,6 +138,11 @@ public sealed interface PatternRegistry {
 		 */
 		MICROS("ms", "micros"), //
 		/**
+		 * <a href="https://logback.qos.ch/manual/layouts.html#relative">Relative time
+		 * keywords</a>. Milliseconds elapsed since {@link PatternConfig#startTime()}.
+		 */
+		RELATIVE("r", "relative"), //
+		/**
 		 * <a href="https://logback.qos.ch/manual/layouts.html#file">File</a>
 		 */
 		FILE("f", "file"),
@@ -154,8 +159,7 @@ public sealed interface PatternRegistry {
 		 */
 		METHOD("M", "method"),
 		/**
-		 * <a href="https://logback.qos.ch/manual/layouts.html#relative">Thread
-		 * keywords</a>
+		 * <a href="https://logback.qos.ch/manual/layouts.html#thread">Thread keywords</a>
 		 */
 		THREAD("t", "thread"), //
 		/**
@@ -405,6 +409,7 @@ final class DefaultPatternRegistry implements PatternRegistry {
 				case LOGGER -> StandardKeywordFactory.LOGGER;
 				case MDC -> StandardKeywordFactory.MDC;
 				case MICROS -> KeywordFactory.of(LogFormatter.TimestampFormatter.ofMicros());
+				case RELATIVE -> StandardKeywordFactory.RELATIVE;
 				case THREAD -> KeywordFactory.of(LogFormatter.builder().threadName().build());
 				case THROWABLE -> StandardKeywordFactory.THROWABLE;
 				case EXTENDED_THROWABLE -> StandardKeywordFactory.EXTENDED_THROWABLE;
@@ -470,11 +475,6 @@ final class DefaultPatternRegistry implements PatternRegistry {
 	}
 
 	// DEFAULT_CONVERTER_MAP.putAll(Parser.DEFAULT_COMPOSITE_CONVERTER_MAP);
-	//
-	//
-	// DEFAULT_CONVERTER_MAP.put("r", RelativeTimeConverter.class.getName());
-	// DEFAULT_CONVERTER_MAP.put("relative", RelativeTimeConverter.class.getName());
-	// CONVERTER_CLASS_TO_KEY_MAP.put(RelativeTimeConverter.class.getName(), "relative");
 	//
 	//
 

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
@@ -95,6 +95,16 @@ class CompilerTest {
 				assertInstanceOf(TimestampFormatter.class, formatter);
 			}
 		},
+		RELATIVE(List.of("%r", "%relative"), "0") {
+		},
+		RELATIVE_ELAPSED(List.of("%r"), "5000") {
+			@Override
+			protected PatternConfig patternConfig() {
+				return PatternConfig.copy(PatternConfig.builder(), PatternConfig.ofUniversal())
+					.startTime(Instant.EPOCH.minusMillis(5000))
+					.build();
+			}
+		},
 		FILE(List.of("%f", "%file"), "CompilerTest.java") {
 			LogEvent event() {
 				Caller caller = Caller.ofDepthOrNull(1);


### PR DESCRIPTION
Adds PatternConfig.startTime(), the baseline instant %r/%relative formats elapsed milliseconds from, mirroring logback's RelativeTimeConverter (captured once rather than recomputed per event).

DefaultFormatterConfig (used by the DEFAULT_FORMATTER_CONFIG enum singleton) captures a shared Instant.now() once when the interface is loaded. UNIVERSAL_FORMATTER_CONFIG uses Instant.EPOCH for deterministic output. Programmatically/property-built configs (SimpleFormatterConfig via PatternConfigurator.provideFormatterConfig) default to a fresh Instant.now() at build time if not explicitly set, and PatternConfigBuilder gets a generated startTime(Instant) setter since the new provideFormatterConfig parameter is @PassThroughParameter.

Wires up %r/%relative in PatternRegistry.KeywordKey and StandardKeywordFactory. Also fixed a pre-existing javadoc copy-paste bug where THREAD linked to logback's #relative anchor instead of #thread.