### PR TITLE
Support %lsn (local sequence number) pattern keyword

### DIFF
--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfig.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfig.java
@@ -72,6 +72,12 @@ public sealed interface PatternConfig extends Configurator {
 	public Instant startTime();
 
 	/**
+	 * The first value returned by <code>%lsn</code>. Defaults to <code>0</code>.
+	 * @return sequence number start.
+	 */
+	public long sequenceNumberStart();
+
+	/**
 	 * Creates a builder to create formatter config.
 	 * @return builder.
 	 * @apiNote {@link PatternConfig} implements {@link Configurator} so it can be
@@ -104,6 +110,7 @@ public sealed interface PatternConfig extends Configurator {
 		builder.zoneId(config.zoneId());
 		builder.propertyFunction(config.propertyFunction());
 		builder.startTime(config.startTime());
+		builder.sequenceNumberStart(config.sequenceNumberStart());
 		return builder;
 	}
 
@@ -197,6 +204,11 @@ non-sealed interface DefaultFormatterConfig extends PatternConfig {
 		return DEFAULT_START_TIME;
 	}
 
+	@Override
+	default long sequenceNumberStart() {
+		return 0L;
+	}
+
 	enum StandardPropertyFunction implements Function<String, @Nullable String> {
 
 		INSTANCE;
@@ -238,6 +250,7 @@ enum StandardFormatterConfig implements DefaultFormatterConfig {
 }
 
 record SimpleFormatterConfig(ZoneId zoneId, String lineSeparator, boolean ansiDisabled,
-		Function<String, @Nullable String> propertyFunction, Instant startTime) implements PatternConfig {
+		Function<String, @Nullable String> propertyFunction, Instant startTime,
+		long sequenceNumberStart) implements PatternConfig {
 
 }

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -98,15 +98,22 @@ public final class PatternConfigurator implements Configurator {
 			@Nullable String lineSeparator, //
 			@Nullable Boolean ansiDisabled, //
 			@PassThroughParameter @Nullable Function<String, @Nullable String> propertyFunction, //
-			@PassThroughParameter @Nullable Instant startTime) {
+			@PassThroughParameter @Nullable Instant startTime, //
+			@ConvertParameter("convertSequenceNumberStart") @Nullable Long sequenceNumberStart) {
 		PatternConfig dc = PatternConfig.of();
 		ansiDisabled = ansiDisabled == null ? dc.ansiDisabled() : ansiDisabled;
 		lineSeparator = lineSeparator == null ? dc.lineSeparator() : lineSeparator;
 		zoneId = zoneId == null ? dc.zoneId() : zoneId;
 		propertyFunction = propertyFunction == null ? StandardPropertyFunction.INSTANCE : propertyFunction;
 		startTime = startTime == null ? Instant.now() : startTime;
-		return new SimpleFormatterConfig(zoneId, lineSeparator, ansiDisabled, propertyFunction, startTime);
+		long sequenceNumberStart_ = sequenceNumberStart == null ? dc.sequenceNumberStart() : sequenceNumberStart;
+		return new SimpleFormatterConfig(zoneId, lineSeparator, ansiDisabled, propertyFunction, startTime,
+				sequenceNumberStart_);
 
+	}
+
+	static @Nullable Long convertSequenceNumberStart(@Nullable String s) {
+		return s == null ? null : Long.valueOf(s);
 	}
 
 	static ZoneId convertZoneId(@Nullable String zoneId) {

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -29,6 +29,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -230,6 +231,19 @@ enum StandardKeywordFactory implements KeywordFactory {
 		@Override
 		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
 			return new RelativeTimeFormatter(config.startTime());
+		}
+
+	},
+	/**
+	 * <code>%lsn</code>: a counter local to this compiled keyword occurrence, starting at
+	 * {@link PatternConfig#sequenceNumberStart()} and incrementing once per event
+	 * formatted.
+	 */
+	LOCAL_SEQUENCE_NUMBER() {
+
+		@Override
+		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
+			return new LocalSequenceNumberFormatter(new AtomicLong(config.sequenceNumberStart()));
 		}
 
 	},
@@ -447,6 +461,15 @@ enum StandardKeywordFactory implements KeywordFactory {
 		public void format(StringBuilder output, LogEvent event) {
 			long millis = Duration.between(startTime, event.timestamp()).toMillis();
 			output.append(millis);
+		}
+
+	}
+
+	record LocalSequenceNumberFormatter(AtomicLong counter) implements LogFormatter.EventFormatter {
+
+		@Override
+		public void format(StringBuilder output, LogEvent event) {
+			output.append(counter.getAndIncrement());
 		}
 
 	}

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
@@ -209,6 +209,16 @@ public sealed interface PatternRegistry {
 		 */
 		NO_EXCEPTION("nopex", "nopexception"), //
 		/**
+		 * <a href="https://logback.qos.ch/manual/layouts.html#lsn">Local sequence number
+		 * keywords</a>. Unlike logback's <code>%sn</code>/ <code>%sequenceNumber</code>
+		 * (which requires configuring a context-wide
+		 * <code>SequenceNumberGenerator</code>, a feature not implemented here) this is a
+		 * simple counter local to each compiled use of <code>%lsn</code>, starting at
+		 * {@link PatternConfig#sequenceNumberStart()} and incrementing once per event
+		 * formatted.
+		 */
+		LOCAL_SEQUENCE_NUMBER("lsn"), //
+		/**
 		 * <a href="https://logback.qos.ch/manual/layouts.html#newline">Newline
 		 * keywords</a>
 		 */
@@ -420,6 +430,7 @@ final class DefaultPatternRegistry implements PatternRegistry {
 				case DATE -> StandardKeywordFactory.DATE;
 				case LEVEL -> KeywordFactory.of(LogFormatter.LevelFormatter.of());
 				case LINESEP -> (fc, n) -> new LogFormatter.StaticFormatter(fc.lineSeparator());
+				case LOCAL_SEQUENCE_NUMBER -> StandardKeywordFactory.LOCAL_SEQUENCE_NUMBER;
 				case LOGGER -> StandardKeywordFactory.LOGGER;
 				case MDC -> StandardKeywordFactory.MDC;
 				case ENCODED_MDC -> StandardKeywordFactory.ENCODED_MDC;
@@ -542,10 +553,6 @@ final class DefaultPatternRegistry implements PatternRegistry {
 	//
 	//
 
-	//
-	// DEFAULT_CONVERTER_MAP.put("lsn", LocalSequenceNumberConverter.class.getName());
-	// CONVERTER_CLASS_TO_KEY_MAP.put(LocalSequenceNumberConverter.class.getName(),
-	// "lsn");
 	//
 	// DEFAULT_CONVERTER_MAP.put("sn", SequenceNumberConverter.class.getName());
 	// DEFAULT_CONVERTER_MAP.put("sequenceNumber",

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
@@ -79,6 +79,19 @@ class CompilerTest {
 		assertEquals("Pattern is invalid: %missing", message);
 	}
 
+	@Test
+	void testLocalSequenceNumberIncrementsPerEvent() {
+		var c = PatternCompiler.builder().patternConfig(PatternConfig.ofUniversal()).build();
+		var formatter = c.compile("%lsn");
+		var event = LogEvent.of(Level.INFO, "io.jstach.logger", "hello", MutableKeyValues.of().freeze(), null)
+			.freeze(Instant.EPOCH);
+		StringBuilder sb = new StringBuilder();
+		formatter.format(sb, event);
+		formatter.format(sb, event);
+		formatter.format(sb, event);
+		assertEquals("012", sb.toString());
+	}
+
 	public static final boolean OUTPUT = true;
 
 	enum PatternTest {
@@ -120,6 +133,16 @@ class CompilerTest {
 			protected PatternConfig patternConfig() {
 				return PatternConfig.copy(PatternConfig.builder(), PatternConfig.ofUniversal())
 					.startTime(Instant.EPOCH.minusMillis(5000))
+					.build();
+			}
+		},
+		LOCAL_SEQUENCE_NUMBER(List.of("%lsn"), "0") {
+		},
+		LOCAL_SEQUENCE_NUMBER_START(List.of("%lsn"), "5") {
+			@Override
+			protected PatternConfig patternConfig() {
+				return PatternConfig.copy(PatternConfig.builder(), PatternConfig.ofUniversal())
+					.sequenceNumberStart(5L)
 					.build();
 			}
 		},

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternConfiguratorTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternConfiguratorTest.java
@@ -1,9 +1,11 @@
 package io.jstach.rainbowgum.pattern.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.Instant;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -34,6 +36,15 @@ class PatternConfiguratorTest {
 			String actual = test.actual(config);
 			assertEquals(test.expected, actual);
 		}
+	}
+
+	@Test
+	void testConvertSequenceNumberStartOfNullIsNull() {
+		// The property pipeline never actually calls this with null (map() only
+		// invokes the conversion function on a successfully found String), but the
+		// method is defensively typed to accept null like its convertZoneId sibling,
+		// so it is tested directly here for completeness.
+		assertNull(PatternConfigurator.convertSequenceNumberStart(null));
 	}
 
 	enum _Test {
@@ -87,6 +98,28 @@ class PatternConfiguratorTest {
 								(c, n) -> LogFormatter.builder().text("blah").build());
 					}
 				});
+			}
+		},
+		/*
+		 * Exercises PatternConfigurator.convertSequenceNumberStart(String), which is only
+		 * invoked when the sequenceNumberStart property is actually present as a String
+		 * (CompilerTest's LOCAL_SEQUENCE_NUMBER_START case sets it via the builder
+		 * directly, bypassing property string conversion entirely).
+		 */
+		SEQUENCE_NUMBER_START_FROM_PROPERTY("""
+				5
+				6
+				7
+				""") {
+			@Override
+			String properties() {
+				return """
+						logging.appenders=list
+						logging.appender.list.output=list
+						logging.appender.list.encoder=pattern
+						logging.pattern.config.list.sequenceNumberStart=5
+						logging.encoder.list.pattern=%lsn%n
+						""";
 			}
 		},
 		/*


### PR DESCRIPTION
Implements logback's local sequence number converter as %lsn: a simple counter local to each compiled use of the keyword, starting at PatternConfig.sequenceNumberStart() (a property-configurable long, defaulting to 0) and incrementing once per event formatted.

Does not implement %sn/%sequenceNumber, which in logback requires configuring a context-wide SequenceNumberGenerator (a feature not present here) - left as a documented follow-up.

sequenceNumberStart is a plain property (logging.pattern.config.{name}.sequenceNumberStart), not a pass-through parameter, using the same @ConvertParameter(String -> Long) approach as zoneId since there is no Property.ofLong() helper.