### PR TITLE
Add ECS (Elastic Common Schema) JSON encoder

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -684,6 +684,19 @@ Here are some of the supported encoders (not a complete listing):
 
 <ul>
   <li>{@link io.jstach.rainbowgum.json.encoder.GelfEncoderBuilder}</li>
+  <li>{@link io.jstach.rainbowgum.json.encoder.EcsEncoderBuilder} -
+    <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic Common Schema (ECS)</a>
+    JSON, URI scheme {@value io.jstach.rainbowgum.json.encoder.EcsEncoder#ECS_SCHEME}. Field names are the
+    flattened, dotted ECS names (e.g. <code>"log.level"</code>) as the reference
+    <a href="https://github.com/elastic/ecs-logging-java">ecs-logging-java</a> implementation writes them, not
+    nested JSON objects. MDC / key values have no reserved ECS field so, matching the reference implementation,
+    they are written as top-level fields using their own key name:
+    {@snippet lang=properties :
+logging.appenders=myappender
+logging.appender.myappender.encoder=ecs
+logging.encoder.myappender.serviceName=myapp
+    }
+  </li>
   <li>{@link io.jstach.rainbowgum.pattern.format.PatternEncoderBuilder}</li>
 </ul>
 

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoder.java
@@ -1,0 +1,152 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import java.time.format.DateTimeFormatter;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogFormatter.LevelFormatter;
+import io.jstach.rainbowgum.LogFormatter.ThrowableFormatter;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.annotation.LogConfigurable;
+import io.jstach.rainbowgum.json.JsonBuffer;
+import io.jstach.rainbowgum.json.JsonBuffer.ExtendedFieldPrefix;
+import io.jstach.rainbowgum.json.JsonBuffer.JSONToken;
+
+/**
+ * A JSON encoder in
+ * <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic
+ * Common Schema (ECS) logging format</a> as produced by
+ * <a href="https://github.com/elastic/ecs-logging-java">ecs-logging-java</a>. Field names
+ * are the flattened, dotted ECS field names (e.g. <code>"log.level"</code>) rather than
+ * nested JSON objects, matching how the reference implementation serializes them.
+ * <p>
+ * MDC / key values have no reserved ECS field, so - like the reference implementation -
+ * they are written as top-level fields using their own key name. This means a key value
+ * whose name collides with a reserved ECS field name (e.g. <code>message</code>) will
+ * overwrite it; that footgun exists in the reference implementation too.
+ */
+public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
+
+	/**
+	 * ECS encoder URI scheme.
+	 */
+	public static final String ECS_SCHEME = "ecs";
+
+	/**
+	 * The ECS schema version this encoder targets.
+	 */
+	public static final String ECS_VERSION = "1.2.0";
+
+	private final @Nullable String serviceName;
+
+	private final @Nullable String serviceVersion;
+
+	private final @Nullable String serviceEnvironment;
+
+	private final @Nullable String serviceNodeName;
+
+	private final @Nullable String eventDataset;
+
+	private final boolean prettyprint;
+
+	private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_INSTANT;
+
+	EcsEncoder(@Nullable String serviceName, @Nullable String serviceVersion, @Nullable String serviceEnvironment,
+			@Nullable String serviceNodeName, @Nullable String eventDataset, boolean prettyprint) {
+		super();
+		this.serviceName = serviceName;
+		this.serviceVersion = serviceVersion;
+		this.serviceEnvironment = serviceEnvironment;
+		this.serviceNodeName = serviceNodeName;
+		this.eventDataset = eventDataset;
+		this.prettyprint = prettyprint;
+	}
+
+	/**
+	 * Creates an ECS encoder using a lambda for easier registration. The builder will
+	 * have properties loaded after the consumer has configured the builder.
+	 * @param consumer lambda to configure builder.
+	 * @return ECS encoder provider.
+	 */
+	public static LogProvider<EcsEncoder> of(Consumer<EcsEncoderBuilder> consumer) {
+		return (s, c) -> {
+			var b = new EcsEncoderBuilder(s);
+			consumer.accept(b);
+			return b.fromProperties(c.properties()).build();
+		};
+	}
+
+	/**
+	 * Creates ECS Encoder.
+	 * @param name property name prefix.
+	 * @param serviceName <code>service.name</code> field, or null to omit.
+	 * @param serviceVersion <code>service.version</code> field, or null to omit.
+	 * @param serviceEnvironment <code>service.environment</code> field, or null to omit.
+	 * @param serviceNodeName <code>service.node.name</code> field, or null to omit.
+	 * @param eventDataset <code>event.dataset</code> field, or null to omit.
+	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
+	 * @return encoder.
+	 */
+	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
+	static EcsEncoder of(@LogConfigurable.KeyParameter String name, @Nullable String serviceName,
+			@Nullable String serviceVersion, @Nullable String serviceEnvironment, @Nullable String serviceNodeName,
+			@Nullable String eventDataset, @Nullable Boolean prettyPrint) {
+		prettyPrint = prettyPrint == null ? false : prettyPrint;
+		return new EcsEncoder(serviceName, serviceVersion, serviceEnvironment, serviceNodeName, eventDataset,
+				prettyPrint);
+	}
+
+	@Override
+	protected JsonBuffer doBuffer(BufferHints hints) {
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.AT);
+	}
+
+	@Override
+	protected void doEncode(LogEvent event, JsonBuffer buffer) {
+		buffer.clear();
+		var formattedMessage = buffer.getFormattedMessageBuilder();
+		event.formattedMessage(formattedMessage);
+		var now = event.timestamp();
+		var t = event.throwableOrNull();
+
+		buffer.write(JSONToken.OBJECT_START);
+		int index = 0;
+		index = buffer.write("@timestamp", timeFormatter.format(now), index);
+		index = buffer.write("log.level", LevelFormatter.toString(event.level()), index);
+		index = buffer.write("message", formattedMessage.toString(), index);
+		index = buffer.write("ecs.version", ECS_VERSION, index);
+		index = buffer.write("service.name", serviceName, index);
+		index = buffer.write("service.version", serviceVersion, index);
+		index = buffer.write("service.environment", serviceEnvironment, index);
+		index = buffer.write("service.node.name", serviceNodeName, index);
+		index = buffer.write("event.dataset", eventDataset, index);
+		index = buffer.write("log.logger", event.loggerName(), index);
+		index = buffer.write("process.thread.name", event.threadName(), index);
+
+		if (t != null) {
+			index = buffer.write("error.type", t.getClass().getName(), index);
+			index = buffer.write("error.message", t.getMessage(), index);
+			var stackTrace = new StringBuilder();
+			ThrowableFormatter.appendThrowable(stackTrace, t);
+			index = buffer.write("error.stack_trace", stackTrace.toString(), index);
+		}
+
+		var kvs = event.keyValues();
+		for (int i = kvs.start(); i >= 0; i = kvs.next(i)) {
+			String k = kvs.key(i);
+			String v = kvs.valueOrNull(i);
+			index = buffer.write(k, v, index);
+		}
+
+		if (index > 0 && prettyprint) {
+			buffer.writeLineFeed();
+		}
+		buffer.write(JSONToken.OBJECT_END);
+		buffer.writeLineFeed();
+	}
+
+}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoderConfigurator.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoderConfigurator.java
@@ -1,0 +1,46 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEncoder.EncoderProvider;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.LogProviderRef;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
+import io.jstach.svc.ServiceProvider;
+
+/**
+ * Adds
+ * <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic
+ * Common Schema (ECS)</a> JSON Encoder to encoder registry with
+ * {@value EcsEncoder#ECS_SCHEME} URI scheme.
+ */
+@ServiceProvider(RainbowGumServiceProvider.class)
+public class EcsEncoderConfigurator implements Configurator {
+
+	/**
+	 * Default constructor for service loader.
+	 */
+	public EcsEncoderConfigurator() {
+	}
+
+	@Override
+	public boolean configure(LogConfig config, Pass pass) {
+		config.encoderRegistry().register(EcsEncoder.ECS_SCHEME, new EcsEncoderProvider());
+		return true;
+	}
+
+	private static class EcsEncoderProvider implements EncoderProvider {
+
+		@Override
+		public LogProvider<LogEncoder> provide(LogProviderRef ref) {
+			return (name, c) -> {
+				EcsEncoderBuilder b = new EcsEncoderBuilder(name);
+				b.fromProperties(c.properties(), ref);
+				return b.build();
+			};
+		}
+
+	}
+
+}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/package-info.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/package-info.java
@@ -1,9 +1,16 @@
 /**
- * Common JSON encoders like GELF.
+ * Common JSON encoders like GELF and ECS.
  * <p>
- * The Service Loaded configurator adds
- * <a href="https://go2docs.graylog.org/5-2/getting_in_log_data/gelf.html">GELF JSON</a>
- * Encoder to encoder registry with {@value GelfEncoder#GELF_SCHEME} URI scheme.
+ * The Service Loaded configurators add:
+ * <ul>
+ * <li><a href="https://go2docs.graylog.org/5-2/getting_in_log_data/gelf.html">GELF
+ * JSON</a> Encoder to encoder registry with {@value GelfEncoder#GELF_SCHEME} URI
+ * scheme.</li>
+ * <li><a href=
+ * "https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic Common
+ * Schema (ECS)</a> Encoder to encoder registry with {@value EcsEncoder#ECS_SCHEME} URI
+ * scheme.</li>
+ * </ul>
  */
 @org.eclipse.jdt.annotation.NonNullByDefault
 package io.jstach.rainbowgum.json.encoder;

--- a/rainbowgum-json/src/main/java/module-info.java
+++ b/rainbowgum-json/src/main/java/module-info.java
@@ -5,16 +5,18 @@
  * @see io.jstach.rainbowgum.json.encoder
  * @see io.jstach.rainbowgum.json.JsonBuffer
  * @see io.jstach.rainbowgum.json.encoder.GelfEncoder
+ * @see io.jstach.rainbowgum.json.encoder.EcsEncoder
  */
 module io.jstach.rainbowgum.json {
 	exports io.jstach.rainbowgum.json;
 	exports io.jstach.rainbowgum.json.encoder;
 	requires transitive io.jstach.rainbowgum;
-	
+
 	requires static io.jstach.rainbowgum.annotation;
 	requires static io.jstach.svc;
 	requires static org.eclipse.jdt.annotation;
-	
-	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider 
-		with io.jstach.rainbowgum.json.encoder.GelfEncoderConfigurator;
+
+	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider
+		with io.jstach.rainbowgum.json.encoder.GelfEncoderConfigurator,
+			io.jstach.rainbowgum.json.encoder.EcsEncoderConfigurator;
 }

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/EcsEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/EcsEncoderTest.java
@@ -1,0 +1,198 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger.Level;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
+import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.PropertiesParser;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+class EcsEncoderTest {
+
+	@Test
+	void testBuilder() {
+		EcsEncoderBuilder b = new EcsEncoderBuilder("ecs");
+		b.serviceName("myapp");
+		b.prettyPrint(true);
+		Map<String, String> props = new LinkedHashMap<>();
+		b.toProperties(props::put);
+		String expected = """
+				logging.encoder.ecs.serviceName=myapp
+				logging.encoder.ecs.prettyPrint=true
+				""";
+		String actual = PropertiesParser.writeProperties(props);
+		assertEquals(expected, actual);
+
+		b = new EcsEncoderBuilder("ecs");
+		props = PropertiesParser.readProperties(actual);
+		b.fromProperties(props::get);
+
+		EcsEncoder encoder = b.build();
+
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "ecs", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String message = out.events().get(0).getValue();
+		expected = """
+				{
+				 "@timestamp":"1970-01-01T00:00:00.001Z",
+				 "log.level":"INFO",
+				 "message":"hello",
+				 "ecs.version":"1.2.0",
+				 "service.name":"myapp",
+				 "log.logger":"ecs",
+				 "process.thread.name":"main"
+				}
+				""";
+
+		assertEquals(expected, message);
+	}
+
+	@Test
+	void testFullLoadUri() throws Exception {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list:///
+				logging.appender.list.encoder=ecs:///?serviceName=myapp
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new EcsEncoderConfigurator())
+			.build();
+		try (var r = RainbowGum.builder(config).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			r.router()
+				.eventBuilder("ecs", System.Logger.Level.INFO)
+				.message("hello")
+				.threadId(1)
+				.timestamp(instant)
+				.log();
+			ListLogOutput output = (ListLogOutput) config.outputRegistry().output("list").orElseThrow();
+			String actual = output.events().get(0).getValue();
+			String expected = "{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"log.level\":\"INFO\","
+					+ "\"message\":\"hello\",\"ecs.version\":\"1.2.0\",\"service.name\":\"myapp\","
+					+ "\"log.logger\":\"ecs\",\"process.thread.name\":\"main\"}\n";
+			assertEquals(expected, actual);
+		}
+	}
+
+	@Test
+	void testMdcIsFlattenedTopLevel() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(EcsEncoder.of(ecs -> {
+			}));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			var kvs = MutableKeyValues.of().add("requestId", "abc123");
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "ecs", "hello", kvs, null).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"requestId\":\"abc123\""), "Got: " + actual);
+		}
+	}
+
+	@ParameterizedTest
+	@EnumSource(EcsTest.class)
+	void test(EcsTest test) throws Exception {
+		var config = LogConfig.builder().level(Level.TRACE).build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(EcsEncoder.of(ecs -> ecs.prettyPrint(true)));
+			a.output(output);
+		})).build().start()) {
+			for (var e : test.events()) {
+				g.log(e);
+			}
+			String actual = output.toString();
+			test.assertOutput(actual);
+		}
+	}
+
+	enum EcsTest {
+
+		hello("""
+				{
+				 "@timestamp":"1970-01-01T00:00:00.001Z",
+				 "log.level":"INFO",
+				 "message":"hello",
+				 "ecs.version":"1.2.0",
+				 "log.logger":"ecs",
+				 "process.thread.name":"main"
+				}
+				"""), error("""
+				 "error.type":"java.lang.RuntimeException",
+				 "error.message":"boom",
+				""") {
+
+			@Override
+			void assertOutput(String actual) {
+				assertTrue(actual.contains(expected()), "Got: " + actual);
+			}
+
+			@Override
+			@org.eclipse.jdt.annotation.Nullable
+			Throwable throwable() {
+				return new RuntimeException("boom");
+			}
+
+		};
+
+		private static final Instant instant = Instant.ofEpochMilli(1);
+
+		private final String expected;
+
+		private EcsTest(String expected) {
+			this.expected = expected;
+		}
+
+		String expected() {
+			return expected;
+		}
+
+		void assertOutput(String actual) {
+			assertEquals(expected, actual);
+		}
+
+		@org.eclipse.jdt.annotation.Nullable
+		Throwable throwable() {
+			return null;
+		}
+
+		List<LogEvent> events() {
+			LogEvent e = LogEvent
+				.ofAll(instant, "main", 1L, Level.INFO, "ecs", "hello", KeyValues.of(), throwable(),
+						StandardMessageFormatter.SLF4J, List.of())
+				.freeze(instant);
+			return List.of(e);
+		}
+
+	}
+
+}


### PR DESCRIPTION
New EcsEncoder/EcsEncoderBuilder with URI scheme "ecs", matching how the reference ecs-logging-java implementation serializes events: flattened dotted field names (@timestamp, log.level, message, ecs.version, log.logger, process.thread.name, optional service.name/ version/environment/node.name, event.dataset, error.type/message/ stack_trace on throwable) rather than nested JSON objects. MDC/key values have no reserved ECS field so, like the reference implementation, they are written as top-level fields using their own key name.

Registered via EcsEncoderConfigurator/module-info, documented in doc/overview.html's Encoders section alongside GELF.