### PR TITLE
Add Logback-style JSON encoder

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -710,6 +710,16 @@ logging.appender.myappender.encoder=logstash
 logging.encoder.myappender.zoneId=UTC
     }
   </li>
+  <li>{@link io.jstach.rainbowgum.json.encoder.LogbackJsonEncoderBuilder} - resembles
+    <a href="https://logback.qos.ch/manual/encoders.html#JsonEncoder">Logback's own opinionated JSON encoder</a>,
+    URI scheme {@value io.jstach.rainbowgum.json.encoder.LogbackJsonEncoder#LOGBACK_SCHEME}. Nests key values
+    under a <code>mdc</code> object and, for throwables, a <code>throwable</code> object with a
+    <code>stepArray</code> of stack frames (recursing into <code>cause</code>):
+    {@snippet lang=properties :
+logging.appenders=myappender
+logging.appender.myappender.encoder=logback
+    }
+  </li>
   <li>{@link io.jstach.rainbowgum.pattern.format.PatternEncoderBuilder}</li>
 </ul>
 

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/JsonBuffer.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/JsonBuffer.java
@@ -223,7 +223,90 @@ public final class JsonBuffer implements Buffer {
 		return index + 1;
 	}
 
-	private final void _writeStartField(String k, int index, int flag) {
+	/**
+	 * Writes a long field.
+	 * @param k field name
+	 * @param v value
+	 * @param index the current index for comma determination
+	 * @param flag see {@link #EXTENDED_F}
+	 * @return index + 1
+	 */
+	public final int writeLong(String k, long v, int index, int flag) {
+		_writeStartField(k, index, flag);
+		jsonWriter.writeAscii(Long.toString(v));
+		_writeEndField(flag);
+		return index + 1;
+	}
+
+	/**
+	 * Starts a nested JSON object as a field value, e.g. <code>"key":{</code>. Fields
+	 * written after this and before the matching {@link #writeObjectEnd()} should use the
+	 * returned index (a fresh comma-counter local to the nested object) rather than the
+	 * outer index.
+	 * @param k field name
+	 * @param index the current index (of the enclosing object) for comma determination
+	 * @param flag see {@link #EXTENDED_F}
+	 * @return 0, the starting index for fields inside the nested object
+	 */
+	public final int writeObjectStart(String k, int index, int flag) {
+		_writeStartField(k, index, flag);
+		jsonWriter.writeByte(RawJsonWriter.OBJECT_START);
+		return 0;
+	}
+
+	/**
+	 * Ends a nested JSON object previously started with
+	 * {@link #writeObjectStart(String, int, int)}.
+	 */
+	public final void writeObjectEnd() {
+		jsonWriter.writeByte(RawJsonWriter.OBJECT_END);
+	}
+
+	/**
+	 * Starts a nested JSON array as a field value, e.g. <code>"key":[</code>. Elements
+	 * written after this and before the matching {@link #writeArrayEnd()} should use
+	 * {@link #writeArrayElementObjectStart(int)} (with a fresh, local index) rather than
+	 * the outer index.
+	 * @param k field name
+	 * @param index the current index (of the enclosing object) for comma determination
+	 * @param flag see {@link #EXTENDED_F}
+	 * @return 0, the starting index for elements inside the nested array
+	 */
+	public final int writeArrayStart(String k, int index, int flag) {
+		_writeStartField(k, index, flag);
+		jsonWriter.writeByte(RawJsonWriter.ARRAY_START);
+		return 0;
+	}
+
+	/**
+	 * Ends a nested JSON array previously started with
+	 * {@link #writeArrayStart(String, int, int)}.
+	 */
+	public final void writeArrayEnd() {
+		jsonWriter.writeByte(RawJsonWriter.ARRAY_END);
+	}
+
+	/**
+	 * Starts an anonymous JSON object as an array element (no field name), e.g. the
+	 * <code>{</code> in <code>[{...},{...}]</code>.
+	 * @param index the current index (within the array) for comma determination
+	 * @return 0, the starting index for fields inside the element object
+	 */
+	public final int writeArrayElementObjectStart(int index) {
+		_writeStartElement(index);
+		jsonWriter.writeByte(RawJsonWriter.OBJECT_START);
+		return 0;
+	}
+
+	/**
+	 * Ends an array element object previously started with
+	 * {@link #writeArrayElementObjectStart(int)}.
+	 */
+	public final void writeArrayElementObjectEnd() {
+		jsonWriter.writeByte(RawJsonWriter.OBJECT_END);
+	}
+
+	private final void _writeStartElement(int index) {
 		if (index > 0) {
 			jsonWriter.writeByte(COMMA);
 		}
@@ -231,6 +314,10 @@ public final class JsonBuffer implements Buffer {
 			jsonWriter.writeByte(LF);
 			jsonWriter.writeByte(SPACE);
 		}
+	}
+
+	private final void _writeStartField(String k, int index, int flag) {
+		_writeStartElement(index);
 		if ((flag & EXTENDED_F) == EXTENDED_F) {
 			/*
 			 * Field names come from application controlled data (e.g. MDC keys) and must

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoder.java
@@ -1,0 +1,148 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogFormatter.LevelFormatter;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.annotation.LogConfigurable;
+import io.jstach.rainbowgum.json.JsonBuffer;
+import io.jstach.rainbowgum.json.JsonBuffer.ExtendedFieldPrefix;
+import io.jstach.rainbowgum.json.JsonBuffer.JSONToken;
+
+/**
+ * A JSON encoder resembling
+ * <a href="https://logback.qos.ch/manual/encoders.html#JsonEncoder">Logback's own
+ * opinionated <code>ch.qos.logback.classic.encoder.JsonEncoder</code></a>.
+ * <p>
+ * Fields written: <code>timestamp</code> (epoch millis), <code>nanoseconds</code>
+ * (nanosecond-of-second, for sub-millisecond precision), <code>level</code>,
+ * <code>threadName</code>, <code>loggerName</code>, <code>mdc</code> (nested object of
+ * the event's key values), <code>message</code> (already formatted), and
+ * <code>throwable</code> (nested object with <code>className</code>, <code>message</code>
+ * and a <code>stepArray</code> of stack frame objects, recursing into <code>cause</code>
+ * if present).
+ * <p>
+ * Unlike Logback's encoder, which is independently configurable per field via
+ * {@code <withXxx>} elements, <code>sequenceNumber</code> is intentionally not
+ * implemented (Rainbow Gum has no context-wide sequence number generator, see
+ * {@code %lsn}/{@code %sn} in the pattern module discussion), <code>context</code> is
+ * omitted (Rainbow Gum has no equivalent to Logback's {@code LoggerContext}), and
+ * <code>kvpList</code> is omitted because Rainbow Gum does not distinguish MDC-origin key
+ * values from SLF4J fluent {@code addKeyValue} ones - both already end up merged into
+ * {@link LogEvent#keyValues()}, which this encoder writes as <code>mdc</code>.
+ */
+public final class LogbackJsonEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
+
+	/**
+	 * Logback JSON encoder URI scheme.
+	 */
+	public static final String LOGBACK_SCHEME = "logback";
+
+	private final boolean prettyprint;
+
+	LogbackJsonEncoder(boolean prettyprint) {
+		super();
+		this.prettyprint = prettyprint;
+	}
+
+	/**
+	 * Creates a Logback JSON encoder using a lambda for easier registration. The builder
+	 * will have properties loaded after the consumer has configured the builder.
+	 * @param consumer lambda to configure builder.
+	 * @return encoder provider.
+	 */
+	public static LogProvider<LogbackJsonEncoder> of(Consumer<LogbackJsonEncoderBuilder> consumer) {
+		return (s, c) -> {
+			var b = new LogbackJsonEncoderBuilder(s);
+			consumer.accept(b);
+			return b.fromProperties(c.properties()).build();
+		};
+	}
+
+	/**
+	 * Creates a Logback JSON encoder.
+	 * @param name property name prefix.
+	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
+	 * @return encoder.
+	 */
+	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
+	static LogbackJsonEncoder of(@LogConfigurable.KeyParameter String name, @Nullable Boolean prettyPrint) {
+		prettyPrint = prettyPrint == null ? false : prettyPrint;
+		return new LogbackJsonEncoder(prettyPrint);
+	}
+
+	@Override
+	protected JsonBuffer doBuffer(BufferHints hints) {
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.UNDERSCORE);
+	}
+
+	@Override
+	protected void doEncode(LogEvent event, JsonBuffer buffer) {
+		buffer.clear();
+		var formattedMessage = buffer.getFormattedMessageBuilder();
+		event.formattedMessage(formattedMessage);
+		var now = event.timestamp();
+		var t = event.throwableOrNull();
+
+		buffer.write(JSONToken.OBJECT_START);
+		int index = 0;
+		index = buffer.writeLong("timestamp", now.toEpochMilli(), index, 0);
+		index = buffer.writeInt("nanoseconds", now.getNano(), index, 0);
+		index = buffer.write("level", LevelFormatter.toString(event.level()), index);
+		index = buffer.write("threadName", event.threadName(), index);
+		index = buffer.write("loggerName", event.loggerName(), index);
+
+		int mdcIndex = buffer.writeObjectStart("mdc", index, 0);
+		var kvs = event.keyValues();
+		for (int i = kvs.start(); i >= 0; i = kvs.next(i)) {
+			mdcIndex = buffer.write(kvs.key(i), kvs.valueOrNull(i), mdcIndex, 0);
+		}
+		buffer.writeObjectEnd();
+		index++;
+
+		index = buffer.write("message", formattedMessage.toString(), index);
+
+		if (t != null) {
+			index = writeThrowable("throwable", t, buffer, index);
+		}
+
+		if (index > 0 && prettyprint) {
+			buffer.writeLineFeed();
+		}
+		buffer.write(JSONToken.OBJECT_END);
+		buffer.writeLineFeed();
+	}
+
+	private static int writeThrowable(String field, Throwable t, JsonBuffer buffer, int index) {
+		int throwableIndex = buffer.writeObjectStart(field, index, 0);
+		throwableIndex = buffer.write("className", t.getClass().getName(), throwableIndex, 0);
+		throwableIndex = buffer.write("message", t.getMessage(), throwableIndex, 0);
+
+		int arrayIndex = buffer.writeArrayStart("stepArray", throwableIndex, 0);
+		for (var frame : t.getStackTrace()) {
+			int frameIndex = buffer.writeArrayElementObjectStart(arrayIndex);
+			frameIndex = buffer.write("className", frame.getClassName(), frameIndex, 0);
+			frameIndex = buffer.write("methodName", frame.getMethodName(), frameIndex, 0);
+			frameIndex = buffer.write("fileName", frame.getFileName(), frameIndex, 0);
+			frameIndex = buffer.writeInt("lineNumber", frame.getLineNumber(), frameIndex, 0);
+			buffer.writeArrayElementObjectEnd();
+			arrayIndex++;
+		}
+		buffer.writeArrayEnd();
+		throwableIndex++;
+
+		var cause = t.getCause();
+		if (cause != null && cause != t) {
+			writeThrowable("cause", cause, buffer, throwableIndex);
+		}
+
+		buffer.writeObjectEnd();
+		return index + 1;
+	}
+
+}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderConfigurator.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderConfigurator.java
@@ -1,0 +1,45 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEncoder.EncoderProvider;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.LogProviderRef;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
+import io.jstach.svc.ServiceProvider;
+
+/**
+ * Adds a <a href="https://logback.qos.ch/manual/encoders.html#JsonEncoder">Logback style
+ * JSON encoder</a> to encoder registry with {@value LogbackJsonEncoder#LOGBACK_SCHEME}
+ * URI scheme.
+ */
+@ServiceProvider(RainbowGumServiceProvider.class)
+public class LogbackJsonEncoderConfigurator implements Configurator {
+
+	/**
+	 * Default constructor for service loader.
+	 */
+	public LogbackJsonEncoderConfigurator() {
+	}
+
+	@Override
+	public boolean configure(LogConfig config, Pass pass) {
+		config.encoderRegistry().register(LogbackJsonEncoder.LOGBACK_SCHEME, new LogbackJsonEncoderProvider());
+		return true;
+	}
+
+	private static class LogbackJsonEncoderProvider implements EncoderProvider {
+
+		@Override
+		public LogProvider<LogEncoder> provide(LogProviderRef ref) {
+			return (name, c) -> {
+				LogbackJsonEncoderBuilder b = new LogbackJsonEncoderBuilder(name);
+				b.fromProperties(c.properties(), ref);
+				return b.build();
+			};
+		}
+
+	}
+
+}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/package-info.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Common JSON encoders like GELF, ECS, and Logstash's format.
+ * Common JSON encoders like GELF, ECS, Logstash's, and Logback's own JSON format.
  * <p>
  * The Service Loaded configurators add:
  * <ul>
@@ -14,6 +14,9 @@
  * "https://github.com/logfellow/logstash-logback-encoder">logstash-logback-encoder</a>
  * style Encoder to encoder registry with {@value LogstashEncoder#LOGSTASH_SCHEME} URI
  * scheme.</li>
+ * <li><a href="https://logback.qos.ch/manual/encoders.html#JsonEncoder">Logback style
+ * JSON</a> Encoder to encoder registry with {@value LogbackJsonEncoder#LOGBACK_SCHEME}
+ * URI scheme.</li>
  * </ul>
  */
 @org.eclipse.jdt.annotation.NonNullByDefault

--- a/rainbowgum-json/src/main/java/module-info.java
+++ b/rainbowgum-json/src/main/java/module-info.java
@@ -7,6 +7,7 @@
  * @see io.jstach.rainbowgum.json.encoder.GelfEncoder
  * @see io.jstach.rainbowgum.json.encoder.EcsEncoder
  * @see io.jstach.rainbowgum.json.encoder.LogstashEncoder
+ * @see io.jstach.rainbowgum.json.encoder.LogbackJsonEncoder
  */
 module io.jstach.rainbowgum.json {
 	exports io.jstach.rainbowgum.json;
@@ -20,5 +21,6 @@ module io.jstach.rainbowgum.json {
 	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider
 		with io.jstach.rainbowgum.json.encoder.GelfEncoderConfigurator,
 			io.jstach.rainbowgum.json.encoder.EcsEncoderConfigurator,
-			io.jstach.rainbowgum.json.encoder.LogstashEncoderConfigurator;
+			io.jstach.rainbowgum.json.encoder.LogstashEncoderConfigurator,
+			io.jstach.rainbowgum.json.encoder.LogbackJsonEncoderConfigurator;
 }

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderTest.java
@@ -1,0 +1,100 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger.Level;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
+import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+class LogbackJsonEncoderTest {
+
+	@Test
+	void testSimpleMessage() {
+		var encoder = new LogbackJsonEncoderBuilder("logback").build();
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "logback", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String actual = out.events().get(0).getValue();
+		String expected = "{\"timestamp\":1,\"nanoseconds\":1000000,\"level\":\"INFO\",\"threadName\":\"main\","
+				+ "\"loggerName\":\"logback\",\"mdc\":{},\"message\":\"hello\"}\n";
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testMdcNestedObject() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(LogbackJsonEncoder.of(logback -> {
+			}));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			var kvs = MutableKeyValues.of().add("k1", "v1").add("k2", "v2");
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "logback", "hello", kvs, null).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"mdc\":{\"k1\":\"v1\",\"k2\":\"v2\"}"), "Got: " + actual);
+		}
+	}
+
+	@Test
+	void testThrowableStepArrayAndCause() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(LogbackJsonEncoder.of(logback -> {
+			}));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			Throwable cause = new IllegalStateException("root cause");
+			Throwable t = new RuntimeException("boom", cause);
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "logback", "hello", KeyValues.of(), t).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"throwable\":{\"className\":\"java.lang.RuntimeException\","
+					+ "\"message\":\"boom\",\"stepArray\":[{"), "Got: " + actual);
+			assertTrue(actual.contains("\"cause\":{\"className\":\"java.lang.IllegalStateException\","
+					+ "\"message\":\"root cause\",\"stepArray\":[{"), "Got: " + actual);
+		}
+	}
+
+	@Test
+	void testPrettyPrint() {
+		var encoder = new LogbackJsonEncoderBuilder("logback").prettyPrint(true).build();
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "logback", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String actual = out.events().get(0).getValue();
+		assertTrue(actual.startsWith("{\n "), "Got: " + actual);
+		assertTrue(actual.contains("\"mdc\":{}"), "Got: " + actual);
+	}
+
+}


### PR DESCRIPTION
New LogbackJsonEncoder/LogbackJsonEncoderBuilder with URI scheme "logback", resembling ch.qos.logback.classic.encoder.JsonEncoder: timestamp (epoch millis), nanoseconds (nanosecond-of-second, from Instant's own precision), level, threadName, loggerName, a nested mdc object of the event's key values, message, and - when present - a nested throwable object (className/message/stepArray of frame objects), recursing into cause.

sequenceNumber, context, and kvpList are intentionally not implemented/omitted with rationale in the class javadoc (no sequence number generator, no LoggerContext equivalent, and Rainbow Gum doesn't distinguish MDC-origin key values from fluent addKeyValue ones - both already merge into LogEvent.keyValues(), written here as mdc).

Required extending JsonBuffer with nested object/array primitives (writeObjectStart/End, writeArrayStart/End, writeArrayElementObjectStart/End, writeLong) since GELF/ECS only needed flat fields.

Registered via LogbackJsonEncoderConfigurator/module-info, documented in doc/overview.html's Encoders section.