### PR TITLE
Add Logstash JSON encoder

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -697,6 +697,19 @@ logging.appender.myappender.encoder=ecs
 logging.encoder.myappender.serviceName=myapp
     }
   </li>
+  <li>{@link io.jstach.rainbowgum.json.encoder.LogstashEncoderBuilder} - format produced by
+    <a href="https://github.com/logfellow/logstash-logback-encoder">logstash-logback-encoder</a>'s
+    <code>LogstashEncoder</code>, URI scheme
+    {@value io.jstach.rainbowgum.json.encoder.LogstashEncoder#LOGSTASH_SCHEME}. Key values are flattened
+    top-level fields (matching the reference implementation) and <code>@timestamp</code> is rendered with
+    an offset using {@linkplain io.jstach.rainbowgum.json.encoder.LogstashEncoder#zoneId() a configurable zone}
+    (defaults to the system default zone):
+    {@snippet lang=properties :
+logging.appenders=myappender
+logging.appender.myappender.encoder=logstash
+logging.encoder.myappender.zoneId=UTC
+    }
+  </li>
   <li>{@link io.jstach.rainbowgum.pattern.format.PatternEncoderBuilder}</li>
 </ul>
 

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogstashEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogstashEncoder.java
@@ -1,0 +1,161 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogFormatter.LevelFormatter;
+import io.jstach.rainbowgum.LogFormatter.ThrowableFormatter;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.annotation.LogConfigurable;
+import io.jstach.rainbowgum.annotation.LogConfigurable.ConvertParameter;
+import io.jstach.rainbowgum.json.JsonBuffer;
+import io.jstach.rainbowgum.json.JsonBuffer.ExtendedFieldPrefix;
+import io.jstach.rainbowgum.json.JsonBuffer.JSONToken;
+
+/**
+ * A JSON encoder in the format produced by
+ * <a href="https://github.com/logfellow/logstash-logback-encoder">
+ * logstash-logback-encoder</a>'s <code>LogstashEncoder</code>.
+ * <p>
+ * Fields written: <code>@timestamp</code> (<code>ISO_OFFSET_DATE_TIME</code>, using
+ * {@link #zoneId()} - defaulting to the system default zone, matching the reference
+ * implementation), <code>@version</code> (constant <code>"1"</code>),
+ * <code>message</code>, <code>logger_name</code>, <code>thread_name</code>,
+ * <code>level</code>, <code>level_value</code> (Logback's conventional level integers:
+ * TRACE=5000, DEBUG=10000, INFO=20000, WARN=30000, ERROR=40000), and - only if a
+ * throwable was logged - <code>stack_trace</code> (the full stack trace as a single
+ * string).
+ * <p>
+ * <code>tags</code> (from SLF4J markers) is not implemented since Rainbow Gum core has no
+ * built-in {@code org.slf4j.Marker} support. MDC / key values have no reserved field so,
+ * matching the reference implementation, they are written as top-level fields using their
+ * own key name.
+ */
+public final class LogstashEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
+
+	/**
+	 * Logstash encoder URI scheme.
+	 */
+	public static final String LOGSTASH_SCHEME = "logstash";
+
+	private final ZoneId zoneId;
+
+	private final boolean prettyprint;
+
+	private final DateTimeFormatter timeFormatter;
+
+	LogstashEncoder(ZoneId zoneId, boolean prettyprint) {
+		super();
+		this.zoneId = zoneId;
+		this.prettyprint = prettyprint;
+		this.timeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
+	}
+
+	/**
+	 * The zone used to render <code>@timestamp</code>.
+	 * @return zone id.
+	 */
+	public ZoneId zoneId() {
+		return this.zoneId;
+	}
+
+	/**
+	 * Creates a Logstash encoder using a lambda for easier registration. The builder will
+	 * have properties loaded after the consumer has configured the builder.
+	 * @param consumer lambda to configure builder.
+	 * @return encoder provider.
+	 */
+	public static LogProvider<LogstashEncoder> of(Consumer<LogstashEncoderBuilder> consumer) {
+		return (s, c) -> {
+			var b = new LogstashEncoderBuilder(s);
+			consumer.accept(b);
+			return b.fromProperties(c.properties()).build();
+		};
+	}
+
+	/**
+	 * Creates a Logstash encoder.
+	 * @param name property name prefix.
+	 * @param zoneId zone used for <code>@timestamp</code>, defaults to the system default
+	 * zone.
+	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
+	 * @return encoder.
+	 */
+	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
+	static LogstashEncoder of(@LogConfigurable.KeyParameter String name,
+			@ConvertParameter("convertZoneId") @Nullable ZoneId zoneId, @Nullable Boolean prettyPrint) {
+		prettyPrint = prettyPrint == null ? false : prettyPrint;
+		zoneId = zoneId == null ? ZoneId.systemDefault() : zoneId;
+		return new LogstashEncoder(zoneId, prettyPrint);
+	}
+
+	static ZoneId convertZoneId(@Nullable String zoneId) {
+		return zoneId == null ? ZoneId.systemDefault() : ZoneId.of(zoneId);
+	}
+
+	@Override
+	protected JsonBuffer doBuffer(BufferHints hints) {
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.AT);
+	}
+
+	@Override
+	protected void doEncode(LogEvent event, JsonBuffer buffer) {
+		buffer.clear();
+		var formattedMessage = buffer.getFormattedMessageBuilder();
+		event.formattedMessage(formattedMessage);
+		var now = event.timestamp();
+		var t = event.throwableOrNull();
+
+		buffer.write(JSONToken.OBJECT_START);
+		int index = 0;
+		index = buffer.write("@timestamp", timeFormatter.format(now), index);
+		index = buffer.write("@version", "1", index);
+		index = buffer.write("message", formattedMessage.toString(), index);
+		index = buffer.write("logger_name", event.loggerName(), index);
+		index = buffer.write("thread_name", event.threadName(), index);
+		index = buffer.write("level", LevelFormatter.toString(event.level()), index);
+		index = buffer.writeInt("level_value", levelValue(event.level()), index, 0);
+
+		if (t != null) {
+			var stackTrace = new StringBuilder();
+			ThrowableFormatter.appendThrowable(stackTrace, t);
+			index = buffer.write("stack_trace", stackTrace.toString(), index);
+		}
+
+		var kvs = event.keyValues();
+		for (int i = kvs.start(); i >= 0; i = kvs.next(i)) {
+			String k = kvs.key(i);
+			String v = kvs.valueOrNull(i);
+			index = buffer.write(k, v, index);
+		}
+
+		if (index > 0 && prettyprint) {
+			buffer.writeLineFeed();
+		}
+		buffer.write(JSONToken.OBJECT_END);
+		buffer.writeLineFeed();
+	}
+
+	private static int levelValue(java.lang.System.Logger.Level level) {
+		/*
+		 * Logback's conventional level integers, which is what logstash-logback-encoder
+		 * writes as level_value.
+		 */
+		return switch (level) {
+			case TRACE -> 5000;
+			case DEBUG -> 10000;
+			case INFO -> 20000;
+			case WARNING -> 30000;
+			case ERROR -> 40000;
+			case ALL -> Integer.MIN_VALUE;
+			case OFF -> Integer.MAX_VALUE;
+		};
+	}
+
+}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderConfigurator.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderConfigurator.java
@@ -1,0 +1,46 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEncoder.EncoderProvider;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.LogProviderRef;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
+import io.jstach.svc.ServiceProvider;
+
+/**
+ * Adds a <a href=
+ * "https://github.com/logfellow/logstash-logback-encoder">logstash-logback-encoder</a>
+ * style JSON Encoder to encoder registry with {@value LogstashEncoder#LOGSTASH_SCHEME}
+ * URI scheme.
+ */
+@ServiceProvider(RainbowGumServiceProvider.class)
+public class LogstashEncoderConfigurator implements Configurator {
+
+	/**
+	 * Default constructor for service loader.
+	 */
+	public LogstashEncoderConfigurator() {
+	}
+
+	@Override
+	public boolean configure(LogConfig config, Pass pass) {
+		config.encoderRegistry().register(LogstashEncoder.LOGSTASH_SCHEME, new LogstashEncoderProvider());
+		return true;
+	}
+
+	private static class LogstashEncoderProvider implements EncoderProvider {
+
+		@Override
+		public LogProvider<LogEncoder> provide(LogProviderRef ref) {
+			return (name, c) -> {
+				LogstashEncoderBuilder b = new LogstashEncoderBuilder(name);
+				b.fromProperties(c.properties(), ref);
+				return b.build();
+			};
+		}
+
+	}
+
+}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/package-info.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Common JSON encoders like GELF and ECS.
+ * Common JSON encoders like GELF, ECS, and Logstash's format.
  * <p>
  * The Service Loaded configurators add:
  * <ul>
@@ -9,6 +9,10 @@
  * <li><a href=
  * "https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic Common
  * Schema (ECS)</a> Encoder to encoder registry with {@value EcsEncoder#ECS_SCHEME} URI
+ * scheme.</li>
+ * <li><a href=
+ * "https://github.com/logfellow/logstash-logback-encoder">logstash-logback-encoder</a>
+ * style Encoder to encoder registry with {@value LogstashEncoder#LOGSTASH_SCHEME} URI
  * scheme.</li>
  * </ul>
  */

--- a/rainbowgum-json/src/main/java/module-info.java
+++ b/rainbowgum-json/src/main/java/module-info.java
@@ -6,6 +6,7 @@
  * @see io.jstach.rainbowgum.json.JsonBuffer
  * @see io.jstach.rainbowgum.json.encoder.GelfEncoder
  * @see io.jstach.rainbowgum.json.encoder.EcsEncoder
+ * @see io.jstach.rainbowgum.json.encoder.LogstashEncoder
  */
 module io.jstach.rainbowgum.json {
 	exports io.jstach.rainbowgum.json;
@@ -18,5 +19,6 @@ module io.jstach.rainbowgum.json {
 
 	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider
 		with io.jstach.rainbowgum.json.encoder.GelfEncoderConfigurator,
-			io.jstach.rainbowgum.json.encoder.EcsEncoderConfigurator;
+			io.jstach.rainbowgum.json.encoder.EcsEncoderConfigurator,
+			io.jstach.rainbowgum.json.encoder.LogstashEncoderConfigurator;
 }

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
@@ -1,0 +1,96 @@
+package io.jstach.rainbowgum.json.encoder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger.Level;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
+import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+class LogstashEncoderTest {
+
+	@Test
+	void testSimpleMessage() {
+		var encoder = new LogstashEncoderBuilder("logstash").zoneId(java.time.ZoneOffset.UTC).build();
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "logstash", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String actual = out.events().get(0).getValue();
+		String expected = "{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"@version\":\"1\",\"message\":\"hello\","
+				+ "\"logger_name\":\"logstash\",\"thread_name\":\"main\",\"level\":\"INFO\",\"level_value\":20000}\n";
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testZoneIdOffset() {
+		var encoder = new LogstashEncoderBuilder("logstash").zoneId(ZoneOffset.ofHours(-5)).build();
+		assertEquals(ZoneOffset.ofHours(-5), encoder.zoneId());
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "logstash", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String actual = out.events().get(0).getValue();
+		assertTrue(actual.contains("\"@timestamp\":\"1969-12-31T19:00:00.001-05:00\""), "Got: " + actual);
+	}
+
+	@Test
+	void testMdcIsFlattenedTopLevel() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(LogstashEncoder.of(logstash -> logstash.zoneId(java.time.ZoneOffset.UTC)));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			var kvs = MutableKeyValues.of().add("requestId", "abc123");
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "logstash", "hello", kvs, null).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"requestId\":\"abc123\""), "Got: " + actual);
+		}
+	}
+
+	@Test
+	void testStackTrace() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(LogstashEncoder.of(logstash -> logstash.zoneId(java.time.ZoneOffset.UTC)));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			Throwable t = new RuntimeException("boom");
+			LogEvent e = LogEvent.of(System.Logger.Level.ERROR, "logstash", "hello", KeyValues.of(), t).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"level_value\":40000"), "Got: " + actual);
+			assertTrue(actual.contains("\"stack_trace\":\"java.lang.RuntimeException: boom"), "Got: " + actual);
+		}
+	}
+
+}


### PR DESCRIPTION
New LogstashEncoder/LogstashEncoderBuilder with URI scheme "logstash", matching logstash-logback-encoder's LogstashEncoder: @timestamp (ISO_OFFSET_DATE_TIME, configurable zone defaulting to the system default, matching the reference implementation), @version ("1"), message, logger_name, thread_name, level, level_value (Logback's conventional level integers), and stack_trace (full trace as a single string) when a throwable was logged. Key values are flattened top-level fields, matching the reference implementation. tags (SLF4J markers) is not implemented since core has no built-in Marker support.

Registered via LogstashEncoderConfigurator/module-info, documented in doc/overview.html's Encoders section.