### PR TITLE
Add structured (nested) shape to EcsEncoder

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -686,15 +686,19 @@ Here are some of the supported encoders (not a complete listing):
   <li>{@link io.jstach.rainbowgum.json.encoder.GelfEncoderBuilder}</li>
   <li>{@link io.jstach.rainbowgum.json.encoder.EcsEncoderBuilder} -
     <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic Common Schema (ECS)</a>
-    JSON, URI scheme {@value io.jstach.rainbowgum.json.encoder.EcsEncoder#ECS_SCHEME}. Field names are the
-    flattened, dotted ECS names (e.g. <code>"log.level"</code>) as the reference
-    <a href="https://github.com/elastic/ecs-logging-java">ecs-logging-java</a> implementation writes them, not
-    nested JSON objects. MDC / key values have no reserved ECS field so, matching the reference implementation,
-    they are written as top-level fields using their own key name:
+    JSON, URI scheme {@value io.jstach.rainbowgum.json.encoder.EcsEncoder#ECS_SCHEME}. Two shapes are supported:
+    by default field names are the flattened, dotted ECS names (e.g. <code>"log.level"</code>) as the reference
+    <a href="https://github.com/elastic/ecs-logging-java">ecs-logging-java</a> implementation writes them; setting
+    <code>logging.encoder.{name}.structured=true</code> instead nests fields as JSON objects (e.g.
+    <code>"log":{"level":...}</code>) matching
+    <a href="https://docs.spring.io/spring-boot/reference/features/logging.html">Spring Boot's ECS structured
+    logging format</a>. MDC / key values have no reserved ECS field in either shape so, matching both reference
+    implementations, they are written as top-level fields using their own key name:
     {@snippet lang=properties :
 logging.appenders=myappender
 logging.appender.myappender.encoder=ecs
 logging.encoder.myappender.serviceName=myapp
+logging.encoder.myappender.structured=true
     }
   </li>
   <li>{@link io.jstach.rainbowgum.json.encoder.LogstashEncoderBuilder} - format produced by

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoder.java
@@ -19,15 +19,25 @@ import io.jstach.rainbowgum.json.JsonBuffer.JSONToken;
 /**
  * A JSON encoder in
  * <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Elastic
- * Common Schema (ECS) logging format</a> as produced by
- * <a href="https://github.com/elastic/ecs-logging-java">ecs-logging-java</a>. Field names
- * are the flattened, dotted ECS field names (e.g. <code>"log.level"</code>) rather than
- * nested JSON objects, matching how the reference implementation serializes them.
+ * Common Schema (ECS) logging format</a>.
  * <p>
- * MDC / key values have no reserved ECS field, so - like the reference implementation -
- * they are written as top-level fields using their own key name. This means a key value
- * whose name collides with a reserved ECS field name (e.g. <code>message</code>) will
- * overwrite it; that footgun exists in the reference implementation too.
+ * Two shapes are supported, controlled by {@link #structured()}:
+ * <ul>
+ * <li><strong>Flattened (default)</strong>: field names are the flattened, dotted ECS
+ * field names (e.g. <code>"log.level"</code>) rather than nested JSON objects, matching
+ * how the reference <a href="https://github.com/elastic/ecs-logging-java">
+ * ecs-logging-java</a> implementation serializes them.</li>
+ * <li><strong>Structured</strong> ({@link EcsEncoderBuilder#structured(Boolean)
+ * structured=true}): fields are nested JSON objects (e.g.
+ * <code>"log":{"level":...}</code>), matching
+ * <a href="https://docs.spring.io/spring-boot/reference/features/logging.html">Spring
+ * Boot's ECS structured logging format</a>.</li>
+ * </ul>
+ * MDC / key values have no reserved ECS field in either shape, so - like both reference
+ * implementations - they are written as top-level fields using their own key name. This
+ * means a key value whose name collides with a reserved ECS field name (e.g.
+ * <code>message</code>) will overwrite it; that footgun exists in the reference
+ * implementations too.
  */
 public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 
@@ -51,19 +61,31 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 
 	private final @Nullable String eventDataset;
 
+	private final boolean structured;
+
 	private final boolean prettyprint;
 
 	private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_INSTANT;
 
 	EcsEncoder(@Nullable String serviceName, @Nullable String serviceVersion, @Nullable String serviceEnvironment,
-			@Nullable String serviceNodeName, @Nullable String eventDataset, boolean prettyprint) {
+			@Nullable String serviceNodeName, @Nullable String eventDataset, boolean structured, boolean prettyprint) {
 		super();
 		this.serviceName = serviceName;
 		this.serviceVersion = serviceVersion;
 		this.serviceEnvironment = serviceEnvironment;
 		this.serviceNodeName = serviceNodeName;
 		this.eventDataset = eventDataset;
+		this.structured = structured;
 		this.prettyprint = prettyprint;
+	}
+
+	/**
+	 * Whether fields are nested JSON objects (Spring Boot's ECS shape) instead of the
+	 * default flattened, dotted field names (the reference ecs-logging-java shape).
+	 * @return true if fields are nested.
+	 */
+	public boolean structured() {
+		return this.structured;
 	}
 
 	/**
@@ -88,16 +110,19 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 	 * @param serviceEnvironment <code>service.environment</code> field, or null to omit.
 	 * @param serviceNodeName <code>service.node.name</code> field, or null to omit.
 	 * @param eventDataset <code>event.dataset</code> field, or null to omit.
+	 * @param structured <code>true</code> nests fields as JSON objects (Spring Boot's ECS
+	 * shape) instead of flattened dotted field names, default is false.
 	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
 	 * @return encoder.
 	 */
 	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
 	static EcsEncoder of(@LogConfigurable.KeyParameter String name, @Nullable String serviceName,
 			@Nullable String serviceVersion, @Nullable String serviceEnvironment, @Nullable String serviceNodeName,
-			@Nullable String eventDataset, @Nullable Boolean prettyPrint) {
+			@Nullable String eventDataset, @Nullable Boolean structured, @Nullable Boolean prettyPrint) {
 		prettyPrint = prettyPrint == null ? false : prettyPrint;
+		structured = structured == null ? false : structured;
 		return new EcsEncoder(serviceName, serviceVersion, serviceEnvironment, serviceNodeName, eventDataset,
-				prettyPrint);
+				structured, prettyPrint);
 	}
 
 	@Override
@@ -110,6 +135,18 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 		buffer.clear();
 		var formattedMessage = buffer.getFormattedMessageBuilder();
 		event.formattedMessage(formattedMessage);
+
+		int index = structured ? encodeStructured(event, buffer, formattedMessage)
+				: encodeFlattened(event, buffer, formattedMessage);
+
+		if (index > 0 && prettyprint) {
+			buffer.writeLineFeed();
+		}
+		buffer.write(JSONToken.OBJECT_END);
+		buffer.writeLineFeed();
+	}
+
+	private int encodeFlattened(LogEvent event, JsonBuffer buffer, StringBuilder formattedMessage) {
 		var now = event.timestamp();
 		var t = event.throwableOrNull();
 
@@ -135,18 +172,84 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 			index = buffer.write("error.stack_trace", stackTrace.toString(), index);
 		}
 
+		index = writeKeyValues(event, buffer, index);
+		return index;
+	}
+
+	private int encodeStructured(LogEvent event, JsonBuffer buffer, StringBuilder formattedMessage) {
+		var now = event.timestamp();
+		var t = event.throwableOrNull();
+
+		buffer.write(JSONToken.OBJECT_START);
+		int index = 0;
+		index = buffer.write("@timestamp", timeFormatter.format(now), index);
+
+		int logIndex = buffer.writeObjectStart("log", index, 0);
+		logIndex = buffer.write("level", LevelFormatter.toString(event.level()), logIndex, 0);
+		logIndex = buffer.write("logger", event.loggerName(), logIndex, 0);
+		buffer.writeObjectEnd();
+		index++;
+
+		index = buffer.write("message", formattedMessage.toString(), index);
+
+		int ecsIndex = buffer.writeObjectStart("ecs", index, 0);
+		buffer.write("version", ECS_VERSION, ecsIndex, 0);
+		buffer.writeObjectEnd();
+		index++;
+
+		boolean hasService = serviceName != null || serviceVersion != null || serviceEnvironment != null
+				|| serviceNodeName != null;
+		if (hasService) {
+			int serviceIndex = buffer.writeObjectStart("service", index, 0);
+			serviceIndex = buffer.write("name", serviceName, serviceIndex, 0);
+			serviceIndex = buffer.write("version", serviceVersion, serviceIndex, 0);
+			serviceIndex = buffer.write("environment", serviceEnvironment, serviceIndex, 0);
+			if (serviceNodeName != null) {
+				int nodeIndex = buffer.writeObjectStart("node", serviceIndex, 0);
+				buffer.write("name", serviceNodeName, nodeIndex, 0);
+				buffer.writeObjectEnd();
+			}
+			buffer.writeObjectEnd();
+			index++;
+		}
+
+		if (eventDataset != null) {
+			int eventIndex = buffer.writeObjectStart("event", index, 0);
+			buffer.write("dataset", eventDataset, eventIndex, 0);
+			buffer.writeObjectEnd();
+			index++;
+		}
+
+		int processIndex = buffer.writeObjectStart("process", index, 0);
+		int threadIndex = buffer.writeObjectStart("thread", processIndex, 0);
+		buffer.write("name", event.threadName(), threadIndex, 0);
+		buffer.writeObjectEnd();
+		buffer.writeObjectEnd();
+		index++;
+
+		if (t != null) {
+			int errorIndex = buffer.writeObjectStart("error", index, 0);
+			errorIndex = buffer.write("type", t.getClass().getName(), errorIndex, 0);
+			errorIndex = buffer.write("message", t.getMessage(), errorIndex, 0);
+			var stackTrace = new StringBuilder();
+			ThrowableFormatter.appendThrowable(stackTrace, t);
+			buffer.write("stack_trace", stackTrace.toString(), errorIndex, 0);
+			buffer.writeObjectEnd();
+			index++;
+		}
+
+		index = writeKeyValues(event, buffer, index);
+		return index;
+	}
+
+	private static int writeKeyValues(LogEvent event, JsonBuffer buffer, int index) {
 		var kvs = event.keyValues();
 		for (int i = kvs.start(); i >= 0; i = kvs.next(i)) {
 			String k = kvs.key(i);
 			String v = kvs.valueOrNull(i);
 			index = buffer.write(k, v, index);
 		}
-
-		if (index > 0 && prettyprint) {
-			buffer.writeLineFeed();
-		}
-		buffer.write(JSONToken.OBJECT_END);
-		buffer.writeLineFeed();
+		return index;
 	}
 
 }

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/EcsEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/EcsEncoderTest.java
@@ -101,6 +101,72 @@ class EcsEncoderTest {
 	}
 
 	@Test
+	void testStructuredSimple() {
+		EcsEncoder encoder = new EcsEncoderBuilder("ecs").structured(true).build();
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "ecs", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String actual = out.events().get(0).getValue();
+		String expected = "{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"log\":{\"level\":\"INFO\","
+				+ "\"logger\":\"ecs\"},\"message\":\"hello\",\"ecs\":{\"version\":\"1.2.0\"},"
+				+ "\"process\":{\"thread\":{\"name\":\"main\"}}}\n";
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testStructuredServiceAndNode() {
+		EcsEncoder encoder = new EcsEncoderBuilder("ecs").structured(true)
+			.serviceName("myapp")
+			.serviceVersion("1.0")
+			.serviceEnvironment("prod")
+			.serviceNodeName("node-1")
+			.build();
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "ecs", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		encoder.encode(e, buffer);
+		ListLogOutput out = new ListLogOutput();
+		buffer.drain(out, e);
+		String actual = out.events().get(0).getValue();
+		assertTrue(actual.contains(
+				"\"service\":{\"name\":\"myapp\",\"version\":\"1.0\",\"environment\":\"prod\",\"node\":{\"name\":\"node-1\"}}"),
+				"Got: " + actual);
+	}
+
+	@Test
+	void testStructuredErrorAndMdc() throws Exception {
+		var config = LogConfig.builder().build();
+		ListLogOutput output = new ListLogOutput();
+		try (var g = RainbowGum.builder(config).route(rb -> rb.appender("list", a -> {
+			a.encoder(EcsEncoder.of(ecs -> ecs.structured(true)));
+			a.output(output);
+		})).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			var kvs = MutableKeyValues.of().add("requestId", "abc123");
+			Throwable t = new RuntimeException("boom");
+			LogEvent e = LogEvent.of(System.Logger.Level.INFO, "ecs", "hello", kvs, t).freeze(instant);
+			g.log(e);
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.contains("\"error\":{\"type\":\"java.lang.RuntimeException\",\"message\":\"boom\","),
+					"Got: " + actual);
+			assertTrue(actual.contains("\"requestId\":\"abc123\""), "Got: " + actual);
+			// custom key values stay flattened top-level even in structured mode.
+			assertTrue(!actual.contains("\"requestId\":{"), "Got: " + actual);
+		}
+	}
+
+	@Test
 	void testMdcIsFlattenedTopLevel() throws Exception {
 		var config = LogConfig.builder().build();
 		ListLogOutput output = new ListLogOutput();


### PR DESCRIPTION
Adds a "structured" boolean property to EcsEncoder: when true, fields are nested JSON objects (e.g. "log":{"level":...}, "service":{"name":..., "node":{"name":...}}}) instead of the default flattened dotted field names, matching Spring Boot's ECS structured logging format (https://docs.spring.io/spring-boot/reference/features/logging.html) rather than the reference ecs-logging-java shape. Chose a single-encoder flag over a second encoder class since it's a strict subset of the same field set, just reshaped - one URI scheme, one property to flip.

MDC/key values stay flattened top-level in both shapes, matching both reference implementations (Spring Boot's docs explicitly confirm this for its structured format too).

Uses JsonBuffer's nested object primitives (already added for the Logback encoder) rather than introducing new ones.