### PR TITLE
Remove dead SHUTDOWN poison-pill check from GlobalLogRouter

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogLifecycle.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogLifecycle.java
@@ -13,12 +13,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public interface LogLifecycle extends AutoCloseable {
 
 	/**
-	 * Special event message that serves as a poison pill for shutdown. For now this is
-	 * internal.
-	 */
-	static final String SHUTDOWN = "#SHUTDOWN#";
-
-	/**
 	 * Starts a component.
 	 * @param config log config.
 	 */

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -902,11 +902,6 @@ enum GlobalLogRouter implements InternalRootRouter, Route {
 
 	private final ReentrantLock drainLock = new ReentrantLock();
 
-	static boolean isShutdownEvent(String loggerName, java.lang.System.Logger.Level level) {
-		return loggerName.equals(LogLifecycle.SHUTDOWN)
-				&& Boolean.parseBoolean(System.getProperty(LogLifecycle.SHUTDOWN));
-	}
-
 	@Override
 	public LevelResolver levelResolver() {
 		return delegate.levelResolver();
@@ -924,14 +919,9 @@ enum GlobalLogRouter implements InternalRootRouter, Route {
 			q.log(event);
 		}
 		else {
-			String loggerName = event.loggerName();
-			var level = event.level();
 			var route = d.route(event.loggerName(), event.level());
 			if (route.isEnabled()) {
 				route.log(event);
-			}
-			if (isShutdownEvent(loggerName, level)) {
-				d.close();
 			}
 		}
 	}


### PR DESCRIPTION
LogLifecycle.SHUTDOWN ("#SHUTDOWN#") was never used as an actual logger name anywhere in the codebase, so isShutdownEvent's loggerName check never matched and the mechanism never fired - dead code since it was introduced in a March 2024 refactor. It also ran on every event logged through GlobalLogRouter (the router behind RainbowGum's default construction path, the Tomcat integration, and the System.Logger/JUL bridge) once past bootstrap. Had it ever fired, it would have been buggy anyway: it called d.close() directly without resetting delegate back to a fresh QueueEventsRouter, unlike the actual close() path GlobalLogRouter already has (invoked from RainbowGum.close()), which does that correctly.