### PR TITLE
Make the pattern module's %X/%mdc match Logback's MDC output exactly

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
@@ -251,14 +251,61 @@ public sealed interface LogFormatter {
 		}
 
 		/**
+		 * Creates a formatter that will print <strong>ALL</strong> of the key values the
+		 * same way Logback's <code>%X</code>/<code>%mdc</code> does: comma-space
+		 * separated <code>key=value</code> pairs with no surrounding braces (unlike
+		 * Log4j2, which wraps the same pairs in <code>{}</code>), and no percent
+		 * encoding. An empty map renders as an empty string. Keys that are mapped to
+		 * <code>null</code> will only have the key printed and no separating equal sign
+		 * (<code>=</code>), to differentiate empty string and <code>null</code>. For the
+		 * percent-encoded RFC 3986 URI query style instead, see
+		 * {@link #encodedKeyValues()}.
+		 * @return formatter.
+		 */
+		public Builder keyValues() {
+			return add(LogbackKeyValuesFormatter.INSTANCE);
+		}
+
+		/**
+		 * Creates a formatter that will print the key values in order of the passed in
+		 * keys if they exist, Logback <code>%X</code> style (see {@link #keyValues()} for
+		 * the exact format). <strong>An empty list is considered a noop and no keys will
+		 * be ommitted!</strong> If you want all keys use {@link #keyValues()}. For the
+		 * percent-encoded style instead, see {@link #encodedKeyValues(List)}.
+		 * @param keys keys where order is important.
+		 * @return this.
+		 */
+		public Builder keyValues(List<String> keys) {
+			if (keys.isEmpty()) {
+				return this;
+			}
+			return add(new LogbackListKeyValuesFormatter(keys));
+		}
+
+		/**
+		 * Creates a formatter that will print a single key's value, Logback/Log4j2
+		 * <code>%X{key}</code> style: just the raw value (or the fallback, or an empty
+		 * string if neither is present) - no key prefix, no percent encoding. For the
+		 * percent-encoded <code>key=value</code> style instead, see
+		 * {@link #encodedKeyValue(String, String)}.
+		 * @param key key to select.
+		 * @param fallback if the value is null the fallback will be used.
+		 * @return this.
+		 */
+		public Builder keyValue(String key, @Nullable String fallback) {
+			return add(new LogbackSingleKeyValueFormatter(key, fallback));
+		}
+
+		/**
 		 * Creates a formatter that will print <strong>ALL</strong> of the key values by
 		 * percent encoding (RFC 3986 URI aka the format usually used in
 		 * {@link URI#getQuery()}). Keys that are mapped to <code>null</code> will only
 		 * have the key printed and no separating equal sign (<code>=</code>). This is to
-		 * differentiate empty string and <code>null</code>.
+		 * differentiate empty string and <code>null</code>. For Logback's <code>%X</code>
+		 * style instead, see {@link #keyValues()}.
 		 * @return formatter.
 		 */
-		public Builder keyValues() {
+		public Builder encodedKeyValues() {
 			return add(DefaultKeyValuesFormatter.INSTANCE);
 		}
 
@@ -267,11 +314,12 @@ public sealed interface LogFormatter {
 		 * keys if they exist in percent encoding (RFC 3986 URI aka the format usually
 		 * used in {@link URI#getQuery()}). <strong>An empty list is considered a noop and
 		 * no keys will be ommitted!</strong> If you want to all keys use
-		 * {@link #keyValues()}.
+		 * {@link #encodedKeyValues()}. For Logback's <code>%X</code> style instead, see
+		 * {@link #keyValues(List)}.
 		 * @param keys keys where order is important.
 		 * @return this.
 		 */
-		public Builder keyValues(List<String> keys) {
+		public Builder encodedKeyValues(List<String> keys) {
 			if (keys.isEmpty()) {
 				return this;
 			}
@@ -280,12 +328,14 @@ public sealed interface LogFormatter {
 
 		/**
 		 * Creates a formatter that will print a single key value in percent encoding (RFC
-		 * 3986 URI aka the format usually used in {@link URI#getQuery()}).
+		 * 3986 URI aka the format usually used in {@link URI#getQuery()}). For Logback/
+		 * Log4j2's <code>%X{key}</code> style instead, see
+		 * {@link #keyValue(String, String)}.
 		 * @param key key to select.
 		 * @param fallback if the value is null the fallback will be used.
 		 * @return this.
 		 */
-		public Builder keyValue(String key, @Nullable String fallback) {
+		public Builder encodedKeyValue(String key, @Nullable String fallback) {
 			return add(new SingleKeyValueFormatter(key, fallback));
 		}
 
@@ -1335,6 +1385,94 @@ record SingleKeyValueFormatter(String key, @Nullable String fallback) implements
 			v = fallback;
 		}
 		DefaultKeyValuesFormatter.formatKeyValue(output, key, v);
+	}
+
+}
+
+/**
+ * Logback <code>%X</code> style: comma-space separated <code>key=value</code> pairs, no
+ * surrounding braces, no percent encoding. See {@link LogFormatter.Builder#keyValues()}.
+ */
+enum LogbackKeyValuesFormatter implements LogFormatter, KeyValuesConsumer<StringBuilder> {
+
+	INSTANCE;
+
+	@Override
+	public void format(StringBuilder output, LogEvent event) {
+		var keyValues = event.keyValues();
+		keyValues.forEach(this, 0, output);
+	}
+
+	static void formatKeyValue(StringBuilder output, String k, @Nullable String v) {
+		output.append(k);
+		if (v != null) {
+			output.append("=").append(v);
+		}
+	}
+
+	@Override
+	public int accept(KeyValues values, String key, @Nullable String value, int index, StringBuilder storage) {
+		if (index > 0) {
+			storage.append(", ");
+		}
+		formatKeyValue(storage, key, value);
+		return index + 1;
+	}
+
+}
+
+final class LogbackListKeyValuesFormatter implements LogFormatter {
+
+	private final String[] keys;
+
+	@SuppressWarnings("nullness")
+	LogbackListKeyValuesFormatter(List<String> keys) {
+		var ks = List.copyOf(keys);
+		this.keys = ks.toArray(new String[] {});
+	}
+
+	@Override
+	public void format(StringBuilder output, LogEvent event) {
+		var kvs = event.keyValues();
+		formatKeyValues(output, kvs);
+	}
+
+	void formatKeyValues(StringBuilder output, KeyValues keyValues) {
+		boolean first = true;
+		for (String k : keys) {
+			String v = keyValues.getValueOrNull(k);
+			if (v == null) {
+				continue;
+			}
+			if (first) {
+				first = false;
+			}
+			else {
+				output.append(", ");
+			}
+			LogbackKeyValuesFormatter.formatKeyValue(output, k, v);
+		}
+	}
+
+}
+
+/**
+ * Logback/Log4j2 <code>%X{key}</code> style: just the raw value (or fallback, or empty
+ * string), no key prefix, no percent encoding. See
+ * {@link LogFormatter.Builder#keyValue(String, String)}.
+ */
+record LogbackSingleKeyValueFormatter(String key, @Nullable String fallback) implements LogFormatter {
+
+	@Override
+	public void format(StringBuilder output, LogEvent event) {
+		var kvs = event.keyValues();
+		String v = kvs.getValueOrNull(key);
+		if (v == null) {
+			v = fallback;
+		}
+		if (v != null) {
+			output.append(v);
+		}
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogEventBuilderTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEventBuilderTest.java
@@ -112,7 +112,7 @@ class LogEventBuilderTest {
 
 		EVERYTHING(
 				"""
-						threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k1=v1&k2=v2&k3=v3},RuntimeException:expected
+						threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k1=v1, k2=v2, k3=v3},RuntimeException:expected
 						""") {
 			@Override
 			@Nullable
@@ -121,7 +121,7 @@ class LogEventBuilderTest {
 			}
 		},
 		SINGLE_KEY_VALUE("""
-				threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k2=v2},null
+				threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{v2},null
 				""") {
 			@Override
 			LogFormatter keyValuesFormatter() {
@@ -129,7 +129,7 @@ class LogEventBuilderTest {
 			}
 		},
 		SELECT_KEY_VALUES("""
-				threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k2=v2&k3=v3},null
+				threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k2=v2, k3=v3},null
 				""") {
 			@Override
 			LogFormatter keyValuesFormatter() {
@@ -145,7 +145,7 @@ class LogEventBuilderTest {
 			}
 		},
 		CALLER("""
-				threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k1=v1&k2=v2&k3=v3},null,io.jstach.rainbowgum.LogEventBuilderTest:testBuilder
+				threadName,1,1970-01-01T00:00:00.000Z,INFO,test,'hello arg argSupplier',{k1=v1, k2=v2, k3=v3},null,io.jstach.rainbowgum.LogEventBuilderTest:testBuilder
 				""") {
 			@Override
 			@Nullable

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -208,7 +208,10 @@ enum StandardKeywordFactory implements KeywordFactory {
 
 	},
 	/**
-	 * This is logbacks MDC style
+	 * Logback/Log4j2 <code>%X</code>/<code>%mdc</code> style - see
+	 * {@link LogFormatter.Builder#keyValues()} and
+	 * {@link LogFormatter.Builder#keyValue(String, String)} for the exact format. For
+	 * RainbowGum's own percent-encoded style instead, see {@link #ENCODED_MDC}.
 	 */
 	MDC() {
 
@@ -218,19 +221,27 @@ enum StandardKeywordFactory implements KeywordFactory {
 			if (key == null) {
 				return LogFormatter.builder().keyValues().build();
 			}
-			String[] s = key.split(":-");
-			String k;
-			String fallback;
-			if (s.length == 2) {
-				k = s[0];
-				fallback = s[1];
-			}
-			else {
-				k = key;
-				fallback = null;
-			}
-			return LogFormatter.builder().keyValue(k, fallback).build();
+			var kf = keyAndFallback(key);
+			return LogFormatter.builder().keyValue(kf.key(), kf.fallback()).build();
+		}
 
+	},
+	/**
+	 * RainbowGum's percent-encoded (RFC 3986 URI query) MDC style - see
+	 * {@link LogFormatter.Builder#encodedKeyValues()} and
+	 * {@link LogFormatter.Builder#encodedKeyValue(String, String)} for the exact format.
+	 * For Logback/Log4j2's <code>%X</code> style instead, see {@link #MDC}.
+	 */
+	ENCODED_MDC() {
+
+		@Override
+		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
+			String key = node.optOrNull(0);
+			if (key == null) {
+				return LogFormatter.builder().encodedKeyValues().build();
+			}
+			var kf = keyAndFallback(key);
+			return LogFormatter.builder().encodedKeyValue(kf.key(), kf.fallback()).build();
 		}
 
 	},
@@ -301,6 +312,21 @@ enum StandardKeywordFactory implements KeywordFactory {
 	static final String ISO8601_STR = "ISO8601";
 
 	static final String ISO8601_PATTERN = "yyyy-MM-dd HH:mm:ss,SSS";
+
+	record KeyAndFallback(String key, @Nullable String fallback) {
+	}
+
+	/**
+	 * Splits a <code>%X{key}</code>/<code>%mdc{key}</code> option on <code>:-</code>,
+	 * Logback's syntax for a default value (e.g. <code>%X{requestId:-none}</code>).
+	 */
+	static KeyAndFallback keyAndFallback(String option) {
+		String[] s = option.split(":-");
+		if (s.length == 2) {
+			return new KeyAndFallback(s[0], s[1]);
+		}
+		return new KeyAndFallback(option, null);
+	}
 
 	/**
 	 * Whether a {@link DateTimeFormatter} pattern's finest resolution is milliseconds or

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
@@ -180,6 +180,12 @@ public sealed interface PatternRegistry {
 		 */
 		MDC("X", "mdc"), //
 		/**
+		 * RainbowGum's own percent-encoded (RFC 3986 URI query) MDC style, e.g.
+		 * <code>key1=value1&amp;key2=value2</code> - unlike {@link #MDC}, which matches
+		 * Logback/Log4j2's <code>%X</code> output exactly.
+		 */
+		ENCODED_MDC("encodedMdc"), //
+		/**
 		 * <a href="https://logback.qos.ch/manual/layouts.html#mdc">Property keywords</a>
 		 * @see PatternConfig#propertyFunction()
 		 */
@@ -408,6 +414,7 @@ final class DefaultPatternRegistry implements PatternRegistry {
 				case LINESEP -> (fc, n) -> new LogFormatter.StaticFormatter(fc.lineSeparator());
 				case LOGGER -> StandardKeywordFactory.LOGGER;
 				case MDC -> StandardKeywordFactory.MDC;
+				case ENCODED_MDC -> StandardKeywordFactory.ENCODED_MDC;
 				case MICROS -> KeywordFactory.of(LogFormatter.TimestampFormatter.ofMicros());
 				case RELATIVE -> StandardKeywordFactory.RELATIVE;
 				case THREAD -> KeywordFactory.of(LogFormatter.builder().threadName().build());

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
@@ -160,9 +160,13 @@ class CompilerTest {
 		},
 		MESSAGE(List.of("%m", "%msg", "%message"), "hello") {
 		},
-		MDC(List.of("%X", "%mdc"), "k1=v1&k2=v2") {
+		MDC(List.of("%X", "%mdc"), "k1=v1, k2=v2") {
 		},
-		MDC_KEY(List.of("%X{k2}", "%mdc{k2}"), "k2=v2") {
+		MDC_KEY(List.of("%X{k2}", "%mdc{k2}"), "v2") {
+		},
+		ENCODED_MDC(List.of("%encodedMdc"), "k1=v1&k2=v2") {
+		},
+		ENCODED_MDC_KEY(List.of("%encodedMdc{k2}"), "k2=v2") {
 		},
 		THROWABLE(List.of("%ex", "%exception", "%throwable"), "java.lang.RuntimeException: test_throwable") {
 			LogEvent event() {

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilderTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumEventBuilderTest.java
@@ -53,10 +53,10 @@ class RainbowGumEventBuilderTest {
 
 	enum _Test {
 
-		LEVEL_LOGGER("logger {mdcKey1=mdcValue1&key1=value1} - hello [arg0]\n") {
+		LEVEL_LOGGER("logger {mdcKey1=mdcValue1, key1=value1} - hello [arg0]\n") {
 		},
 		REPLACEABLE_LOGGER("""
-				ERROR logger {mdcKey1=mdcValue1&key1=value1} - hello [arg0]
+				ERROR logger {mdcKey1=mdcValue1, key1=value1} - hello [arg0]
 				io.jstach.rainbowgum.slf4j.RainbowGumEventBuilderTest$_Test.log
 				""") {
 
@@ -74,7 +74,7 @@ class RainbowGumEventBuilderTest {
 				return LogFormatter.builder().level().space().add(formatter).build();
 			}
 		},
-		OVERRIDE_MDC("logger {mdcKey1=value2&key1=value1} - hello [arg0]\n") {
+		OVERRIDE_MDC("logger {mdcKey1=value2, key1=value1} - hello [arg0]\n") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				super.build(builder);
@@ -94,7 +94,7 @@ class RainbowGumEventBuilderTest {
 			}
 
 		},
-		TWO_ARG("logger {mdcKey1=mdcValue1&key1=value1} - hello two [arg0] [arg1]\n" + "") {
+		TWO_ARG("logger {mdcKey1=mdcValue1, key1=value1} - hello two [arg0] [arg1]\n" + "") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.setMessage("hello two {} {}");
@@ -103,7 +103,7 @@ class RainbowGumEventBuilderTest {
 				builder.addKeyValue("key1", () -> "value1");
 			}
 		},
-		TWO_ARG_LOG("logger {mdcKey1=mdcValue1&key1=value1} - hello two [arg0] [arg1]\n" + "") {
+		TWO_ARG_LOG("logger {mdcKey1=mdcValue1, key1=value1} - hello two [arg0] [arg1]\n" + "") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.addKeyValue("key1", "value1");
@@ -114,7 +114,7 @@ class RainbowGumEventBuilderTest {
 				builder.log("hello two {} {}", "[arg0]", "[arg1]");
 			}
 		},
-		ONE_ARG_LOG("logger {mdcKey1=mdcValue1&key1=value1} - hello one [arg0]\n" + "") {
+		ONE_ARG_LOG("logger {mdcKey1=mdcValue1, key1=value1} - hello one [arg0]\n" + "") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.addKeyValue("key1", "value1");
@@ -125,7 +125,7 @@ class RainbowGumEventBuilderTest {
 				builder.log("hello one {}", "[arg0]");
 			}
 		},
-		THREE_ARG("logger {mdcKey1=mdcValue1&key1=value1} - hello three [arg0] [arg1] [arg2]\n") {
+		THREE_ARG("logger {mdcKey1=mdcValue1, key1=value1} - hello three [arg0] [arg1] [arg2]\n") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.setMessage("hello three {} {} {}");
@@ -135,7 +135,7 @@ class RainbowGumEventBuilderTest {
 				builder.addKeyValue("key1", "value1");
 			}
 		},
-		THREE_ARG_LOG("logger {mdcKey1=mdcValue1&key1=value1} - hello three [arg0] [arg1] [arg2]\n") {
+		THREE_ARG_LOG("logger {mdcKey1=mdcValue1, key1=value1} - hello three [arg0] [arg1] [arg2]\n") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.addKeyValue("key1", "value1");
@@ -146,7 +146,7 @@ class RainbowGumEventBuilderTest {
 				builder.log("hello three {} {} {}", "[arg0]", "[arg1]", "[arg2]");
 			}
 		},
-		SUPPLIER_MESSAGE_LOG("logger {mdcKey1=mdcValue1&key1=value1} - hello supplier\n") {
+		SUPPLIER_MESSAGE_LOG("logger {mdcKey1=mdcValue1, key1=value1} - hello supplier\n") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.addKeyValue("key1", "value1");
@@ -163,7 +163,7 @@ class RainbowGumEventBuilderTest {
 				builder.setMessage("hello no arg");
 			}
 		},
-		THROWABLE("logger {mdcKey1=mdcValue1&key1=value1} - hello [arg0]\n" + "fail") {
+		THROWABLE("logger {mdcKey1=mdcValue1, key1=value1} - hello [arg0]\n" + "fail") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				super.build(builder);
@@ -171,7 +171,7 @@ class RainbowGumEventBuilderTest {
 			}
 		},
 		CALLER_INFO("""
-				logger {mdcKey1=mdcValue1&key1=value1} - hello [arg0]
+				logger {mdcKey1=mdcValue1, key1=value1} - hello [arg0]
 				io.jstach.rainbowgum.slf4j.RainbowGumEventBuilderTest$_Test$13.callerLog
 								""") {
 			@Override
@@ -189,7 +189,7 @@ class RainbowGumEventBuilderTest {
 				builder.log();
 			}
 		},
-		NULL_KEY_VALUE("logger {mdcKey1=mdcValue1&key1} - hello [arg0]\n") {
+		NULL_KEY_VALUE("logger {mdcKey1=mdcValue1, key1} - hello [arg0]\n") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.setMessage("hello {}");
@@ -197,7 +197,7 @@ class RainbowGumEventBuilderTest {
 				builder.addKeyValue("key1", (Object) null);
 			}
 		},
-		NULL_KEY_VALUE_SUPPLIER("logger {mdcKey1=mdcValue1&key1} - hello [arg0]\n") {
+		NULL_KEY_VALUE_SUPPLIER("logger {mdcKey1=mdcValue1, key1} - hello [arg0]\n") {
 			@Override
 			protected void build(LoggingEventBuilder builder) {
 				builder.setMessage("hello {}");

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumMDCAdapterTest.java
@@ -42,7 +42,7 @@ class RainbowGumMDCAdapterTest {
 
 	enum MdcTest {
 
-		put("k1=v1&k2=v2", a -> a.put("k2", "v2")), //
+		put("k1=v1, k2=v2", a -> a.put("k2", "v2")), //
 		remove("", a -> a.remove("k1")), //
 		clear("", a -> a.clear()), //
 		get("k1=v1", a -> {


### PR DESCRIPTION
LogFormatter.Builder.keyValues()/keyValue() - the only callers of which were the pattern module's MDC keyword - actually percent-encoded output as an RFC 3986 URI query (k1=v1&k2=v2), despite the keyword's own doc comment claiming "This is logback's MDC style". It wasn't: Logback's %X renders "k1=v1, k2=v2" (comma-space, no braces, empty MDC -> ""), and %X{key} renders just the raw value, not "key=value". Neither matched.

Repurpose keyValues()/keyValues(List)/keyValue(key, fallback) to actually produce that output (new LogbackKeyValuesFormatter/LogbackListKeyValuesFormatter/ LogbackSingleKeyValueFormatter), and move the old percent-encoded behavior to new encodedKeyValues()/encodedKeyValues(List)/encodedKeyValue() methods, backing a new %encodedMdc pattern keyword - nothing outside the pattern module used the old keyValues()/keyValue() names, so this is purely additive from any other caller's perspective.

Log4j2's %X differs from Logback's only in wrapping the all-keys case in braces ({k1=v1, k2=v2}); Adam picked Logback's braceless style as the default given the pattern module's MDC keyword already claimed to be that style.