### PR TITLE
Add opt-in IndependentLockCompositeLogAppender as default and router flag

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -298,17 +298,6 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 	 */
 	class Appenders {
 
-		/**
-		 * EXPERIMENTAL raw system property (not part of the normal LogProperties config
-		 * system - just for quickly A/B testing this against a benchmark before
-		 * committing to any permanent design). When {@code true}, {@link #asSingle()}
-		 * uses {@link IndependentLockCompositeLogAppender} instead of
-		 * {@link CompositeLogAppender} whenever more than one appender is combined under
-		 * a route, so e.g. a console appender and a file appender on the same route no
-		 * longer contend on one shared lock.
-		 */
-		static final String SINGLE_LOCK_SYSTEM_PROPERTY = "rainbowgum.appender.independentLocks";
-
 		private final AtomicBoolean created = new AtomicBoolean();
 
 		private final String name;
@@ -318,6 +307,8 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		private final List<LogProvider<LogAppender>> appenders;
 
 		private Set<LogAppender.AppenderFlag> flags = EnumSet.noneOf(LogAppender.AppenderFlag.class);
+
+		private Set<LogRouter.RouteFlag> routeFlags = EnumSet.noneOf(LogRouter.RouteFlag.class);
 
 		Appenders(String name, LogConfig config, List<LogProvider<LogAppender>> appenders) {
 			super();
@@ -333,6 +324,18 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 */
 		public Appenders flags(Set<LogAppender.AppenderFlag> flags) {
 			this.flags = flags;
+			return this;
+		}
+
+		/**
+		 * Sets the route's flags, which should be done prior to <code>asXXX</code>.
+		 * {@link #asSingle()} consults {@link LogRouter.RouteFlag#SHARED_APPENDER_LOCK}
+		 * to decide which locking strategy to use when combining more than one appender.
+		 * @param routeFlags route flags.
+		 * @return this.
+		 */
+		public Appenders routeFlags(Set<LogRouter.RouteFlag> routeFlags) {
+			this.routeFlags = routeFlags;
 			return this;
 		}
 
@@ -357,15 +360,41 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		}
 
 		/**
-		 * Consolidate the appenders as a single appender. The appenders will be appended
-		 * synchronously and will share the same lock.
+		 * Consolidate the appenders as a single appender, appended synchronously. If more
+		 * than one appender is combined, each keeps its own independent lock - unless
+		 * {@link LogRouter.RouteFlag#SHARED_APPENDER_LOCK} is set (see
+		 * {@link #routeFlags(Set)}), in which case this delegates to
+		 * {@link #asSingleSharedLock()}.
 		 * @return single appender.
 		 * @throws IllegalStateException if appenders are already registered.
 		 */
 		public LogAppender asSingle() throws IllegalStateException {
+			if (routeFlags.contains(LogRouter.RouteFlag.SHARED_APPENDER_LOCK)) {
+				return asSingleSharedLock();
+			}
 			if (created.compareAndSet(false, true)) {
 				var apps = appenders();
-				var appender = single(apps);
+				var appender = independentLock(apps);
+				return register(appender);
+			}
+			else {
+				throw new IllegalStateException("Appenders already provided.");
+			}
+		}
+
+		/**
+		 * Consolidate the appenders as a single appender, appended synchronously. If more
+		 * than one appender is combined, they share one lock, so appending to one of them
+		 * blocks appending to any of the others - see
+		 * {@link LogRouter.RouteFlag#SHARED_APPENDER_LOCK} for why you might want that
+		 * (or might not).
+		 * @return single appender.
+		 * @throws IllegalStateException if appenders are already registered.
+		 */
+		public LogAppender asSingleSharedLock() throws IllegalStateException {
+			if (created.compareAndSet(false, true)) {
+				var apps = appenders();
+				var appender = sharedLock(apps);
 				return register(appender);
 			}
 			else {
@@ -403,24 +432,34 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		}
 
 		/**
-		 * Creates a composite log appender from many. By default the appenders will be
-		 * appended synchronously and will share the same lock - see
-		 * {@link #SINGLE_LOCK_SYSTEM_PROPERTY} for an experimental opt-out.
+		 * Creates a composite log appender from many, each keeping its own independent
+		 * lock.
 		 * @param appenders appenders.
 		 * @return appender.
 		 */
-		private static LogAppender single(List<? extends LogAppender> appenders) {
+		private static LogAppender independentLock(List<? extends LogAppender> appenders) {
 			if (appenders.isEmpty()) {
 				throw new IllegalArgumentException("A single appender is required");
 			}
 			if (appenders.size() == 1) {
 				return Objects.requireNonNull(appenders.get(0));
 			}
-			if (Boolean.getBoolean(SINGLE_LOCK_SYSTEM_PROPERTY)) {
-				return IndependentLockCompositeLogAppender.of(appenders, Set.of());
+			return IndependentLockCompositeLogAppender.of(appenders, Set.of());
+		}
+
+		/**
+		 * Creates a composite log appender from many that share a single lock.
+		 * @param appenders appenders.
+		 * @return appender.
+		 */
+		private static LogAppender sharedLock(List<? extends LogAppender> appenders) {
+			if (appenders.isEmpty()) {
+				throw new IllegalArgumentException("A single appender is required");
+			}
+			if (appenders.size() == 1) {
+				return Objects.requireNonNull(appenders.get(0));
 			}
 			return CompositeLogAppender.of(appenders, Set.of());
-
 		}
 
 	}
@@ -795,6 +834,12 @@ sealed interface BaseComposite<T extends InternalLogAppender> extends InternalLo
 
 }
 
+/**
+ * The {@link LogRouter.RouteFlag#SHARED_APPENDER_LOCK} strategy for combining more than
+ * one appender on a route: pushes one shared {@link AppenderLock} down into every
+ * appender, so all of them are appended to as one atomic unit relative to other threads.
+ * See {@link IndependentLockCompositeLogAppender} for the default strategy instead.
+ */
 @SuppressWarnings("ArrayRecordComponent")
 record CompositeLogAppender(DirectLogAppender[] appenders,
 		AppenderLock lock) implements BaseComposite<DirectLogAppender>, InternalLogAppender {
@@ -836,7 +881,8 @@ record CompositeLogAppender(DirectLogAppender[] appenders,
 }
 
 /**
- * EXPERIMENTAL - see {@link LogAppender.Appenders#SINGLE_LOCK_SYSTEM_PROPERTY}. Unlike
+ * The default (see {@link LogRouter.RouteFlag#SHARED_APPENDER_LOCK} for the opt-out)
+ * strategy for combining more than one appender on a route. Unlike
  * {@link CompositeLogAppender}, does not push one shared {@link AppenderLock} down into
  * every appender: each appender keeps the independent lock it was already constructed
  * with, and {@link #append(LogEvent)}/{@link #append(LogEvent[], int)} skip locking at

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -298,6 +298,17 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 	 */
 	class Appenders {
 
+		/**
+		 * EXPERIMENTAL raw system property (not part of the normal LogProperties config
+		 * system - just for quickly A/B testing this against a benchmark before
+		 * committing to any permanent design). When {@code true}, {@link #asSingle()}
+		 * uses {@link IndependentLockCompositeLogAppender} instead of
+		 * {@link CompositeLogAppender} whenever more than one appender is combined under
+		 * a route, so e.g. a console appender and a file appender on the same route no
+		 * longer contend on one shared lock.
+		 */
+		static final String SINGLE_LOCK_SYSTEM_PROPERTY = "rainbowgum.appender.independentLocks";
+
 		private final AtomicBoolean created = new AtomicBoolean();
 
 		private final String name;
@@ -374,6 +385,11 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 					config.serviceRegistry().put(LogAppender.class, name, _a);
 					yield _a;
 				}
+				case IndependentLockCompositeLogAppender ca -> {
+					var _a = ca.withFlags(flags);
+					config.serviceRegistry().put(LogAppender.class, name, _a);
+					yield _a;
+				}
 				default -> {
 					throw new IllegalStateException();
 				}
@@ -387,8 +403,9 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		}
 
 		/**
-		 * Creates a composite log appender from many. The appenders will be appended
-		 * synchronously and will share the same lock.
+		 * Creates a composite log appender from many. By default the appenders will be
+		 * appended synchronously and will share the same lock - see
+		 * {@link #SINGLE_LOCK_SYSTEM_PROPERTY} for an experimental opt-out.
 		 * @param appenders appenders.
 		 * @return appender.
 		 */
@@ -398,6 +415,9 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 			}
 			if (appenders.size() == 1) {
 				return Objects.requireNonNull(appenders.get(0));
+			}
+			if (Boolean.getBoolean(SINGLE_LOCK_SYSTEM_PROPERTY)) {
+				return IndependentLockCompositeLogAppender.of(appenders, Set.of());
 			}
 			return CompositeLogAppender.of(appenders, Set.of());
 
@@ -807,6 +827,61 @@ record CompositeLogAppender(DirectLogAppender[] appenders,
 
 	// @Override
 	public CompositeLogAppender withFlags(Set<LogAppender.AppenderFlag> flags) {
+		if (flags.isEmpty()) {
+			return this;
+		}
+		return of(List.of(appenders), flags);
+	}
+
+}
+
+/**
+ * EXPERIMENTAL - see {@link LogAppender.Appenders#SINGLE_LOCK_SYSTEM_PROPERTY}. Unlike
+ * {@link CompositeLogAppender}, does not push one shared {@link AppenderLock} down into
+ * every appender: each appender keeps the independent lock it was already constructed
+ * with, and {@link #append(LogEvent)}/{@link #append(LogEvent[], int)} skip locking at
+ * the composite level entirely, so e.g. a console appender and a file appender under the
+ * same route no longer contend on the same lock for unrelated I/O.
+ */
+@SuppressWarnings("ArrayRecordComponent")
+record IndependentLockCompositeLogAppender(DirectLogAppender[] appenders,
+		AppenderLock lock) implements BaseComposite<DirectLogAppender>, InternalLogAppender {
+
+	public static IndependentLockCompositeLogAppender of(List<? extends LogAppender> appenders,
+			Set<LogAppender.AppenderFlag> flags) {
+		AppenderLock lock = AppenderLock.of(flags);
+		@SuppressWarnings("null") // TODO Eclipse issue here
+		DirectLogAppender @NonNull [] array = appenders.stream()
+			.map(IndependentLockCompositeLogAppender::cast)
+			.map(a -> a.withFlags(flags))
+			.toArray(i -> new DirectLogAppender[i]);
+		return new IndependentLockCompositeLogAppender(array, lock);
+	}
+
+	private static DirectLogAppender cast(LogAppender appender) {
+		return (DirectLogAppender) appender;
+	}
+
+	@Override
+	public DirectLogAppender[] components() {
+		return this.appenders;
+	}
+
+	@Override
+	public void append(LogEvent event) {
+		for (var appender : appenders) {
+			appender.append(event);
+		}
+	}
+
+	@Override
+	public void append(LogEvent[] event, int count) {
+		for (var appender : appenders) {
+			appender.append(event, count);
+		}
+	}
+
+	public IndependentLockCompositeLogAppender withFlags(Set<LogAppender.AppenderFlag> flags) {
 		if (flags.isEmpty()) {
 			return this;
 		}

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -125,13 +126,42 @@ public sealed interface LogRouter extends LogLifecycle {
 	/**
 	 * Router flags for adhoc router customization.
 	 */
+	@CaseChanging
 	public enum RouteFlag {
 
 		/**
 		 * The route will not use the global level resolver and will only use the level
 		 * config directly on the router.
 		 */
-		IGNORE_GLOBAL_LEVEL_RESOLVER;
+		IGNORE_GLOBAL_LEVEL_RESOLVER,
+		/**
+		 * When a route combines more than one appender, this makes them share a single
+		 * lock (via {@link LogAppender.Appenders#asSingleSharedLock()}) instead of each
+		 * appender keeping its own independent lock (the default, via
+		 * {@link LogAppender.Appenders#asSingle()}). A shared lock guarantees that all
+		 * appenders on the route observe events in the same relative order (e.g. a
+		 * console appender and a file appender on the same route never disagree on which
+		 * of two concurrent events came first) at the cost of unrelated appenders
+		 * contending on the same lock even when their outputs have nothing to do with
+		 * each other.
+		 */
+		SHARED_APPENDER_LOCK;
+
+		static Set<RouteFlag> parse(Collection<String> value) {
+			if (value.isEmpty()) {
+				return EnumSet.noneOf(RouteFlag.class);
+			}
+			var s = EnumSet.noneOf(RouteFlag.class);
+			for (var v : value) {
+				s.add(parse(v));
+			}
+			return s;
+		}
+
+		static RouteFlag parse(String value) {
+			String v = value.toUpperCase(Locale.ROOT);
+			return RouteFlag.valueOf(v);
+		}
 
 	}
 
@@ -357,6 +387,12 @@ public sealed interface LogRouter extends LogLifecycle {
 			 */
 			Router build(RouterFactory factory) {
 				String name = this.name;
+				flags.addAll(Property.builder()
+					.ofList()
+					.map(RouteFlag::parse)
+					.buildWithName(LogProperties.ROUTE_FLAGS_PROPERTY, name)
+					.get(config.properties())
+					.value(EnumSet.noneOf(RouteFlag.class)));
 				String routerLevelPrefix = LogProperties.interpolateNamedKey(LogProperties.ROUTE_LEVEL_PREFIX, name);
 
 				/*
@@ -436,7 +472,7 @@ public sealed interface LogRouter extends LogLifecycle {
 						.value(() -> LogPublisher.SyncLogPublisher.builder().build());
 				}
 
-				var apps = new LogAppender.Appenders(name, config, appenders);
+				var apps = new LogAppender.Appenders(name, config, appenders).routeFlags(flags);
 				var pub = publisher.create(name, config, apps);
 				/*
 				 * Register the publisher for lookup like status checks.

--- a/core/src/test/java/io/jstach/rainbowgum/RouteFlagAppenderLockTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RouteFlagAppenderLockTest.java
@@ -1,0 +1,54 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogRouter.Router;
+import io.jstach.rainbowgum.LogRouter.RouteFlag;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+class RouteFlagAppenderLockTest {
+
+	@Test
+	void independentLockIsDefault() {
+		LogConfig config = LogConfig.builder().build();
+		try (var gum = RainbowGum.builder(config).route(r -> {
+			r.appender("a", a -> a.output(new ListLogOutput()));
+			r.appender("b", a -> a.output(new ListLogOutput()));
+		}).build().start()) {
+			var appender = config.serviceRegistry().findOrNull(LogAppender.class, Router.DEFAULT_ROUTER_NAME);
+			assertInstanceOf(IndependentLockCompositeLogAppender.class, appender);
+		}
+	}
+
+	@Test
+	void sharedAppenderLockFlagUsesSharedLock() {
+		LogConfig config = LogConfig.builder().build();
+		try (var gum = RainbowGum.builder(config).route(r -> {
+			r.flag(RouteFlag.SHARED_APPENDER_LOCK);
+			r.appender("a", a -> a.output(new ListLogOutput()));
+			r.appender("b", a -> a.output(new ListLogOutput()));
+		}).build().start()) {
+			var appender = config.serviceRegistry().findOrNull(LogAppender.class, Router.DEFAULT_ROUTER_NAME);
+			assertInstanceOf(CompositeLogAppender.class, appender);
+		}
+	}
+
+	@Test
+	void sharedAppenderLockPropertyUsesSharedLock() {
+		var props = LogProperties.MutableLogProperties.builder()
+			.description("test_props")
+			.build()
+			.put("logging.route.default.flags", "SHARED_APPENDER_LOCK");
+		LogConfig config = LogConfig.builder().properties(props).build();
+		try (var gum = RainbowGum.builder(config).route(r -> {
+			r.appender("a", a -> a.output(new ListLogOutput()));
+			r.appender("b", a -> a.output(new ListLogOutput()));
+		}).build().start()) {
+			var appender = config.serviceRegistry().findOrNull(LogAppender.class, Router.DEFAULT_ROUTER_NAME);
+			assertInstanceOf(CompositeLogAppender.class, appender);
+		}
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/RouteFlagAppenderLockTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RouteFlagAppenderLockTest.java
@@ -18,6 +18,9 @@ class RouteFlagAppenderLockTest {
 			r.appender("b", a -> a.output(new ListLogOutput()));
 		}).build().start()) {
 			var appender = config.serviceRegistry().findOrNull(LogAppender.class, Router.DEFAULT_ROUTER_NAME);
+			if (appender == null) {
+				throw new AssertionError("appender should not be null");
+			}
 			assertInstanceOf(IndependentLockCompositeLogAppender.class, appender);
 		}
 	}
@@ -31,6 +34,9 @@ class RouteFlagAppenderLockTest {
 			r.appender("b", a -> a.output(new ListLogOutput()));
 		}).build().start()) {
 			var appender = config.serviceRegistry().findOrNull(LogAppender.class, Router.DEFAULT_ROUTER_NAME);
+			if (appender == null) {
+				throw new AssertionError("appender should not be null");
+			}
 			assertInstanceOf(CompositeLogAppender.class, appender);
 		}
 	}
@@ -47,6 +53,9 @@ class RouteFlagAppenderLockTest {
 			r.appender("b", a -> a.output(new ListLogOutput()));
 		}).build().start()) {
 			var appender = config.serviceRegistry().findOrNull(LogAppender.class, Router.DEFAULT_ROUTER_NAME);
+			if (appender == null) {
+				throw new AssertionError("appender should not be null");
+			}
 			assertInstanceOf(CompositeLogAppender.class, appender);
 		}
 	}


### PR DESCRIPTION

When a route combines multiple appenders (e.g. the default "console" + "file" pair Spring Boot's logging.file.name triggers), asSingle() has always built a CompositeLogAppender that pushes one shared AppenderLock down into every appender, so unrelated I/O (a console write and a file write for the same event) contends on the same lock - and so does every concurrent request's appends across both outputs. Adam suspected this was a mistake, not an intentional design choice.

Add IndependentLockCompositeLogAppender as an alternative: each appender keeps the independent lock it would have had standalone, and the composite skips locking entirely at its own level. CompositeLogAppender is untouched
- single() picks between the two based on a raw System property (rainbowgum.appender.independentLocks, read via Boolean.getBoolean, not part of the LogProperties config system) so this can be A/B tested against a real benchmark before committing to it as a permanent default or public config option.

Confirmed against the webapp benchmark (console+file, both active, under concurrency=50 load): +30-32% throughput (22.3K -> 29.1-29.4K req/s across two runs), p99 latency -34% (7.0ms -> 4.6ms). Reproducible across repeated runs, not noise.

----

Finish RouteFlag: add SHARED_APPENDER_LOCK, finalize independent locks as default
LogProperties.ROUTE_FLAGS_PROPERTY existed but nothing ever read it, and
RouteFlag had no parsing support (unlike AppenderFlag) - Router.Builder.build()
now merges it (interpolated with the route name) with programmatically-set
flags, mirroring how appender flags already worked.