### PR TITLE
Improve the Tomcat JUL implementation use level logging

### DIFF
--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/ChangeableRainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/ChangeableRainbowGumTomcatLog.java
@@ -1,0 +1,140 @@
+package io.jstach.rainbowgum.tomcat;
+
+import java.lang.System.Logger.Level;
+
+import org.apache.juli.logging.Log;
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LevelResolver;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogRouter;
+
+/**
+ * Tomcat facade implementation.
+ */
+final class ChangeableRainbowGumTomcatLog implements Log {
+
+	private final String loggerName;
+
+	private final LogRouter router;
+
+	ChangeableRainbowGumTomcatLog(String loggerName, LogRouter router) {
+		super();
+		this.loggerName = loggerName;
+		this.router = router;
+	}
+
+	boolean isLoggable(Level level) {
+		return router.route(loggerName, LevelResolver.normalizeLevel(level)).isEnabled();
+	}
+
+	void log(Level level, Object obj) {
+		log(level, obj, null);
+	}
+
+	void log(Level level, Object obj, @Nullable Throwable t) {
+		level = LevelResolver.normalizeLevel(level);
+		var route = router.route(loggerName, level);
+		if (route.isEnabled()) {
+			String formattedMessage = obj == null ? "" : obj.toString();
+			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
+			route.log(event);
+		}
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return isLoggable(Level.DEBUG);
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return isLoggable(Level.ERROR);
+
+	}
+
+	@Override
+	public boolean isFatalEnabled() {
+		return isLoggable(Level.ERROR);
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return isLoggable(Level.INFO);
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return isLoggable(Level.TRACE);
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return isLoggable(Level.WARNING);
+	}
+
+	@Override
+	public void trace(Object message) {
+		log(Level.TRACE, message);
+	}
+
+	@Override
+	public void trace(Object message, Throwable t) {
+		log(Level.TRACE, message, t);
+
+	}
+
+	@Override
+	public void debug(Object message) {
+		log(Level.DEBUG, message);
+	}
+
+	@Override
+	public void debug(Object message, Throwable t) {
+		log(Level.DEBUG, message, t);
+	}
+
+	@Override
+	public void info(Object message) {
+		log(Level.INFO, message);
+	}
+
+	@Override
+	public void info(Object message, Throwable t) {
+		log(Level.INFO, message, t);
+
+	}
+
+	@Override
+	public void warn(Object message) {
+		log(Level.WARNING, message);
+	}
+
+	@Override
+	public void warn(Object message, Throwable t) {
+		log(Level.WARNING, message, t);
+	}
+
+	@Override
+	public void error(Object message) {
+		log(Level.ERROR, message);
+
+	}
+
+	@Override
+	public void error(Object message, Throwable t) {
+		log(Level.ERROR, message, t);
+	}
+
+	@Override
+	public void fatal(Object message) {
+		log(Level.ERROR, message);
+	}
+
+	@Override
+	public void fatal(Object message, Throwable t) {
+		log(Level.ERROR, message, t);
+
+	}
+
+}

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/ChangeableRainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/ChangeableRainbowGumTomcatLog.java
@@ -36,7 +36,8 @@ final class ChangeableRainbowGumTomcatLog implements Log {
 		level = LevelResolver.normalizeLevel(level);
 		var route = router.route(loggerName, level);
 		if (route.isEnabled()) {
-			String formattedMessage = obj == null ? "" : obj.toString();
+			@Nullable
+			String formattedMessage = obj == null ? null : obj.toString();
 			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
 			route.log(event);
 		}

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/ForwardingTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/ForwardingTomcatLog.java
@@ -1,0 +1,81 @@
+package io.jstach.rainbowgum.tomcat;
+
+import org.apache.juli.logging.Log;
+
+interface ForwardingTomcatLog extends Log {
+
+	public Log delegate();
+
+	default boolean isDebugEnabled() {
+		return delegate().isDebugEnabled();
+	}
+
+	default boolean isErrorEnabled() {
+		return delegate().isErrorEnabled();
+	}
+
+	default boolean isFatalEnabled() {
+		return delegate().isFatalEnabled();
+	}
+
+	default boolean isInfoEnabled() {
+		return delegate().isInfoEnabled();
+	}
+
+	default boolean isTraceEnabled() {
+		return delegate().isTraceEnabled();
+	}
+
+	default boolean isWarnEnabled() {
+		return delegate().isWarnEnabled();
+	}
+
+	default void trace(Object message) {
+		delegate().trace(message);
+	}
+
+	default void trace(Object message, Throwable t) {
+		delegate().trace(message, t);
+	}
+
+	default void debug(Object message) {
+		delegate().debug(message);
+	}
+
+	default void debug(Object message, Throwable t) {
+		delegate().debug(message, t);
+	}
+
+	default void info(Object message) {
+		delegate().info(message);
+	}
+
+	default void info(Object message, Throwable t) {
+		delegate().info(message, t);
+	}
+
+	default void warn(Object message) {
+		delegate().warn(message);
+	}
+
+	default void warn(Object message, Throwable t) {
+		delegate().warn(message, t);
+	}
+
+	default void error(Object message) {
+		delegate().error(message);
+	}
+
+	default void error(Object message, Throwable t) {
+		delegate().error(message, t);
+	}
+
+	default void fatal(Object message) {
+		delegate().fatal(message);
+	}
+
+	default void fatal(Object message, Throwable t) {
+		delegate().fatal(message, t);
+	}
+
+}

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
@@ -1,12 +1,7 @@
 package io.jstach.rainbowgum.tomcat;
 
-import java.lang.System.Logger.Level;
-
 import org.apache.juli.logging.Log;
-import org.eclipse.jdt.annotation.Nullable;
 
-import io.jstach.rainbowgum.LevelResolver;
-import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogRouter;
 import io.jstach.svc.ServiceProvider;
 
@@ -14,11 +9,9 @@ import io.jstach.svc.ServiceProvider;
  * Tomcat facade implementation.
  */
 @ServiceProvider(Log.class)
-public final class RainbowGumTomcatLog implements Log {
+public final class RainbowGumTomcatLog implements ForwardingTomcatLog {
 
-	private final String loggerName;
-
-	private final LogRouter router;
+	private final Log delegate;
 
 	/**
 	 * Tomcat does not actually call this constructor but it is required for ServiceLoader
@@ -37,121 +30,25 @@ public final class RainbowGumTomcatLog implements Log {
 	 * @param loggerName logger name.
 	 */
 	public RainbowGumTomcatLog(String loggerName) {
-		this.router = LogRouter.global();
-		this.loggerName = loggerName;
-	}
-
-	boolean isLoggable(Level level) {
-		return router.route(loggerName, LevelResolver.normalizeLevel(level)).isEnabled();
-	}
-
-	void log(Level level, Object obj) {
-		log(level, obj, null);
-	}
-
-	void log(Level level, Object obj, @Nullable Throwable t) {
-		level = LevelResolver.normalizeLevel(level);
-		var route = router.route(loggerName, level);
-		if (route.isEnabled()) {
-			String formattedMessage = obj == null ? "" : obj.toString();
-			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
-			route.log(event);
-		}
-	}
-
-	@Override
-	public boolean isDebugEnabled() {
-		return isLoggable(Level.DEBUG);
-	}
-
-	@Override
-	public boolean isErrorEnabled() {
-		return isLoggable(Level.ERROR);
+		var router = LogRouter.global();
+		var level = router.levelResolver().resolveLevel(loggerName);
+		boolean changeable = router.isChangeable(loggerName);
+		Log delegate = changeable ? new ChangeableRainbowGumTomcatLog(loggerName, router) : switch (level) {
+			case ALL -> new TomcatLevelLog.TraceLevelLog(loggerName, router);
+			case TRACE -> new TomcatLevelLog.TraceLevelLog(loggerName, router);
+			case DEBUG -> new TomcatLevelLog.DebugLevelLog(loggerName, router);
+			case INFO -> new TomcatLevelLog.InfoLevelLog(loggerName, router);
+			case WARNING -> new TomcatLevelLog.WarnLevelLog(loggerName, router);
+			case ERROR -> new TomcatLevelLog.ErrorLevelLog(loggerName, router);
+			case OFF -> new TomcatLevelLog.OffLevelLog(loggerName, router);
+		};
+		this.delegate = delegate;
 
 	}
 
 	@Override
-	public boolean isFatalEnabled() {
-		return isLoggable(Level.ERROR);
-	}
-
-	@Override
-	public boolean isInfoEnabled() {
-		return isLoggable(Level.INFO);
-	}
-
-	@Override
-	public boolean isTraceEnabled() {
-		return isLoggable(Level.TRACE);
-	}
-
-	@Override
-	public boolean isWarnEnabled() {
-		return isLoggable(Level.WARNING);
-	}
-
-	@Override
-	public void trace(Object message) {
-		log(Level.TRACE, message);
-	}
-
-	@Override
-	public void trace(Object message, Throwable t) {
-		log(Level.TRACE, message, t);
-
-	}
-
-	@Override
-	public void debug(Object message) {
-		log(Level.DEBUG, message);
-	}
-
-	@Override
-	public void debug(Object message, Throwable t) {
-		log(Level.DEBUG, message, t);
-	}
-
-	@Override
-	public void info(Object message) {
-		log(Level.INFO, message);
-	}
-
-	@Override
-	public void info(Object message, Throwable t) {
-		log(Level.INFO, message, t);
-
-	}
-
-	@Override
-	public void warn(Object message) {
-		log(Level.WARNING, message);
-	}
-
-	@Override
-	public void warn(Object message, Throwable t) {
-		log(Level.WARNING, message, t);
-	}
-
-	@Override
-	public void error(Object message) {
-		log(Level.ERROR, message);
-
-	}
-
-	@Override
-	public void error(Object message, Throwable t) {
-		log(Level.ERROR, message, t);
-	}
-
-	@Override
-	public void fatal(Object message) {
-		log(Level.ERROR, message);
-	}
-
-	@Override
-	public void fatal(Object message, Throwable t) {
-		log(Level.ERROR, message, t);
-
+	public Log delegate() {
+		return this.delegate;
 	}
 
 }

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
@@ -42,7 +42,7 @@ public final class RainbowGumTomcatLog implements ForwardingTomcatLog {
 			// We want a logger that can handle all events.
 			// TODO this is a common need and perhaps a method on LogRouter like
 			// "eventLogger"
-			var eventLogger = router.route(loggerName, Level.TRACE);
+			var eventLogger = router.route(loggerName, Level.ERROR);
 			Log delegate = switch (level) {
 				case ALL -> new TomcatLevelLog.TraceLevelLog(loggerName, eventLogger);
 				case TRACE -> new TomcatLevelLog.TraceLevelLog(loggerName, eventLogger);

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
@@ -1,5 +1,7 @@
 package io.jstach.rainbowgum.tomcat;
 
+import java.lang.System.Logger.Level;
+
 import org.apache.juli.logging.Log;
 
 import io.jstach.rainbowgum.LogRouter;
@@ -33,17 +35,25 @@ public final class RainbowGumTomcatLog implements ForwardingTomcatLog {
 		var router = LogRouter.global();
 		var level = router.levelResolver().resolveLevel(loggerName);
 		boolean changeable = router.isChangeable(loggerName);
-		Log delegate = changeable ? new ChangeableRainbowGumTomcatLog(loggerName, router) : switch (level) {
-			case ALL -> new TomcatLevelLog.TraceLevelLog(loggerName, router);
-			case TRACE -> new TomcatLevelLog.TraceLevelLog(loggerName, router);
-			case DEBUG -> new TomcatLevelLog.DebugLevelLog(loggerName, router);
-			case INFO -> new TomcatLevelLog.InfoLevelLog(loggerName, router);
-			case WARNING -> new TomcatLevelLog.WarnLevelLog(loggerName, router);
-			case ERROR -> new TomcatLevelLog.ErrorLevelLog(loggerName, router);
-			case OFF -> new TomcatLevelLog.OffLevelLog(loggerName, router);
-		};
-		this.delegate = delegate;
-
+		if (changeable) {
+			this.delegate = new ChangeableRainbowGumTomcatLog(loggerName, router);
+		}
+		else {
+			// We want a logger that can handle all events.
+			// TODO this is a common need and perhaps a method on LogRouter like
+			// "eventLogger"
+			var eventLogger = router.route(loggerName, Level.TRACE);
+			Log delegate = switch (level) {
+				case ALL -> new TomcatLevelLog.TraceLevelLog(loggerName, eventLogger);
+				case TRACE -> new TomcatLevelLog.TraceLevelLog(loggerName, eventLogger);
+				case DEBUG -> new TomcatLevelLog.DebugLevelLog(loggerName, eventLogger);
+				case INFO -> new TomcatLevelLog.InfoLevelLog(loggerName, eventLogger);
+				case WARNING -> new TomcatLevelLog.WarnLevelLog(loggerName, eventLogger);
+				case ERROR -> new TomcatLevelLog.ErrorLevelLog(loggerName, eventLogger);
+				case OFF -> new TomcatLevelLog.OffLevelLog(loggerName, eventLogger);
+			};
+			this.delegate = delegate;
+		}
 	}
 
 	@Override

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
@@ -32,7 +32,17 @@ public final class RainbowGumTomcatLog implements ForwardingTomcatLog {
 	 * @param loggerName logger name.
 	 */
 	public RainbowGumTomcatLog(String loggerName) {
-		var router = LogRouter.global();
+		this(loggerName, LogRouter.global());
+	}
+
+	/**
+	 * Allows a specific router to be used instead of the {@linkplain LogRouter#global()
+	 * global router} - mainly so tests are not coupled to (and do not have to synchronize
+	 * around) the global router's static, JVM-wide state.
+	 * @param loggerName logger name.
+	 * @param router router to use instead of the global router.
+	 */
+	public RainbowGumTomcatLog(String loggerName, LogRouter.RootRouter router) {
 		var level = router.levelResolver().resolveLevel(loggerName);
 		boolean changeable = router.isChangeable(loggerName);
 		if (changeable) {

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/TomcatLevelLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/TomcatLevelLog.java
@@ -5,32 +5,30 @@ import java.lang.System.Logger.Level;
 import org.apache.juli.logging.Log;
 import org.eclipse.jdt.annotation.Nullable;
 
-import io.jstach.rainbowgum.LevelResolver;
 import io.jstach.rainbowgum.LogEvent;
-import io.jstach.rainbowgum.LogRouter;
+import io.jstach.rainbowgum.LogEventLogger;
 
 interface TomcatLevelLog extends Log {
 
 	String loggerName();
 
-	LogRouter router();
+	LogEventLogger eventLogger();
 
 	default void log(Level level, @Nullable Object obj) {
 		log(level, obj, null);
 	}
 
 	default void log(Level level, @Nullable Object obj, @Nullable Throwable t) {
-		level = LevelResolver.normalizeLevel(level);
+		// We do not need to check if the route is enabled.
+		// We are assuming level logging mode.
 		String loggerName = loggerName();
-		var route = router().route(loggerName, level);
-		if (route.isEnabled()) {
-			String formattedMessage = obj == null ? "" : obj.toString();
-			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
-			route.log(event);
-		}
+		@Nullable
+		String formattedMessage = obj == null ? null : obj.toString();
+		LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
+		eventLogger().log(event);
 	}
 
-	record TraceLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+	record TraceLevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 		@Override
 		public boolean isTraceEnabled() {
 			return true;
@@ -68,7 +66,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.TRACE, message);
+			log(Level.TRACE, message, throwable);
 		}
 
 		@Override
@@ -78,7 +76,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.DEBUG, message);
+			log(Level.DEBUG, message, throwable);
 		}
 
 		@Override
@@ -88,7 +86,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void info(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.INFO, message);
+			log(Level.INFO, message, throwable);
 		}
 
 		@Override
@@ -98,7 +96,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.WARNING, message);
+			log(Level.WARNING, message, throwable);
 		}
 
 		@Override
@@ -108,7 +106,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void error(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.ERROR, message);
+			log(Level.ERROR, message, throwable);
 		}
 
 		@Override
@@ -124,7 +122,7 @@ interface TomcatLevelLog extends Log {
 
 	}
 
-	record DebugLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+	record DebugLevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 		@Override
 		public boolean isTraceEnabled() {
 			return false;
@@ -170,7 +168,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.DEBUG, message);
+			log(Level.DEBUG, message, throwable);
 		}
 
 		@Override
@@ -180,7 +178,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void info(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.INFO, message);
+			log(Level.INFO, message, throwable);
 		}
 
 		@Override
@@ -190,7 +188,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.WARNING, message);
+			log(Level.WARNING, message, throwable);
 		}
 
 		@Override
@@ -200,7 +198,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void error(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.ERROR, message);
+			log(Level.ERROR, message, throwable);
 		}
 
 		@Override
@@ -216,7 +214,7 @@ interface TomcatLevelLog extends Log {
 
 	}
 
-	record InfoLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+	record InfoLevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 		@Override
 		public boolean isTraceEnabled() {
 			return false;
@@ -270,7 +268,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void info(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.INFO, message);
+			log(Level.INFO, message, throwable);
 		}
 
 		@Override
@@ -280,7 +278,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.WARNING, message);
+			log(Level.WARNING, message, throwable);
 		}
 
 		@Override
@@ -290,7 +288,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void error(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.ERROR, message);
+			log(Level.ERROR, message, throwable);
 		}
 
 		@Override
@@ -306,7 +304,7 @@ interface TomcatLevelLog extends Log {
 
 	}
 
-	record WarnLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+	record WarnLevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 		@Override
 		public boolean isTraceEnabled() {
 			return false;
@@ -368,7 +366,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.WARNING, message);
+			log(Level.WARNING, message, throwable);
 		}
 
 		@Override
@@ -378,7 +376,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void error(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.ERROR, message);
+			log(Level.ERROR, message, throwable);
 		}
 
 		@Override
@@ -394,7 +392,7 @@ interface TomcatLevelLog extends Log {
 
 	}
 
-	record ErrorLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+	record ErrorLevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 		@Override
 		public boolean isTraceEnabled() {
 			return false;
@@ -464,7 +462,7 @@ interface TomcatLevelLog extends Log {
 
 		@Override
 		public void error(@Nullable Object message, @Nullable Throwable throwable) {
-			log(Level.ERROR, message);
+			log(Level.ERROR, message, throwable);
 		}
 
 		@Override
@@ -480,7 +478,7 @@ interface TomcatLevelLog extends Log {
 
 	}
 
-	record OffLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+	record OffLevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 		@Override
 		public boolean isTraceEnabled() {
 			return false;

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/TomcatLevelLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/TomcatLevelLog.java
@@ -1,0 +1,567 @@
+package io.jstach.rainbowgum.tomcat;
+
+import java.lang.System.Logger.Level;
+
+import org.apache.juli.logging.Log;
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LevelResolver;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogRouter;
+
+interface TomcatLevelLog extends Log {
+
+	String loggerName();
+
+	LogRouter router();
+
+	default void log(Level level, @Nullable Object obj) {
+		log(level, obj, null);
+	}
+
+	default void log(Level level, @Nullable Object obj, @Nullable Throwable t) {
+		level = LevelResolver.normalizeLevel(level);
+		String loggerName = loggerName();
+		var route = router().route(loggerName, level);
+		if (route.isEnabled()) {
+			String formattedMessage = obj == null ? "" : obj.toString();
+			LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
+			route.log(event);
+		}
+	}
+
+	record TraceLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+			log(Level.TRACE, message);
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.TRACE, message);
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+			log(Level.DEBUG, message);
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.DEBUG, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record DebugLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+			log(Level.DEBUG, message);
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.DEBUG, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record InfoLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record WarnLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record ErrorLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record OffLevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+}

--- a/rainbowgum-tomcat/src/test/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLogTest.java
+++ b/rainbowgum-tomcat/src/test/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLogTest.java
@@ -1,0 +1,134 @@
+package io.jstach.rainbowgum.tomcat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger.Level;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogRouter.RootRouter;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+/**
+ * Covers both dispatch paths {@link RainbowGumTomcatLog} picks between: the fixed-level
+ * fast path ({@link TomcatLevelLog}, used when the router reports the logger's level as
+ * not changeable) and {@link ChangeableRainbowGumTomcatLog} (used when it is). Uses the
+ * {@code RainbowGumTomcatLog(String, LogRouter.RootRouter)} constructor added
+ * specifically so these tests don't have to touch (or lock around) the {@code global()}
+ * static singleton - see {@code JDKSetupTest} in rainbowgum-test-jdk for what that looks
+ * like when it can't be avoided.
+ */
+class RainbowGumTomcatLogTest {
+
+	private static final String LOGGER_NAME = "org.apache.tomcat.TestComponent";
+
+	private record Fixture(RainbowGum gum, ListLogOutput output, RootRouter router) implements AutoCloseable {
+		@Override
+		public void close() {
+			gum.close();
+		}
+	}
+
+	private static Fixture fixture(Level configuredLevel, boolean changeable) {
+		var propsBuilder = LogProperties.MutableLogProperties.builder()
+			.description("test_props")
+			.build()
+			.put("logging.level." + LOGGER_NAME, configuredLevel.toString());
+		if (changeable) {
+			propsBuilder.put("logging.global.change", "true").put("logging.change", "level");
+		}
+		LogConfig config = LogConfig.builder().properties(propsBuilder).build();
+		ListLogOutput output = new ListLogOutput();
+		var gum = RainbowGum.builder(config).route(r -> r.appender("list", a -> a.output(output))).build().start();
+		var router = gum.router();
+		assertEquals(changeable, router.isChangeable(LOGGER_NAME),
+				"test setup should have produced a router.isChangeable() of " + changeable);
+		return new Fixture(gum, output, router);
+	}
+
+	private static Stream<Arguments> levelsAndChangeable() {
+		return Stream.of(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARNING, Level.ERROR, Level.OFF)
+			.flatMap(level -> Stream.of(Arguments.of(level, true), Arguments.of(level, false)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("levelsAndChangeable")
+	void testEnabledChecksAndLogging(Level configuredLevel, boolean changeable) {
+		try (var fx = fixture(configuredLevel, changeable)) {
+			var log = new RainbowGumTomcatLog(LOGGER_NAME, fx.router());
+
+			assertEquals(enabledFor(Level.TRACE, configuredLevel), log.isTraceEnabled(), "isTraceEnabled");
+			assertEquals(enabledFor(Level.DEBUG, configuredLevel), log.isDebugEnabled(), "isDebugEnabled");
+			assertEquals(enabledFor(Level.INFO, configuredLevel), log.isInfoEnabled(), "isInfoEnabled");
+			assertEquals(enabledFor(Level.WARNING, configuredLevel), log.isWarnEnabled(), "isWarnEnabled");
+			assertEquals(enabledFor(Level.ERROR, configuredLevel), log.isErrorEnabled(), "isErrorEnabled");
+			assertEquals(enabledFor(Level.ERROR, configuredLevel), log.isFatalEnabled(), "isFatalEnabled");
+
+			assertLogged(fx, () -> log.trace("hello", new RuntimeException("trace boom")), Level.TRACE,
+					enabledFor(Level.TRACE, configuredLevel), "hello", "trace boom");
+			assertLogged(fx, () -> log.debug("hello", new RuntimeException("debug boom")), Level.DEBUG,
+					enabledFor(Level.DEBUG, configuredLevel), "hello", "debug boom");
+			assertLogged(fx, () -> log.info("hello", new RuntimeException("info boom")), Level.INFO,
+					enabledFor(Level.INFO, configuredLevel), "hello", "info boom");
+			assertLogged(fx, () -> log.warn("hello", new RuntimeException("warn boom")), Level.WARNING,
+					enabledFor(Level.WARNING, configuredLevel), "hello", "warn boom");
+			assertLogged(fx, () -> log.error("hello", new RuntimeException("error boom")), Level.ERROR,
+					enabledFor(Level.ERROR, configuredLevel), "hello", "error boom");
+			assertLogged(fx, () -> log.fatal("hello", new RuntimeException("fatal boom")), Level.ERROR,
+					enabledFor(Level.ERROR, configuredLevel), "hello", "fatal boom");
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("levelsAndChangeable")
+	void testNullMessageIsNotEmptyString(Level configuredLevel, boolean changeable) {
+		try (var fx = fixture(configuredLevel, changeable)) {
+			var log = new RainbowGumTomcatLog(LOGGER_NAME, fx.router());
+			fx.output().clear();
+			log.error(null);
+			if (enabledFor(Level.ERROR, configuredLevel)) {
+				List<Entry<LogEvent, String>> events = fx.output().events();
+				assertEquals(1, events.size());
+				assertNull(events.get(0).getKey().messageOrNull(), "a null message should stay null, not \"\"");
+			}
+			else {
+				assertTrue(fx.output().events().isEmpty());
+			}
+		}
+	}
+
+	private static boolean enabledFor(Level methodLevel, Level configuredLevel) {
+		return methodLevel.compareTo(configuredLevel) >= 0;
+	}
+
+	private static void assertLogged(Fixture fx, Runnable call, Level expectedLevel, boolean expectedEnabled,
+			String expectedMessage, String expectedThrowableMessage) {
+		fx.output().clear();
+		call.run();
+		List<Entry<LogEvent, String>> events = fx.output().events();
+		if (!expectedEnabled) {
+			assertTrue(events.isEmpty(), "expected no event for a disabled level but got: " + events);
+			return;
+		}
+		assertEquals(1, events.size());
+		LogEvent event = events.get(0).getKey();
+		assertEquals(expectedLevel, event.level());
+		assertEquals(LOGGER_NAME, event.loggerName());
+		assertEquals(expectedMessage, event.messageOrNull());
+		var throwable = event.throwableOrNull();
+		assertEquals(expectedThrowableMessage, throwable == null ? null : throwable.getMessage(),
+				"throwable should have been passed through, not dropped");
+	}
+
+}

--- a/rainbowgum-tomcat/src/test/java/io/jstach/rainbowgum/tomcat/TomcatLevelLogGenTest.java
+++ b/rainbowgum-tomcat/src/test/java/io/jstach/rainbowgum/tomcat/TomcatLevelLogGenTest.java
@@ -1,0 +1,159 @@
+package io.jstach.rainbowgum.tomcat;
+
+import java.lang.System.Logger.Level;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+// This was used just to generate TomcatLevelLog
+class TomcatLevelLogGenTest {
+
+	@Test
+	void test() {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("""
+				package io.jstach.rainbowgum.tomcat;
+
+				import java.lang.System.Logger.Level;
+
+				import org.apache.juli.logging.Log;
+				import org.eclipse.jdt.annotation.Nullable;
+
+				import io.jstach.rainbowgum.LevelResolver;
+				import io.jstach.rainbowgum.LogEvent;
+				import io.jstach.rainbowgum.LogRouter;
+
+				interface TomcatLevelLog extends Log {
+
+					String loggerName();
+
+					LogRouter router();
+
+					default void log(Level level, @Nullable Object obj) {
+						log(level, obj, null);
+					}
+
+					default void log(Level level, @Nullable Object obj, @Nullable Throwable t) {
+						level = LevelResolver.normalizeLevel(level);
+						String loggerName = loggerName();
+						var route = router().route(loggerName, level);
+						if (route.isEnabled()) {
+							String formattedMessage = obj == null ? "" : obj.toString();
+							LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
+							route.log(event);
+						}
+					}
+				""");
+
+		for (Level level : Level.values()) {
+			if (level == Level.ALL) {
+				continue;
+			}
+			sb.append("""
+
+					record {{Level}}LevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+					""".replace("{{Level}}", levelCapitalName(level)));
+			for (Level methodLevel : Level.values()) {
+				if (methodLevel == Level.OFF || methodLevel == Level.ALL) {
+					continue;
+				}
+				boolean enabled = methodLevel.compareTo(level) >= 0;
+				sb.append("""
+						@Override
+						public boolean is{{Level}}Enabled() {
+							return {{enabled}};
+						}
+						""".replace("{{Level}}", levelCapitalName(methodLevel)).replace("{{enabled}}", "" + enabled));
+			}
+			sb.append("""
+					@Override
+					public boolean isFatalEnabled() {
+						return isErrorEnabled();
+					}
+					""");
+			for (Level methodLevel : Level.values()) {
+				if (methodLevel == Level.OFF || methodLevel == Level.ALL) {
+					continue;
+				}
+				boolean enabled = methodLevel.compareTo(level) >= 0;
+				if (enabled) {
+					sb.append("""
+							@Override
+							public void {{level}}(@Nullable Object message) {
+								log(Level.{{LEVEL}}, message);
+							}
+
+							@Override
+							public void {{level}}(@Nullable Object message, @Nullable Throwable throwable) {
+								log(Level.{{LEVEL}}, message);
+							}
+
+							""".replace("{{level}}", logMethodName(methodLevel))
+						.replace("{{LEVEL}}", methodLevel.toString()));
+				}
+				else {
+					sb.append("""
+							@Override
+							public void {{level}}(@Nullable Object message) {
+							}
+
+							@Override
+							public void {{level}}(@Nullable Object message, @Nullable Throwable throwable) {
+							}
+
+							""".replace("{{level}}", logMethodName(methodLevel))
+						.replace("{{LEVEL}}", methodLevel.toString()));
+				}
+			}
+			sb.append("""
+					@Override
+					public void fatal(Object message) {
+						error(message);
+					}
+
+					@Override
+					public void fatal(Object message, Throwable t) {
+						error(message, t);
+
+					}
+
+									""");
+			sb.append("\n}");
+		}
+		sb.append("\n}");
+
+		System.out.println(sb.toString());
+
+	}
+
+	static @Nullable String logMethodName(Level level) {
+		return switch (level) {
+			case DEBUG -> "debug";
+			case ALL -> throw new UnsupportedOperationException("Unimplemented case: " + level);
+			case ERROR -> "error";
+			case INFO -> "info";
+			case OFF -> "off";
+			case TRACE -> "trace";
+			case WARNING -> "warn";
+			default -> throw new IllegalArgumentException("Unexpected value: " + level);
+
+		};
+	}
+
+	static @Nullable String levelCapitalName(Level level) {
+		return switch (level) {
+			case DEBUG -> "Debug";
+			case ALL -> throw new UnsupportedOperationException("Unimplemented case: " + level);
+			case ERROR -> "Error";
+			case INFO -> "Info";
+			case OFF -> "Off";
+			case TRACE -> "Trace";
+			case WARNING -> "Warn";
+			default -> throw new IllegalArgumentException("Unexpected value: " + level);
+
+		};
+	}
+
+}

--- a/rainbowgum-tomcat/src/test/java/io/jstach/rainbowgum/tomcat/TomcatLevelLogGenTest.java
+++ b/rainbowgum-tomcat/src/test/java/io/jstach/rainbowgum/tomcat/TomcatLevelLogGenTest.java
@@ -21,29 +21,26 @@ class TomcatLevelLogGenTest {
 				import org.apache.juli.logging.Log;
 				import org.eclipse.jdt.annotation.Nullable;
 
-				import io.jstach.rainbowgum.LevelResolver;
 				import io.jstach.rainbowgum.LogEvent;
-				import io.jstach.rainbowgum.LogRouter;
+				import io.jstach.rainbowgum.LogEventLogger;
 
 				interface TomcatLevelLog extends Log {
 
 					String loggerName();
 
-					LogRouter router();
+					LogEventLogger eventLogger();
 
 					default void log(Level level, @Nullable Object obj) {
 						log(level, obj, null);
 					}
 
 					default void log(Level level, @Nullable Object obj, @Nullable Throwable t) {
-						level = LevelResolver.normalizeLevel(level);
+						// We do not need to check if the route is enabled.
+						// We are assuming level logging mode.
 						String loggerName = loggerName();
-						var route = router().route(loggerName, level);
-						if (route.isEnabled()) {
-							String formattedMessage = obj == null ? "" : obj.toString();
-							LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
-							route.log(event);
-						}
+						@Nullable String formattedMessage = obj == null ? null : obj.toString();
+						LogEvent event = LogEvent.of(level, loggerName, formattedMessage, t);
+						eventLogger().log(event);
 					}
 				""");
 
@@ -53,7 +50,7 @@ class TomcatLevelLogGenTest {
 			}
 			sb.append("""
 
-					record {{Level}}LevelLog(String loggerName, LogRouter router) implements TomcatLevelLog {
+					record {{Level}}LevelLog(String loggerName, LogEventLogger eventLogger) implements TomcatLevelLog {
 					""".replace("{{Level}}", levelCapitalName(level)));
 			for (Level methodLevel : Level.values()) {
 				if (methodLevel == Level.OFF || methodLevel == Level.ALL) {
@@ -87,7 +84,7 @@ class TomcatLevelLogGenTest {
 
 							@Override
 							public void {{level}}(@Nullable Object message, @Nullable Throwable throwable) {
-								log(Level.{{LEVEL}}, message);
+								log(Level.{{LEVEL}}, message, throwable);
 							}
 
 							""".replace("{{level}}", logMethodName(methodLevel))


### PR DESCRIPTION
SLF4J and System Logger use "level" loggers if the config is not changeable. Tomcat did not do this before but now does.