### PR TITLE
Downgrade rainbowgum-jansi from org.jline:jansi-core to org.fusesourc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,9 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.jline</groupId>
-        <artifactId>jansi-core</artifactId>
-        <version>4.3.1</version>
+        <groupId>org.fusesource.jansi</groupId>
+        <artifactId>jansi</artifactId>
+        <version>2.4.2</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/rainbowgum-jansi/pom.xml
+++ b/rainbowgum-jansi/pom.xml
@@ -17,8 +17,8 @@
       <artifactId>rainbowgum-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jansi-core</artifactId>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.jstach.pistachio</groupId>

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
@@ -1,7 +1,7 @@
 package io.jstach.rainbowgum.jansi;
 
-import org.jline.jansi.AnsiConsole;
-import org.jline.jansi.AnsiMode;
+import org.fusesource.jansi.AnsiConsole;
+import org.fusesource.jansi.AnsiMode;
 
 import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogEncoder;

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JansiLogFormatter.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JansiLogFormatter.java
@@ -1,7 +1,7 @@
 package io.jstach.rainbowgum.jansi;
 
-import org.jline.jansi.Ansi.Attribute;
-import org.jline.jansi.Ansi.Color;
+import org.fusesource.jansi.Ansi.Attribute;
+import org.fusesource.jansi.Ansi.Color;
 
 import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogFormatter;

--- a/rainbowgum-jansi/src/main/java/module-info.java
+++ b/rainbowgum-jansi/src/main/java/module-info.java
@@ -18,7 +18,7 @@ module io.jstach.rainbowgum.jansi {
 	exports io.jstach.rainbowgum.jansi;
 
 	requires transitive io.jstach.rainbowgum;
-	requires org.jline.jansi.core;
+	requires org.fusesource.jansi;
 	
 	requires static io.jstach.svc;
 	requires static org.eclipse.jdt.annotation;

--- a/test/rainbowgum-test-jlink/pom.xml
+++ b/test/rainbowgum-test-jlink/pom.xml
@@ -31,6 +31,9 @@
               <stripDebug>true</stripDebug>
               <noHeaderFiles>true</noHeaderFiles>
               <noManPages>true</noManPages>
+              <addOptions>
+                <addOption>--enable-native-access=org.fusesource.jansi</addOption>
+              </addOptions>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
…e.jansi

org.jline:jansi-core (the jline project's fork/continuation of jansi) builds a full jline Terminal via AnsiConsole.systemInstall() when it detects a real controlling terminal - and that Terminal writes directly to the tty device, bypassing the process's own stdout file descriptor entirely. Confirmed via rainbowgum-test-jlink under a real pty (script): `./run.sh > file` produced a completely empty file while all the actual output appeared on the terminal instead - shell output redirection was silently broken whenever a real terminal was present anywhere in the session (e.g. stdin attached to a tty even if stdout was separately redirected), regardless of --enable-native-access.

Switching to the original org.fusesource.jansi:jansi:2.4.2 (the codebase the jline fork itself originated from) fixes this outright: no Terminal abstraction, no shutdown hooks, no ProcessBuilder/stty calls - just a wrapped OutputStream that strips or passes through ANSI codes based on whether the destination looks like a terminal. Re-verified redirect correctness, real-terminal coloring, and piped-output stripping all still work with the swap. Also moved the jlink test app's --enable-native-access flag to the new native loader's module name via maven-jlink-plugin's addOptions (jlink --add-options), rather than editing run.sh by hand.

Only 5 files needed touching: two pom.xml GAV/version swaps and three import-only changes (AnsiConsole, AnsiMode, Ansi.Attribute, Ansi.Color - identical API in both, since the fork started from this exact code).