### PR TITLE
Default appenders to immediate flush,

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -85,10 +85,11 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 */
 		REUSE_BUFFER,
 		/**
-		 * The appender will call flush on each item appended or if in async batch mode
-		 * for each batch.
+		 * By default the appender will call flush on each item appended or if in async
+		 * batch mode for each batch. This flag disables that behavior so that flushing is
+		 * left up to the output (or an external mechanism) instead.
 		 */
-		IMMEDIATE_FLUSH,
+		DISABLE_IMMEDIATE_FLUSH,
 		/**
 		 * The appender will drop events on reentry which happens if an appender during
 		 * its append causes recursive appending in the same thread. This is an analog to
@@ -707,7 +708,7 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 		this.output = output;
 		this.encoder = encoder;
 		this.flags = flags;
-		this.immediateFlush = flags.contains(LogAppender.AppenderFlag.IMMEDIATE_FLUSH);
+		this.immediateFlush = !flags.contains(LogAppender.AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
 	}
 
 	@Override

--- a/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
@@ -34,7 +34,7 @@ import io.jstach.rainbowgum.annotation.CaseChanging;
  *
  * @see LogOutput.OutputProvider
  * @see Buffer
- * @see AppenderFlag#IMMEDIATE_FLUSH
+ * @see AppenderFlag#DISABLE_IMMEDIATE_FLUSH
  * @apiNote if for some reason the output needs to share events with other threads call
  * {@link LogEvent#freeze()} which will return an immutable event.
  */
@@ -298,10 +298,11 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 	}
 
 	/**
-	 * Flushes if the output is maintaining a buffer. An appender will call this after
-	 * each event in synchronous mode or after a batched group of events if in
-	 * asynchronous mode if {@link LogAppender.AppenderFlag#IMMEDIATE_FLUSH} is set.
-	 * @see LogAppender.AppenderFlag#IMMEDIATE_FLUSH
+	 * Flushes if the output is maintaining a buffer. By default an appender will call
+	 * this after each event in synchronous mode or after a batched group of events if in
+	 * asynchronous mode unless {@link LogAppender.AppenderFlag#DISABLE_IMMEDIATE_FLUSH}
+	 * is set.
+	 * @see LogAppender.AppenderFlag#DISABLE_IMMEDIATE_FLUSH
 	 */
 	@Override
 	public void flush();


### PR DESCRIPTION
rename flag to DISABLE_IMMEDIATE_FLUSH

Flushing on every append/batch is now the default appender behavior; the flag is now opt-out instead of opt-in. General flag enable/disable infrastructure is a separate follow-up.