### PR TITLE
Make FileChannelOutput write/flush/close after close a no-op

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/output/FileOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/output/FileOutput.java
@@ -13,6 +13,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -252,6 +253,16 @@ class FileChannelOutput implements FileOutput {
 
 	protected final FileChannel channel;
 
+	/*
+	 * A log call can still be in flight (e.g. routed through SLF4J from a shutdown hook)
+	 * after something outside the normal appender/publisher lifecycle - like Spring
+	 * Boot's LoggingSystem.cleanUp() - has already closed this output directly. Once
+	 * closed, write/flush become no-ops instead of throwing so that race does not surface
+	 * as an uncaught exception on whatever thread is still trying to log. See the
+	 * analogous fix for LogOutput.AbstractOutputStreamOutput (issue #323).
+	 */
+	private final AtomicBoolean closed = new AtomicBoolean();
+
 	public FileChannelOutput(URI uri, FileChannel channel) {
 		super();
 		this.uri = uri;
@@ -270,6 +281,9 @@ class FileChannelOutput implements FileOutput {
 
 	@Override
 	public void write(LogEvent event, ByteBuffer buffer, ContentType contentType) {
+		if (closed.get()) {
+			return;
+		}
 		try {
 
 			// Clear any current interrupt (see LOGBACK-875)
@@ -305,6 +319,9 @@ class FileChannelOutput implements FileOutput {
 
 	@Override
 	public void close() {
+		if (!closed.compareAndSet(false, true)) {
+			return;
+		}
 		try {
 			channel.close();
 		}
@@ -315,6 +332,9 @@ class FileChannelOutput implements FileOutput {
 
 	@Override
 	public void flush() {
+		if (closed.get()) {
+			return;
+		}
 		try {
 			channel.force(false);
 		}

--- a/core/src/test/java/io/jstach/rainbowgum/output/FileOutputTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/output/FileOutputTest.java
@@ -207,6 +207,36 @@ class FileOutputTest {
 		}
 	}
 
+	@Test
+	void writeAndFlushAfterCloseShouldNotThrowFileChannelOutput() throws IOException {
+		String fileName = "./target/FileOutputTest/writeAfterCloseChannel.log";
+		try {
+			var config = LogConfig.builder().build();
+			var output = FileOutput.of(b -> {
+				b.fileName(fileName);
+				b.prudent(true);
+			}).provide("file", config);
+			output.start(config);
+			var event = TestEventBuilder.of().build(b -> b.message("before close"));
+			output.write(event, "before close\n");
+			output.flush();
+			output.close();
+			/*
+			 * Simulates a log call still in flight (e.g. via a shutdown hook) after
+			 * something outside the normal appender/publisher lifecycle - like Spring
+			 * Boot's LoggingSystem.cleanUp() - has already closed the output directly.
+			 * Same race as issue #323, but for prudent mode's FileChannelOutput rather
+			 * than the OutputStream based FileOutputStreamOutput.
+			 */
+			assertDoesNotThrow(() -> output.write(event, "after close\n"));
+			assertDoesNotThrow(output::flush);
+			assertDoesNotThrow(output::close);
+		}
+		finally {
+			Files.deleteIfExists(Path.of(fileName));
+		}
+	}
+
 	private static String duplicate(String s, int count) {
 		return s.repeat(count);
 	}


### PR DESCRIPTION
Same shutdown-ordering race as issue #323, but for prudent mode's FileChannelOutput (implements FileOutput directly, not via LogOutput.AbstractOutputStreamOutput, so the fix there doesn't cover it). A log call still in flight after the output has already been closed directly - e.g. Spring Boot's LoggingSystem.cleanUp() - previously threw an uncaught ClosedChannelException instead of no-oping. Not yet filed as an issue; pushing this branch as a reminder/starting point.