### PR TITLE
Make AbstractOutputStreamOutput write/flush/close after close a no-op

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.jstach.rainbowgum.LogAppender.AppenderFlag;
 import io.jstach.rainbowgum.LogEncoder.Buffer;
@@ -418,6 +419,15 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 		 */
 		protected final OutputStream outputStream;
 
+		/*
+		 * A log call can still be in flight (e.g. routed through SLF4J from a shutdown
+		 * hook) after something outside the normal appender/publisher lifecycle - like
+		 * LoggingSystem.cleanUp() - has already closed this output directly. Once closed,
+		 * write/flush become no-ops instead of throwing so that race does not surface as
+		 * an uncaught exception on whatever thread is still trying to log.
+		 */
+		private final AtomicBoolean closed = new AtomicBoolean();
+
 		/**
 		 * Adapts an OutputStream to an Output.
 		 * @param uri usually comes from output registry.
@@ -436,6 +446,9 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 
 		@Override
 		public void write(LogEvent event, byte[] bytes, int off, int len, ContentType contentType) {
+			if (closed.get()) {
+				return;
+			}
 			try {
 				outputStream.write(bytes, off, len);
 			}
@@ -446,6 +459,9 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 
 		@Override
 		public void flush() {
+			if (closed.get()) {
+				return;
+			}
 			try {
 				outputStream.flush();
 			}
@@ -456,6 +472,9 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 
 		@Override
 		public void close() {
+			if (!closed.compareAndSet(false, true)) {
+				return;
+			}
 			try {
 				outputStream.close();
 			}

--- a/core/src/test/java/io/jstach/rainbowgum/output/FileOutputTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/output/FileOutputTest.java
@@ -1,5 +1,6 @@
 package io.jstach.rainbowgum.output;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -179,6 +180,31 @@ class FileOutputTest {
 			}).provide("fail", config);
 		});
 
+	}
+
+	@Test
+	void writeAndFlushAfterCloseShouldNotThrow() throws IOException {
+		String fileName = "./target/FileOutputTest/writeAfterClose.log";
+		try {
+			var config = LogConfig.builder().build();
+			var output = FileOutput.of(b -> b.fileName(fileName)).provide("file", config);
+			output.start(config);
+			var event = TestEventBuilder.of().build(b -> b.message("before close"));
+			output.write(event, "before close\n");
+			output.flush();
+			output.close();
+			/*
+			 * Simulates a log call still in flight (e.g. via a shutdown hook) after
+			 * something outside the normal appender/publisher lifecycle - like Spring
+			 * Boot's LoggingSystem.cleanUp() - has already closed the output directly.
+			 */
+			assertDoesNotThrow(() -> output.write(event, "after close\n"));
+			assertDoesNotThrow(output::flush);
+			assertDoesNotThrow(output::close);
+		}
+		finally {
+			Files.deleteIfExists(Path.of(fileName));
+		}
 	}
 
 	private static String duplicate(String s, int count) {


### PR DESCRIPTION
Fixes #323. A log call can still be in flight (e.g. routed through SLF4J from a shutdown hook) after something outside the normal appender/publisher lifecycle - like Spring Boot's LoggingSystem.cleanUp() calling gum.close() directly - has already closed the output. Previously this surfaced as an uncaught UncheckedIOException("Stream Closed") on whatever thread was still trying to log, crashing SpringApplicationShutdownHook. write()/flush() now check a closed flag and no-op instead of attempting the doomed I/O call; close() itself is now idempotent too.