### PR TITLE
Fix stale IMMEDIATE_FLUSH javadoc @link in doc/overview.html

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -629,10 +629,10 @@ or through properties.
   <dd>{@value io.jstach.rainbowgum.LogAppender#APPENDER_FLAGS_PROPERTY} = List of {@link io.jstach.rainbowgum.LogAppender.AppenderFlag}</dd>
 </dl>
 
-An important Appender Flag is {@link io.jstach.rainbowgum.LogAppender.AppenderFlag#IMMEDIATE_FLUSH} which
-will tell the output to flush after each event. This flag is disabled by default for performance reasons
-however if one would like to follow <a href="https://12factor.net/logs">12 Factors requirements of events written unbuffered</a> 
-synchronously this flag should be used.
+An important Appender Flag is {@link io.jstach.rainbowgum.LogAppender.AppenderFlag#DISABLE_IMMEDIATE_FLUSH} which
+will tell the output to not flush after each event. Flushing after each event is enabled by default to follow
+<a href="https://12factor.net/logs">12 Factors requirements of events written unbuffered</a> synchronously;
+this flag should be used to opt out of that for performance reasons.
 
 <h3 id="appender_reentry">Appender Reentry Protection</h3>
 


### PR DESCRIPTION
Missed when the flag was renamed to DISABLE_IMMEDIATE_FLUSH and flipped to default-on (opt-out instead of opt-in). Broke bin/doc.sh (javadoc aggregate generation) since the linked symbol no longer exists. Also updated the surrounding prose to match the new default-on semantics.