### PR TITLE
Improve LogAppender flag coverage with real appenders, no mocks

### DIFF
--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -1,0 +1,167 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+/**
+ * Exercises {@link LogAppender.AppenderFlag} end to end with real appenders/outputs (no
+ * mocks) rather than just unit testing the enum in isolation.
+ */
+class LogAppenderFlagTest {
+
+	ByteArrayOutputStream metaLogBytes = new ByteArrayOutputStream();
+
+	PrintStream metaLogStream = new PrintStream(metaLogBytes);
+
+	@BeforeEach
+	void before() {
+		MetaLog.output = () -> metaLogStream;
+	}
+
+	@AfterEach
+	void after() {
+		MetaLog.output = () -> System.err;
+	}
+
+	private static LogAppender appender(String name, ListLogOutput output, AppenderFlag... flags) {
+		var builder = LogAppender.builder(name).encoder(LogFormatter.builder().message().encoder()).output(output);
+		for (var flag : flags) {
+			builder.flag(flag);
+		}
+		return builder.build().provide(name, LogConfig.builder().build());
+	}
+
+	@Test
+	void appenderFlagParseEmptyListIsNoFlags() {
+		assertEquals(Set.of(), AppenderFlag.parse(List.of()));
+	}
+
+	@Test
+	void reentryDropFlagDropsReentrantAppend() {
+		var output = new ListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.REENTRY_DROP);
+		output.setConsumer((e, s) -> {
+			// A naughty output that logs during its own write - should be dropped.
+			testAppender.append(TestEventBuilder.of().build(b -> b.message("reentrant")));
+		});
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("original")));
+		assertEquals(List.of("original"), output.events().stream().map(e -> e.getKey().message()).toList());
+	}
+
+	@Test
+	void reentryLogFlagDropsReentrantAppendAndLogsDiagnostic() {
+		var output = new ListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.REENTRY_LOG);
+		output.setConsumer((e, s) -> {
+			testAppender.append(TestEventBuilder.of().build(b -> b.message("reentrant")));
+		});
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("original")));
+		assertEquals(List.of("original"), output.events().stream().map(e -> e.getKey().message()).toList());
+		String diagnostic = metaLogBytes.toString(StandardCharsets.UTF_8);
+		assertTrue(diagnostic.contains("reentrant appender"), () -> "expected reentry diagnostic, got: " + diagnostic);
+	}
+
+	@Test
+	void immediateFlushIsDefault() {
+		var output = new CountingListLogOutput();
+		var testAppender = appender("test", output);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("single")));
+		testAppender.append(new LogEvent[] { TestEventBuilder.of().build(b -> b.message("batch")) }, 1);
+		assertEquals(2, output.flushCount);
+	}
+
+	@Test
+	void disableImmediateFlushFlagPreventsFlush() {
+		var output = new CountingListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("single")));
+		testAppender.append(new LogEvent[] { TestEventBuilder.of().build(b -> b.message("batch")) }, 1);
+		assertEquals(0, output.flushCount);
+	}
+
+	@Test
+	void immediateFlushFlagsRespectedWithReuseBuffer() {
+		var output = new CountingListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.REUSE_BUFFER, AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
+		assertInstanceOf(ReuseBufferLogAppender.class, testAppender);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("single")));
+		testAppender.append(new LogEvent[] { TestEventBuilder.of().build(b -> b.message("batch")) }, 1);
+		assertEquals(0, output.flushCount);
+	}
+
+	@Test
+	void appenderLevelFlagsMergeOntoExistingAppenderWithoutReuseBuffer() {
+		LogConfig config = LogConfig.builder().build();
+		var output = new CountingListLogOutput();
+		List<LogProvider<LogAppender>> providers = List
+			.of(LogAppender.builder("test").encoder(LogFormatter.builder().message().encoder()).output(output).build());
+		var appenders = new LogAppender.Appenders("test-route", config, providers);
+		var result = appenders.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)).asSingle();
+		result.start(config);
+		assertInstanceOf(DefaultLogAppender.class, result);
+		result.append(TestEventBuilder.of().build(b -> b.message("hello")));
+		assertEquals(0, output.flushCount);
+	}
+
+	@Test
+	void appenderLevelFlagsAlreadyPresentIsNoop() {
+		LogConfig config = LogConfig.builder().build();
+		var output = new CountingListLogOutput();
+		List<LogProvider<LogAppender>> providers = List.of(LogAppender.builder("test")
+			.encoder(LogFormatter.builder().message().encoder())
+			.output(output)
+			.flag(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)
+			.build());
+		var appenders = new LogAppender.Appenders("test-route", config, providers);
+		var result = appenders.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)).asSingle();
+		result.start(config);
+		result.append(TestEventBuilder.of().build(b -> b.message("hello")));
+		assertEquals(0, output.flushCount);
+	}
+
+	@Test
+	void appenderLevelFlagsMergeOntoSharedLockComposite() {
+		LogConfig config = LogConfig.builder().build();
+		var outputA = new CountingListLogOutput();
+		var outputB = new CountingListLogOutput();
+		List<LogProvider<LogAppender>> providers = List.of(
+				LogAppender.builder("a").encoder(LogFormatter.builder().message().encoder()).output(outputA).build(),
+				LogAppender.builder("b").encoder(LogFormatter.builder().message().encoder()).output(outputB).build());
+		var appenders = new LogAppender.Appenders("test-route", config, providers)
+			.routeFlags(Set.of(LogRouter.RouteFlag.SHARED_APPENDER_LOCK))
+			.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH));
+		var result = appenders.asSingle();
+		result.start(config);
+		assertInstanceOf(CompositeLogAppender.class, result);
+		result.append(TestEventBuilder.of().build(b -> b.message("hello")));
+		assertEquals(0, outputA.flushCount);
+		assertEquals(0, outputB.flushCount);
+	}
+
+	static class CountingListLogOutput extends ListLogOutput {
+
+		int flushCount = 0;
+
+		@Override
+		public void flush() {
+			flushCount++;
+			super.flush();
+		}
+
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderTest.java
@@ -3,14 +3,29 @@ package io.jstach.rainbowgum;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 class LogAppenderTest {
+
+	final Function<Set<LogAppender.AppenderFlag>, AppenderLock> originalLockFactoryFunction = AppenderLock.lockFactoryFunction;
+
+	@AfterEach
+	void after() {
+		/*
+		 * test() below replaces this static factory but never restored it, silently
+		 * corrupting the real REENTRY_DROP/REENTRY_LOG factory logic for every other test
+		 * that runs afterward in the same JVM.
+		 */
+		AppenderLock.lockFactoryFunction = originalLockFactoryFunction;
+	}
 
 	@Test
 	void test() {


### PR DESCRIPTION
Adds LogAppenderFlagTest covering, all via real LogAppender/Appenders instances against ListLogOutput (or a small real subclass counting flush calls) rather than mocks:

- AppenderFlag.parse(List.of()) empty-list branch
- REENTRY_DROP and REENTRY_LOG dropping a genuinely reentrant append (triggered through ListLogOutput's own consumer callback re-entering the appender mid-write), including REENTRY_LOG's MetaLog diagnostic
- DISABLE_IMMEDIATE_FLUSH vs the new default-on immediate flush, for both the single-event and batch append overloads, on both DefaultLogAppender and ReuseBufferLogAppender
- LockLogAppender.withFlags()'s flag-merge branches (adding a new flag vs. a no-op when already present) and CompositeLogAppender.withFlags(), exercised via LogAppender.Appenders directly (same package, real production code - this is how publishers like the async one actually add flags onto already-built appenders)

Also fixes a real pre-existing test-isolation bug found along the way: LogAppenderTest replaced the static AppenderLock.lockFactoryFunction with a custom lambda and never restored it, silently corrupting the real REENTRY_DROP/REENTRY_LOG factory logic for every test that ran afterward in the same JVM (surfaced as the new REENTRY_LOG test's diagnostic assertion failing only when run as part of the full suite, never in isolation).