### PR TITLE
Fix ForwardingOutputTest for the ByteBuffer write convention change

### DIFF
--- a/core/src/test/java/io/jstach/rainbowgum/output/ForwardingOutputTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/output/ForwardingOutputTest.java
@@ -145,10 +145,10 @@ class ForwardingOutputTest {
 		var event = TestEventBuilder.of().build(b -> b.message("hello"));
 
 		/*
-		 * LogOutput's default write(LogEvent, ByteBuffer, ContentType) sizes the array
-		 * off buf.position() (expecting a just-written-into, not-yet-flipped buffer)
-		 * rather than buf.remaining(), so the buffer must be built with put(), not
-		 * wrap().
+		 * LogOutput's default write(LogEvent, ByteBuffer, ContentType) expects a buffer
+		 * ready for reading (position at content start, limit at content end) - the
+		 * standard java.nio idiom. ByteBuffer.wrap(byte[]) already produces one in that
+		 * state.
 		 */
 		assertDoesNotThrow(() -> new TestForwardingOutput(null).write(event, freshByteBuffer(),
 				LogOutput.ContentType.StandardContentType.TEXT_PLAIN));
@@ -160,9 +160,7 @@ class ForwardingOutputTest {
 	}
 
 	private static ByteBuffer freshByteBuffer() {
-		ByteBuffer buf = ByteBuffer.allocate(5);
-		buf.put("hello".getBytes(StandardCharsets.UTF_8));
-		return buf;
+		return ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8));
 	}
 
 	static class TestForwardingOutput implements ForwardingOutput {


### PR DESCRIPTION
writeByteBufferForwardsWhenDelegatePresentAndNoopsWhenAbsent built its buffer with allocate()+put() (unflipped, position at content end) to match the old LogOutput.write(LogEvent, ByteBuffer, ContentType) default, which sized its array off buf.position(). That default was since fixed to use buf.remaining() instead (the standard flipped-buffer idiom), so the unflipped buffer now has zero remaining bytes and the test regressed to expecting an empty write. Switched to ByteBuffer.wrap(byte[]), which is already in the correct ready-to-read state.