### PR TITLE
Support Map<String,String> parameters in @LogConfigurable builders

### DIFF
--- a/rainbowgum-apt/src/main/java/io/jstach/rainbowgum/apt/BuilderModel.java
+++ b/rainbowgum-apt/src/main/java/io/jstach/rainbowgum/apt/BuilderModel.java
@@ -86,6 +86,8 @@ record BuilderModel( //
 
 		private static final String BOOLEAN_TYPE = "java.lang.Boolean";
 
+		private static final String MAP_TYPE = "java.util.Map";
+
 		public String propertyVar() {
 			return "property_" + name;
 		}
@@ -111,6 +113,7 @@ record BuilderModel( //
 				case STRING_TYPE -> null;
 				case URI_TYPE -> ".ofURI()";
 				case BOOLEAN_TYPE -> ".ofBoolean()";
+				case MAP_TYPE -> ".ofMap()";
 				default -> throw new IllegalStateException(type + " is not supported");
 			};
 		}
@@ -121,6 +124,7 @@ record BuilderModel( //
 				case STRING_TYPE -> "String";
 				case URI_TYPE -> "URI";
 				case BOOLEAN_TYPE -> "Boolean";
+				case MAP_TYPE -> "Map&lt;String,String&gt;";
 				default -> "String (converted)";
 			};
 		}

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/GelfEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/GelfEncoder.java
@@ -112,7 +112,7 @@ public final class GelfEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 	 */
 	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
 	static GelfEncoder of(@LogConfigurable.KeyParameter String name, String host, //
-			@LogConfigurable.ConvertParameter("convertHeaders") @Nullable Map<String, String> headers,
+			@Nullable Map<String, String> headers, //
 			@Nullable Boolean prettyPrint, @Nullable Integer timeFractionalDigits) {
 		prettyPrint = prettyPrint == null ? false : prettyPrint;
 		host = Objects.requireNonNull(host);
@@ -121,10 +121,6 @@ public final class GelfEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 				: timeFractionalDigits;
 
 		return new GelfEncoder(host, _headers, prettyPrint, _timeFractionalDigits);
-	}
-
-	static Map<String, String> convertHeaders(String headers) {
-		return LogProperties.parseMap(headers);
 	}
 
 	@Override


### PR DESCRIPTION
Wires Property.builder().ofMap() (LogProperties.mapOrNull) into the apt config-builder generator's type switch, alongside the existing Integer/String/URI/Boolean cases. Converts GelfEncoder's headers parameter from the ConvertParameter("convertHeaders") workaround (a hand-written String -> Map<String,String> parser) to a plain Map<String,String> parameter using the new native support - same LogProperties.parseMap format for simple LogProperties backends, but now also picks up MultiMapProperties' dotted-notation (headers.key=value) expansion for free, which the old String-only converter path never saw.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5