### PR TITLE
Link generated Map/List type descriptions to LogProperties

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
@@ -342,6 +342,17 @@ public interface LogProperties {
 	 * as a list using {@link LogProperties#parseList(String)} but custom implementations
 	 * may rely on their own parsing or the data type is built-in to the backing
 	 * configuration system.
+	 * <p>
+	 * The default format is a single property value that is comma or ampersand separated
+	 * and percent-encoded (<a href=
+	 * "https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data">
+	 * application/x-www-form-urlencoded</a>) for entries needing to contain the separator
+	 * or an equals sign, for example: <pre><code>
+	 * logging.appenders=console,file
+	 * </code></pre> resolves to <code>["console", "file"]</code>, and: <pre><code>
+	 * logging.appenders=one%20two,three%2Cfour
+	 * </code></pre> (a space and an escaped comma) resolves to
+	 * <code>["one two", "three,four"]</code>.
 	 * @param key property name.
 	 * @return list or <code>null</code>.
 	 * @apiNote the reason empty list is not returned for missing key is that it creates
@@ -361,6 +372,18 @@ public interface LogProperties {
 	 * as map using {@link LogProperties#parseMap(String)} but custom implementations may
 	 * rely on their own parsing or the data type is built-in to the backing configuration
 	 * system.
+	 * <p>
+	 * The default format is a single property value that is comma or ampersand separated
+	 * <code>key=value</code> pairs, percent-encoded (<a href=
+	 * "https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data">
+	 * application/x-www-form-urlencoded</a>) for entries needing to contain the separator
+	 * or an equals sign, for example: <pre><code>
+	 * logging.encoder.gelf.headers=environment=prod,region=us-east
+	 * </code></pre> resolves to
+	 * <code>{"environment": "prod", "region": "us-east"}</code>, and: <pre><code>
+	 * logging.encoder.gelf.headers=region=us%20east
+	 * </code></pre> (a percent-encoded space) resolves to
+	 * <code>{"region": "us east"}</code>.
 	 * @param key property name.
 	 * @return map or <code>null</code>.
 	 * @apiNote the reason empty map is not returned for missing key is that it creates

--- a/rainbowgum-apt/src/main/java/io/jstach/rainbowgum/apt/BuilderModel.java
+++ b/rainbowgum-apt/src/main/java/io/jstach/rainbowgum/apt/BuilderModel.java
@@ -127,8 +127,8 @@ record BuilderModel( //
 				case STRING_TYPE -> "String";
 				case URI_TYPE -> "URI";
 				case BOOLEAN_TYPE -> "Boolean";
-				case MAP_TYPE -> "Map&lt;String,String&gt;";
-				case LIST_TYPE -> "List&lt;String&gt;";
+				case MAP_TYPE -> "{@link LogProperties#mapOrNull(String) Map&lt;String,String&gt;}";
+				case LIST_TYPE -> "{@link LogProperties#listOrNull(String) List&lt;String&gt;}";
 				default -> "String (converted)";
 			};
 		}


### PR DESCRIPTION
The generated builder javadoc's property table showed "Map<String,String>" and "List<String>" as plain text; they now link to LogProperties#mapOrNull(String)/#listOrNull(String). Those two methods' own javadoc previously only pointed at parseMap/parseList without showing what the property value actually looks like, so both gained an inline percent-encoded key=value / comma-separated example (the same format GelfEncoder's headers property now uses).


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5