### PR TITLE
Auto-append exception rendering to patterns that don't address it

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -837,6 +837,22 @@ can instead be set programmatically as a single default shared by every encoder 
 property configuration. Both - with full code examples - are covered in the
 {@link io.jstach.rainbowgum.pattern/ } module javadoc.
 
+<h4 id="pattern_exception">Automatic Exception Rendering</h4>
+
+Notice that none of the pattern examples above (e.g. <code>[%thread] %-5level %logger{15} - %msg%n</code>)
+mention an exception keyword at all. As with Logback, this is intentional and safe: if a pattern does not
+otherwise use <code>%ex</code>/<code>%xEx</code> (or their aliases), Rainbow Gum automatically appends a default
+exception formatter to the end of the compiled pattern, so a logged throwable is never silently dropped just
+because the pattern forgot to ask for it.
+
+To opt out and suppress exception rendering entirely, add <code>%nopex</code> (or <code>%nopexception</code>)
+anywhere in the pattern - like the other throwable keywords, its mere presence is enough to disable the
+automatic append, and it renders nothing itself:
+
+{@snippet lang=properties :
+logging.encoder.myappender.pattern=%msg%nopex
+}
+
 <h3 id="jansi">JAnsi support (largely legacy)</h3>
 <p>
   Rainbow Gum still has an optional {@linkplain io.jstach.rainbowgum.jansi/ JAnsi module} for cross platform ANSI

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternCompiler.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternCompiler.java
@@ -147,9 +147,24 @@ final class Compiler implements PatternCompiler {
 
 	@Override
 	public LogFormatter compile(String pattern) {
+		return compile(pattern, true);
+	}
+
+	/*
+	 * autoAppendException exists as a seam for tests that want to check what a single
+	 * keyword compiles to in isolation, without the default exception formatter that
+	 * would otherwise always be appended (see below). Real callers only ever go through
+	 * the one-arg compile(String) above.
+	 */
+	LogFormatter compile(String pattern, boolean autoAppendException) {
 		try {
 			Parser p = new Parser(pattern);
-			return compile(p.parse());
+			Node parsed = p.parse();
+			LogFormatter formatter = compile(parsed);
+			if (autoAppendException && !containsExceptionKeyword(parsed)) {
+				formatter = LogFormatter.builder().add(formatter).throwable().build();
+			}
+			return formatter;
 		}
 		catch (ScanException | IllegalStateException e) {
 			throw new IllegalArgumentException("Pattern is invalid: " + pattern, e);
@@ -196,6 +211,42 @@ final class Compiler implements PatternCompiler {
 			};
 		}
 		return b.build();
+	}
+
+	/*
+	 * A separate, non-mutating pass (rather than tracking state during compile() itself)
+	 * so that compile(Node) keeps its original, simple recursive shape. Needs its own
+	 * recursion into composite children for the same reason compile(Node) does - a
+	 * keyword like %red(%ex) nests the exception keyword inside a child pattern.
+	 *
+	 * Checked via the resolved factory's isExceptionFormatter() rather than a fixed set
+	 * of known keyword strings, so custom-registered keywords (e.g. Spring Boot's
+	 * %wEx/%wex, registered entirely outside this module) are recognized too.
+	 */
+	private boolean containsExceptionKeyword(Node start) {
+		for (Node n = start; n != Node.end();) {
+			switch (n) {
+				case End e -> {
+					return false;
+				}
+				case LiteralNode ln -> n = ln.next();
+				case FormattingNode fn -> {
+					PatternFormatterFactory f = registry.getOrNull(fn.keyword());
+					if (f != null && f.isExceptionFormatter()) {
+						return true;
+					}
+					var child = switch (fn) {
+						case CompositeNode cn -> cn.childNode();
+						case KeywordNode kn -> null;
+					};
+					if (child != null && containsExceptionKeyword(child)) {
+						return true;
+					}
+					n = fn.next();
+				}
+			}
+		}
+		return false;
 	}
 
 }

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternFormatterFactory.java
@@ -49,6 +49,20 @@ import io.jstach.rainbowgum.pattern.format.PatternFormatterFactory.KeywordFactor
 public sealed interface PatternFormatterFactory {
 
 	/**
+	 * Whether this factory's formatter renders (or, like <code>%nopex</code>,
+	 * deliberately suppresses) a throwable, and thus counts as the pattern having
+	 * addressed exception rendering itself. {@link PatternCompiler} appends a default
+	 * exception formatter to any pattern where every keyword answers {@code false} here,
+	 * so a logged throwable is never silently dropped just because the pattern forgot to
+	 * ask for it - see the built-in throwable keywords and Spring Boot's
+	 * <code>%wEx</code>/<code>%wex</code> for the keywords that override this.
+	 * @return {@code false} by default.
+	 */
+	default boolean isExceptionFormatter() {
+		return false;
+	}
+
+	/**
 	 * A composite formatter factory expects possible children. For example
 	 * {@code %keyword(child) }.
 	 */
@@ -86,6 +100,30 @@ public sealed interface PatternFormatterFactory {
 		 */
 		static PatternFormatterFactory.KeywordFactory of(LogFormatter formatter) {
 			return (c, n) -> PadFormatter.of(formatter, n.padding());
+		}
+
+		/**
+		 * Creates a keyword factory from a formatter that only cares about padding info,
+		 * additionally marking it as {@link #isExceptionFormatter()}. Lambdas cannot
+		 * override default methods, hence this overload instead of a plain lambda for
+		 * keywords like <code>%nopex</code> that need to.
+		 * @param formatter existing formatter.
+		 * @param isExceptionFormatter value to return from
+		 * {@link #isExceptionFormatter()}.
+		 * @return factory.
+		 */
+		static PatternFormatterFactory.KeywordFactory of(LogFormatter formatter, boolean isExceptionFormatter) {
+			return new KeywordFactory() {
+				@Override
+				public LogFormatter create(PatternConfig config, PatternKeyword node) {
+					return PadFormatter.of(formatter, node.padding());
+				}
+
+				@Override
+				public boolean isExceptionFormatter() {
+					return isExceptionFormatter;
+				}
+			};
 		}
 
 	}
@@ -293,6 +331,11 @@ enum StandardKeywordFactory implements KeywordFactory {
 			return PatternFormatterFactory.throwableFormatter(node, false);
 		}
 
+		@Override
+		public boolean isExceptionFormatter() {
+			return true;
+		}
+
 	},
 	/**
 	 * <code>%xEx</code>, <code>%xEx{full}</code>, <code>%xEx{short}</code>,
@@ -305,6 +348,11 @@ enum StandardKeywordFactory implements KeywordFactory {
 		@Override
 		protected LogFormatter _create(PatternConfig config, PatternKeyword node) {
 			return PatternFormatterFactory.throwableFormatter(node, true);
+		}
+
+		@Override
+		public boolean isExceptionFormatter() {
+			return true;
 		}
 
 	};

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternRegistry.java
@@ -201,6 +201,14 @@ public sealed interface PatternRegistry {
 		 */
 		EXTENDED_THROWABLE("xEx", "xException", "xThrowable"), //
 		/**
+		 * <a href="https://logback.qos.ch/manual/layouts.html#nopex">No exception
+		 * keywords</a>. Renders nothing but, like {@link #THROWABLE} and
+		 * {@link #EXTENDED_THROWABLE}, counts as the pattern having addressed exception
+		 * rendering - suppressing the automatic exception formatter that is otherwise
+		 * appended to any pattern that mentions none of these three keywords.
+		 */
+		NO_EXCEPTION("nopex", "nopexception"), //
+		/**
 		 * <a href="https://logback.qos.ch/manual/layouts.html#newline">Newline
 		 * keywords</a>
 		 */
@@ -420,6 +428,7 @@ final class DefaultPatternRegistry implements PatternRegistry {
 				case THREAD -> KeywordFactory.of(LogFormatter.builder().threadName().build());
 				case THROWABLE -> StandardKeywordFactory.THROWABLE;
 				case EXTENDED_THROWABLE -> StandardKeywordFactory.EXTENDED_THROWABLE;
+				case NO_EXCEPTION -> KeywordFactory.of(LogFormatter.noop(), true);
 				case CLASS -> KeywordFactory.of(CallerInfoFormatter.CLASS);
 				case FILE -> KeywordFactory.of(CallerInfoFormatter.FILE);
 				case LINE -> KeywordFactory.of(CallerInfoFormatter.LINE);

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/CompilerTest.java
@@ -30,7 +30,7 @@ class CompilerTest {
 	@ParameterizedTest
 	@EnumSource(value = PatternTest.class)
 	void test(PatternTest test) {
-		var c = PatternCompiler.builder()
+		var c = (Compiler) PatternCompiler.builder()
 			.patternRegistry(PatternRegistry.of())
 			.patternConfig(test.patternConfig())
 			.build();
@@ -43,7 +43,14 @@ class CompilerTest {
 			test.output(actual);
 			assertEquals(expected, test.filter(actual));
 			test.assertOutput(actual);
-			test.assertFormatter(formatter);
+			/*
+			 * Patterns that don't otherwise mention an exception keyword get a default
+			 * exception formatter appended automatically (see Compiler.compile), which
+			 * would otherwise mask what a single keyword like %L or %20logger actually
+			 * compiles to. assertFormatter checks are about that keyword-to-formatter
+			 * mapping, so they get the un-appended result instead.
+			 */
+			test.assertFormatter(c.compile(input, false));
 		}
 	}
 
@@ -222,6 +229,23 @@ class CompilerTest {
 				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
 			}
 		},
+		NO_EXCEPTION(List.of("%nopex", "%nopexception"), "") {
+			LogEvent event() {
+				Throwable throwable = new RuntimeException("should not appear");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+
+			@Override
+			protected void assertFormatter(LogFormatter formatter) {
+				assertTrue(LogFormatter.isNoopOrNull(formatter));
+			}
+		},
+		NO_EXCEPTION_SUPPRESSES_AUTO_APPEND("%msg%nopex", "hello") {
+			LogEvent event() {
+				Throwable throwable = new RuntimeException("should not appear");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+		},
 		LINESEP("%n", "\n") {
 		},
 		LOGGER_LEFT_PAD("%20logger", "    io.jstach.logger") {
@@ -338,6 +362,34 @@ class CompilerTest {
 			@Override
 			protected String logger() {
 				return "com.logback.TriviaMain";
+			}
+		},
+		/*
+		 * This is doc/overview.html's own first pattern example, verbatim - it mentions
+		 * no exception keyword at all, so this confirms the automatic exception formatter
+		 * kicks in rather than silently dropping the throwable, which is exactly the gap
+		 * that motivated adding it.
+		 */
+		FULL_INFO_SHOWS_EXCEPTION_WITHOUT_EXPLICIT_KEYWORD("[%thread] %-5level %logger{15} - %msg%n",
+				"[main] INFO  c.l.TriviaMain - hello\n") {
+			LogEvent event() {
+				Throwable throwable = new RuntimeException("boom");
+				return LogEvent.of(level(), logger(), message(), keyValues(), throwable).freeze(Instant.EPOCH);
+			}
+
+			@Override
+			protected String logger() {
+				return "com.logback.TriviaMain";
+			}
+
+			@Override
+			protected String filter(String output) {
+				return output.lines().findFirst().orElse("FAIL") + "\n";
+			}
+
+			@Override
+			protected void assertOutput(String output) {
+				assertTrue(output.contains("java.lang.RuntimeException: boom"), output);
 			}
 		},
 		COLOR_INFO("[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg%n",

--- a/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/SpringBootKeywordFactory.java
+++ b/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/SpringBootKeywordFactory.java
@@ -47,6 +47,11 @@ enum SpringBootKeywordFactory implements KeywordFactory, PatternKeyProvider {
 			return PatternKey.of("wex");
 		}
 
+		@Override
+		public boolean isExceptionFormatter() {
+			return true;
+		}
+
 	},
 	/**
 	 * Spring Boot's <code>%wEx</code>, backed by
@@ -66,6 +71,11 @@ enum SpringBootKeywordFactory implements KeywordFactory, PatternKeyProvider {
 		@Override
 		public PatternKey key() {
 			return PatternKey.of("wEx");
+		}
+
+		@Override
+		public boolean isExceptionFormatter() {
+			return true;
 		}
 
 	};

--- a/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/SpringBootKeywordFactory.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/SpringBootKeywordFactory.java
@@ -47,6 +47,11 @@ enum SpringBootKeywordFactory implements KeywordFactory, PatternKeyProvider {
 			return PatternKey.of("wex");
 		}
 
+		@Override
+		public boolean isExceptionFormatter() {
+			return true;
+		}
+
 	},
 	/**
 	 * Spring Boot's <code>%wEx</code>, backed by
@@ -66,6 +71,11 @@ enum SpringBootKeywordFactory implements KeywordFactory, PatternKeyProvider {
 		@Override
 		public PatternKey key() {
 			return PatternKey.of("wEx");
+		}
+
+		@Override
+		public boolean isExceptionFormatter() {
+			return true;
 		}
 
 	};


### PR DESCRIPTION
doc/overview.html's own first pattern example
([%thread] %-5level %logger{15} - %msg%n) mentions no exception keyword at all, so a logged throwable was silently dropped unless the pattern explicitly used %ex/%xEx. Matching Logback, PatternCompiler now appends a default exception formatter to any pattern where nothing already addresses exception rendering, and adds %nopex/%nopexception to opt out (rendering nothing, like Logback's NopThrowableInformationConverter).

Whether a keyword "addresses" exception rendering is checked via a new PatternFormatterFactory.isExceptionFormatter() marker (default false) rather than a fixed set of known keyword strings, so it correctly recognizes Spring Boot's %wEx/%wex - registered entirely outside this module - and will pick up any future custom exception keyword the same way. Detection is a separate, non-mutating recursive scan over the parsed pattern (rather than threading state through compile() itself), so compile(Node) keeps its original shape; it still needs its own recursion for composite keywords like %red(%ex).

CompilerTest's assertFormatter checks (which assert what a single keyword compiles to, e.g. %L -> a specific formatter instance) now use a package-visible compile(String, false) to see the un-appended result, since the default auto-append would otherwise wrap every one of them.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5