### PR TITLE
Upgrade error-prone from 2.45.0 to 2.50.0

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
@@ -1551,6 +1551,8 @@ interface ListLogProperties extends LogProperties {
 record CompositeMutableLogProperties(LogProperties[] properties) implements ListLogProperties, MutableLogProperties {
 
 	@Override
+	@SuppressWarnings("ReferenceEquality") // identity check to avoid self-recursion if a
+											// composite contains itself
 	public MutableLogProperties put(String key, @Nullable String value) {
 		for (var p : properties()) {
 			if (p instanceof MutableLogProperties mp && mp != this) {

--- a/core/src/main/java/io/jstach/rainbowgum/spi/RainbowGumServiceProvider.java
+++ b/core/src/main/java/io/jstach/rainbowgum/spi/RainbowGumServiceProvider.java
@@ -160,7 +160,7 @@ public sealed interface RainbowGumServiceProvider {
 		private static void runConfigurators(Stream<? extends RainbowGumServiceProvider.Configurator> configurators,
 				LogConfig config, int passes) {
 			List<Configurator> unresolved = new ArrayList<>(
-					configurators.sorted(Comparator.comparing(Configurator::priority).reversed()).toList());
+					configurators.sorted(Comparator.comparingInt(Configurator::priority).reversed()).toList());
 			for (int i = 0; i < passes; i++) {
 				var it = unresolved.iterator();
 				while (it.hasNext()) {

--- a/core/src/test/java/io/jstach/rainbowgum/MutableKeyValuesTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/MutableKeyValuesTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -225,7 +226,7 @@ class MutableKeyValuesTest {
 		kvs.add("k1", "v1");
 		var expected = kvs.freeze();
 		var actual = expected.freeze();
-		assertTrue(actual == expected);
+		assertSame(expected, actual);
 		assertEquals(expected, actual);
 		assertInstanceOf(ImmutableArrayKeyValues.class, actual);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <ecj.version>3.39.0</ecj.version>
     <plexus-compiler-eclipse.version>2.15.0</plexus-compiler-eclipse.version>
-    <error-prone.version>2.45.0</error-prone.version>
+    <error-prone.version>2.50.0</error-prone.version>
     <nullaway.version>0.13.8</nullaway.version>
     <checkerframework.version>4.2.2</checkerframework.version>
 


### PR DESCRIPTION
Fixes the two new checks the upgrade surfaces on core:
- BoxingComparator in RainbowGumServiceProvider: use Comparator.comparingInt instead of boxing Configurator::priority.
- ReferenceEquality: suppress with justification in CompositeMutableLogProperties.put (identity check is intentional, guards against self-recursion), and switch a test's `==` identity check to assertSame in MutableKeyValuesTest.

Verified via bin/analyze.sh errorprone and the nullaway profile (which shares error-prone.version) on core, plus a full reactor build.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5