### PR TITLE
Bump maven-surefire-plugin, maven-enforcer-plugin, templating-maven-p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.3</version>
+          <version>3.5.6</version>
           <configuration>
             <trimStackTrace>false</trimStackTrace>
             <printSummary>true</printSummary>
@@ -411,7 +411,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>io.spring.javaformat</groupId>
@@ -426,7 +426,7 @@
         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>templating-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
…lugin

Combines the mechanical version bumps from dependabot PRs #303 (maven-surefire-plugin 3.5.3 -> 3.5.6), #300 (maven-enforcer-plugin 3.6.1 -> 3.6.3), and #341 (templating-maven-plugin 3.0.0 -> 3.1.0) into one commit. spring-javaformat-maven-plugin (#318) intentionally excluded.