### PR TITLE
Cover addIfError's Error branch across more @LogConfigurable builders

### DIFF
--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.json.encoder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.System.Logger.Level;
@@ -126,6 +127,38 @@ class GelfEncoderTest {
 		buffer.drain(out, e);
 		String message = out.events().get(0).getValue();
 		assertTrue(message.contains("\"_time\":\"1970-01-01T00:00:00.001456Z\""), message);
+	}
+
+	/*
+	 * timeFractionalDigits is an @Nullable (optional) property, so a malformed value goes
+	 * through Validator.addIfError() rather than add() - a branch that, until now, no
+	 * test anywhere in the suite exercised with a bad value (only ever with a missing or
+	 * a valid one).
+	 */
+	@Test
+	void testMalformedTimeFractionalDigitsReportsErrorViaAddIfError() {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list:///
+				logging.appender.list.encoder=gelf
+				logging.encoder.list.host=localhost
+				logging.encoder.list.timeFractionalDigits=notanumber
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new GelfEncoderConfigurator())
+			.build();
+		var e = assertThrows(RuntimeException.class, () -> RainbowGum.builder(config).build().start());
+		assertEquals(
+				"""
+						Failure providing Appenders for route: 'default'. cause:
+						Failure providing Appender: 'list' from property: Property[logging.appenders]=[list]. cause:
+						Error converting property. key: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder], value: 'gelf' cause:
+						Validation failed for io.jstach.rainbowgum.json.encoder.GelfEncoderBuilder:
+						Error for property. key: 'logging.encoder.list.timeFractionalDigits' from PROPERTIES_STRING[logging.encoder.list.timeFractionalDigits], java.lang.NumberFormatException For input string: "notanumber"
+						Tried: 'logging.encoder.list.timeFractionalDigits' from PROPERTIES_STRING[logging.encoder.list.timeFractionalDigits], [logging.appender.list.encoder]->URI(gelf:///)[timeFractionalDigits]
+						Tried: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder]""",
+				e.getMessage());
 	}
 
 	@Test

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.json.encoder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.System.Logger.Level;
@@ -16,6 +17,7 @@ import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.RainbowGum;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
@@ -56,6 +58,37 @@ class LogstashEncoderTest {
 		buffer.drain(out, e);
 		String actual = out.events().get(0).getValue();
 		assertTrue(actual.contains("\"@timestamp\":\"1969-12-31T19:00:00.001-05:00\""), "Got: " + actual);
+	}
+
+	/*
+	 * zoneId is an @Nullable (optional) property, so a malformed value goes through
+	 * Validator.addIfError() rather than add() - a branch that, until now, no test
+	 * anywhere in the suite exercised with a bad value (only ever with a missing or a
+	 * valid one).
+	 */
+	@Test
+	void testMalformedZoneIdReportsErrorViaAddIfError() {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list:///
+				logging.appender.list.encoder=logstash
+				logging.encoder.list.zoneId=Not/AZone
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new LogstashEncoderConfigurator())
+			.build();
+		var e = assertThrows(RuntimeException.class, () -> RainbowGum.builder(config).build().start());
+		assertEquals(
+				"""
+						Failure providing Appenders for route: 'default'. cause:
+						Failure providing Appender: 'list' from property: Property[logging.appenders]=[list]. cause:
+						Error converting property. key: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder], value: 'logstash' cause:
+						Validation failed for io.jstach.rainbowgum.json.encoder.LogstashEncoderBuilder:
+						Error for property. key: 'logging.encoder.list.zoneId' from PROPERTIES_STRING[logging.encoder.list.zoneId], java.time.zone.ZoneRulesException Unknown time-zone ID: Not/AZone
+						Tried: 'logging.encoder.list.zoneId' from PROPERTIES_STRING[logging.encoder.list.zoneId], [logging.appender.list.encoder]->URI(logstash:///)[zoneId]
+						Tried: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder]""",
+				e.getMessage());
 	}
 
 	@Test

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternConfiguratorTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternConfiguratorTest.java
@@ -2,6 +2,7 @@ package io.jstach.rainbowgum.pattern.format;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
 
@@ -36,6 +37,64 @@ class PatternConfiguratorTest {
 			String actual = test.actual(config);
 			assertEquals(test.expected, actual);
 		}
+	}
+
+	/*
+	 * zoneId and sequenceNumberStart are both @Nullable (optional) properties, so a
+	 * malformed value goes through Validator.addIfError() rather than add() - a branch
+	 * that, until now, no test anywhere in the suite exercised with a bad value (only
+	 * ever with a missing or a valid one).
+	 */
+	@Test
+	void testMalformedZoneIdReportsErrorViaAddIfError() {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list
+				logging.appender.list.encoder=pattern
+				logging.pattern.config.list.zoneId=Not/AZone
+				logging.encoder.list.pattern=%msg%n
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new PatternConfigurator())
+			.build();
+		var e = assertThrows(RuntimeException.class, () -> RainbowGum.builder(config).build().start());
+		assertEquals(
+				"""
+						Failure providing Appenders for route: 'default'. cause:
+						Failure providing Appender: 'list' from property: Property[logging.appenders]=[list]. cause:
+						Error converting property. key: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder], value: 'pattern' cause:
+						Validation failed for io.jstach.rainbowgum.pattern.format.PatternConfigBuilder:
+						Error for property. key: 'logging.pattern.config.list.zoneId' from PROPERTIES_STRING[logging.pattern.config.list.zoneId], java.time.zone.ZoneRulesException Unknown time-zone ID: Not/AZone
+						Tried: 'logging.pattern.config.list.zoneId' from PROPERTIES_STRING[logging.pattern.config.list.zoneId]
+						Tried: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder]""",
+				e.getMessage());
+	}
+
+	@Test
+	void testMalformedSequenceNumberStartReportsErrorViaAddIfError() {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list
+				logging.appender.list.encoder=pattern
+				logging.pattern.config.list.sequenceNumberStart=notanumber
+				logging.encoder.list.pattern=%lsn%n
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new PatternConfigurator())
+			.build();
+		var e = assertThrows(RuntimeException.class, () -> RainbowGum.builder(config).build().start());
+		assertEquals(
+				"""
+						Failure providing Appenders for route: 'default'. cause:
+						Failure providing Appender: 'list' from property: Property[logging.appenders]=[list]. cause:
+						Error converting property. key: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder], value: 'pattern' cause:
+						Validation failed for io.jstach.rainbowgum.pattern.format.PatternConfigBuilder:
+						Error for property. key: 'logging.pattern.config.list.sequenceNumberStart' from PROPERTIES_STRING[logging.pattern.config.list.sequenceNumberStart], java.lang.NumberFormatException For input string: "notanumber"
+						Tried: 'logging.pattern.config.list.sequenceNumberStart' from PROPERTIES_STRING[logging.pattern.config.list.sequenceNumberStart]
+						Tried: 'logging.appender.list.encoder' from PROPERTIES_STRING[logging.appender.list.encoder]""",
+				e.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
Survey of all @LogConfigurable factory methods for @Nullable (optional, addIfError-wired) non-String parameters whose conversion can genuinely fail - Boolean.parseBoolean never throws, so @Nullable Boolean params don't count, and GelfEncoder.headers' percent-decoding never throws either (falls back to literal chars on bad escapes). That leaves:

- PatternConfigurator.zoneId (ZoneId) and .sequenceNumberStart (Long)
- LogstashEncoder.zoneId (ZoneId)
- GelfEncoder.timeFractionalDigits (Integer)

Adds a malformed-value test for each, golden-stringing the resulting error message. Unlike FileOutputBuilder's uri case (which goes through the misleading logging.file.name auto-configuration wrapper noted in todo.md), these all go through explicit encoder/appender configuration and read noticeably cleaner - no unrelated property mislabeled as the cause.

DisruptorConfigurator.bufferSize (Integer) and ExampleConfig.count (Integer) are both non-null/required (add(), not addIfError()) and were left out of this pass; DisruptorConfigurator also has no test module at all currently. ExampleConfig is a demo fixture for the annotation processor itself, not a real user-facing builder.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5