### PR TITLE
Fix Map/List propertyString separator bug found via coverage analysis

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -1635,7 +1635,7 @@ record MapGetter(RootPropertyGetter parent) implements ChildPropertyGetter<Map<S
 		boolean first = true;
 		for (var e : value.entrySet()) {
 			if (first) {
-				first = true;
+				first = false;
 			}
 			else {
 				sb.append("&");
@@ -1669,7 +1669,7 @@ record ListGetter(RootPropertyGetter parent) implements ChildPropertyGetter<List
 		boolean first = true;
 		for (var e : list) {
 			if (first) {
-				first = true;
+				first = false;
 			}
 			else {
 				sb.append(",");

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -12,6 +12,20 @@ import io.jstach.rainbowgum.LogProperty.ValidationException;
 
 class LogPropertyTest {
 
+	/*
+	 * Regression test for a real bug found while investigating LogProperty coverage:
+	 * ListGetter._propertyString had "if (first) { first = true; }" instead of "first =
+	 * false", so entries after the first were never comma-separated. No production
+	 *
+	 * @LogConfigurable builder currently has a real List<String> property (only the
+	 * test/rainbowgum-test-config demo fixture does), so this calls the package-private
+	 * static method directly rather than through a real caller.
+	 */
+	@Test
+	void testListPropertyStringSeparatesMultipleEntriesWithComma() {
+		assertEquals("a,b,c", ListGetter._propertyString(List.of("a", "b", "c")));
+	}
+
 	@Test
 	void testValidation() {
 		LogProperties properties = LogProperties.MutableLogProperties.builder()

--- a/core/src/test/java/io/jstach/rainbowgum/output/FileOutputPropertiesTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/output/FileOutputPropertiesTest.java
@@ -1,6 +1,8 @@
 package io.jstach.rainbowgum.output;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -54,6 +56,55 @@ class FileOutputPropertiesTest {
 		}
 		finally {
 			Files.deleteIfExists(file);
+		}
+	}
+
+	/*
+	 * ValidationException.validate() only ever kept the *first* Error's cause in every
+	 * other test in this file - each only has one malformed property. Here both uri and
+	 * bufferSize are malformed at once, producing two Result.Error entries in the same
+	 * Validator: uri (added first, via addIfError) becomes the reported cause, and
+	 * bufferSize's error (added last, via add) still shows up in the message but its
+	 * cause is discarded in favor of the first. Unlike the message text (which the
+	 * enum-based test() below checks and includes every error), the *cause* field is only
+	 * ever the first one - a distinction the message alone can't prove, so this checks
+	 * getCause() directly instead of going through the shared enum harness.
+	 */
+	@Test
+	void testValidationExceptionKeepsOnlyFirstErrorsCauseWhenMultiplePropertiesAreMalformed() throws IOException {
+		String fileName = FILE_PATH;
+		try {
+			String properties = """
+					logging.appenders=file
+					logging.file.name=%s
+					logging.output.file.uri=not a uri with spaces
+					logging.output.file.bufferSize=blah
+					""".formatted(fileName);
+			var config = LogConfig.builder()
+				.properties(LogProperties.builder().fromProperties(properties).build())
+				.build();
+			var e = assertThrows(RuntimeException.class, () -> RainbowGum.builder(config).build().start());
+			assertEquals(
+					"""
+							Failure providing Appenders for route: 'default'. cause:
+							Failure providing Appender: 'file' from property: Property[logging.appenders]=[file]. cause:
+							Error converting property. key: 'logging.file.name' from PROPERTIES_STRING[logging.file.name], value: './target/FileOutputPropertiesTest/file.log' cause:
+							Validation failed for io.jstach.rainbowgum.output.FileOutputBuilder:
+							Error for property. key: 'logging.output.file.uri' from PROPERTIES_STRING[logging.output.file.uri], java.net.URISyntaxException Illegal character in path at index 3: not a uri with spaces
+							Tried: 'logging.output.file.uri' from PROPERTIES_STRING[logging.output.file.uri]
+							Error for property. key: 'logging.output.file.bufferSize' from PROPERTIES_STRING[logging.output.file.bufferSize], java.lang.NumberFormatException For input string: "blah"
+							Tried: 'logging.output.file.bufferSize' from PROPERTIES_STRING[logging.output.file.bufferSize]
+							Tried: 'logging.file.name' from PROPERTIES_STRING[logging.file.name]""",
+					e.getMessage());
+			Throwable cause = e;
+			while (cause.getCause() != null && cause.getCause() != cause) {
+				cause = cause.getCause();
+			}
+			assertInstanceOf(java.net.URISyntaxException.class, cause,
+					"the ValidationException's cause should be the *first* malformed property's (uri) exception, not bufferSize's, since ValidationException.validate() only keeps the first");
+		}
+		finally {
+			Files.deleteIfExists(Path.of(fileName));
 		}
 	}
 

--- a/core/src/test/java/io/jstach/rainbowgum/output/FileOutputPropertiesTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/output/FileOutputPropertiesTest.java
@@ -97,7 +97,7 @@ class FileOutputPropertiesTest {
 							Tried: 'logging.file.name' from PROPERTIES_STRING[logging.file.name]""",
 					e.getMessage());
 			Throwable cause = e;
-			while (cause.getCause() != null && cause.getCause() != cause) {
+			while (cause.getCause() != null) {
 				cause = cause.getCause();
 			}
 			assertInstanceOf(java.net.URISyntaxException.class, cause,

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
@@ -22,11 +22,33 @@ import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
 import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogProperty;
 import io.jstach.rainbowgum.PropertiesParser;
 import io.jstach.rainbowgum.RainbowGum;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 class GelfEncoderTest {
+
+	/*
+	 * Regression test for a real bug found while investigating LogProperty coverage:
+	 * MapGetter._propertyString/ListGetter._propertyString had "if (first) { first =
+	 * true; }" instead of "first = false", so entries after the first were never
+	 * separated. Every existing headers test used a single-entry map, which can't reveal
+	 * this - "&" is only ever appended starting from the second entry.
+	 */
+	@Test
+	void testHeadersWithMultipleEntriesAreSeparated() {
+		GelfEncoderBuilder b = new GelfEncoderBuilder("gelf");
+		var headers = new java.util.LinkedHashMap<String, String>();
+		headers.put("header1", "1");
+		headers.put("header2", "2");
+		headers.put("header3", "3");
+		b.headers(headers);
+		b.host("localhost");
+		Map<String, String> props = new LinkedHashMap<>();
+		b.toProperties(props::put);
+		assertEquals("header1=1&header2=2&header3=3", props.get("logging.encoder.gelf.headers"));
+	}
 
 	@Test
 	void testBuilder() {
@@ -106,6 +128,20 @@ class GelfEncoderTest {
 		buffer.drain(out, e);
 		String message = out.events().get(0).getValue();
 		assertTrue(message.contains("\"_time\":\"1970-01-01T00:00:00.001Z\""), message);
+	}
+
+	/*
+	 * host is a required property with no default value, so GelfEncoderBuilder's field
+	 * starts out null - if build() is called directly (bypassing fromProperties())
+	 * without ever calling .host(...), Property.require() throws. Every other test in
+	 * this file always sets host, so this branch of require() had no coverage anywhere
+	 * before this.
+	 */
+	@Test
+	void testBuildWithoutRequiredHostThrows() {
+		GelfEncoderBuilder b = new GelfEncoderBuilder("gelf");
+		var e = assertThrows(LogProperty.PropertyMissingException.class, b::build);
+		assertEquals("Value is required not null. property key='logging.encoder.gelf.host'", e.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
Careful review of LogProperty's partially-covered branches, checking each against its real callers rather than writing contrived tests:

- ValidationException.validate() line ~209 ("if (cause == null)"): every existing malformed-property test has exactly one Result.Error, so the "keep only the first error's cause" branch was never exercised. Added a FileOutputPropertiesTest case with two malformed properties (uri and bufferSize) at once, asserting both the combined message and that getCause() is specifically the first error's exception - the message text alone can't distinguish this, since both errors' messages are always appended regardless of which one becomes the exception's cause.

- Property.require() line ~826: every existing test either calls fromProperties() or sets the field first. GelfEncoderBuilder.host has no default (unlike bufferSize), so calling build() directly without .host(...) is a realistic, previously-untested mistake.

- Real bug: MapGetter._propertyString/ListGetter._propertyString had "if (first) { first = true; }" instead of "first = false", so entries after the first were never separated by "&"/",". Every existing test used a single-entry map/list, which can't reveal this since the separator is only appended starting from the second entry. Fixed both, added a multi-entry regression test via the real GelfEncoder.headers caller, and a direct test of ListGetter._propertyString (no real @LogConfigurable builder currently has a List<String> property besides the test/rainbowgum-test-config demo fixture).

The remaining partially-covered branches in LogProperty.java are either defensive guards no real caller's input can trigger (type system or construction pattern prevents it at every real call site), or dead code: PropertyGetter.orElse()/orElseGet() and the entire FallbackGetter record have zero callers anywhere in the codebase, which explains several of the other partial branches (the Success.ValueSuccess arms in RootPropertyGetter.convert() and errorResult()) at once - not pursued here since there's no real caller to test through, and removing unused API surface is a separate decision.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5