### PR TITLE
Add rainbowgum-jfr: JDK Flight Recorder LogOutput

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -865,7 +865,38 @@ Here are some of the supported outputs (not a complete listing):
   <li>stdout and stderr</li>
   <li>{@link io.jstach.rainbowgum.output.FileOutputBuilder} with URI scheme of "file"</li>
   <li>{@link io.jstach.rainbowgum.rabbitmq.RabbitMQOutputBuilder} with URI scheme of "amqp"</li>
+  <li>{@link io.jstach.rainbowgum.jfr.JfrLogOutput} with URI scheme of "jfr" - see below.</li>
 </ul>
+
+<h3 id="jfr">JDK Flight Recorder (JFR)</h3>
+
+The optional {@linkplain io.jstach.rainbowgum.jfr/ JFR module} (inspired by
+<a href="https://github.com/mbien/JFRLog">JFRLog</a>) commits each log event as a JFR event instead of writing
+bytes anywhere, with one event type per level ({@code io.jstach.rainbowgum.Trace}/{@code Debug}/{@code Info}/
+{@code Warn}/{@code Error}) so each can be independently enabled, thresholded, or given a stack trace setting
+through a Flight Recorder configuration (<code>.jfc</code> file or <code>-XX:StartFlightRecording</code>) the
+same way as any other JFR event - not through Rainbow Gum properties. If no recording is active (or the
+relevant event type is disabled in it) writing is a cheap noop.
+
+<p>
+Because an output is always paired with an encoder, and this output never looks at the encoded bytes (it reads
+the fields it needs straight off the event), pair it with the near zero-cost encoder registered under the same
+scheme to avoid wasting time formatting bytes that are thrown away:
+</p>
+
+{@snippet lang=properties :
+logging.appenders=myappender
+logging.appender.myappender.output=jfr:///
+logging.appender.myappender.encoder=jfr:///
+}
+
+{@snippet :
+java -XX:StartFlightRecording:filename=recording.jfr,dumponexit=true,settings=profile -jar myapp.jar
+}
+
+<code>jfr print --events "io.jstach.rainbowgum.*" recording.jfr</code> then shows the recorded events. TRACE and
+DEBUG default to disabled (JFR events are opt-in per type and those two are usually too high volume to want on
+by default) so enable them explicitly in a custom <code>.jfc</code> settings file if needed.
 
 <h3 id="rolling">Rolling Files</h3>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1139,6 +1139,7 @@
     <module>rainbowgum</module>
     <module>rainbowgum-disruptor</module>
     <module>rainbowgum-jansi</module>
+    <module>rainbowgum-jfr</module>
     <module>benchmark</module>
     <module>rainbowgum-avaje-config</module>
     <module>test</module>

--- a/rainbowgum-jfr/pom.xml
+++ b/rainbowgum-jfr/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach.rainbowgum</groupId>
+    <artifactId>rainbowgum-maven-parent</artifactId>
+    <version>0.10.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>rainbowgum-jfr</artifactId>
+  <name>rainbowgum-jfr</name>
+  <properties>
+    <doc.resources>../</doc.resources>
+    <parent.root>${basedir}/..</parent.root>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach.pistachio</groupId>
+      <artifactId>pistachio-svc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach.pistachio</groupId>
+      <artifactId>pistachio-svc-apt</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/JfrConfigurator.java
+++ b/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/JfrConfigurator.java
@@ -1,0 +1,47 @@
+package io.jstach.rainbowgum.jfr;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEncoder.EncoderProvider;
+import io.jstach.rainbowgum.LogFormatter;
+import io.jstach.rainbowgum.LogOutput;
+import io.jstach.rainbowgum.LogOutput.OutputProvider;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.LogProviderRef;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
+import io.jstach.svc.ServiceProvider;
+
+/**
+ * Adds {@link JfrLogOutput} to the output registry, and a near zero-cost encoder (a
+ * {@linkplain LogFormatter#builder() formatter} with no formatters, which
+ * {@linkplain LogFormatter.Builder#build() is a documented noop}) to the encoder
+ * registry, both with URI scheme {@value JfrLogOutput#JFR_SCHEME}.
+ */
+@ServiceProvider(RainbowGumServiceProvider.class)
+public class JfrConfigurator implements Configurator {
+
+	/**
+	 * Default constructor for service loader.
+	 */
+	public JfrConfigurator() {
+	}
+
+	@Override
+	public boolean configure(LogConfig config, Pass pass) {
+		config.outputRegistry().register(JfrLogOutput.JFR_SCHEME, new JfrOutputProvider());
+		config.encoderRegistry()
+			.register(JfrLogOutput.JFR_SCHEME, EncoderProvider.of(LogEncoder.of(LogFormatter.builder().build())));
+		return true;
+	}
+
+	private static class JfrOutputProvider implements OutputProvider {
+
+		@Override
+		public LogProvider<LogOutput> provide(LogProviderRef ref) {
+			return (name, c) -> new JfrLogOutput();
+		}
+
+	}
+
+}

--- a/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/JfrLogOutput.java
+++ b/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/JfrLogOutput.java
@@ -1,0 +1,102 @@
+package io.jstach.rainbowgum.jfr;
+
+import java.net.URI;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogFormatter.ThrowableFormatter;
+import io.jstach.rainbowgum.LogOutput;
+
+/**
+ * A {@link LogOutput} that commits each log event as a JFR event (see
+ * {@link RainbowGumLogEvent}) instead of writing bytes anywhere.
+ * <p>
+ * Because {@link LogOutput} is always paired with an
+ * {@link io.jstach.rainbowgum.LogEncoder} by the appender machinery, some encoder still
+ * has to run even though this output never looks at the encoded bytes - it reads the
+ * fields it needs directly off the {@link LogEvent} passed alongside them. Pair this
+ * output with the encoder registered under the same {@value #JFR_SCHEME} scheme (a
+ * formatter with no formatters, which is a documented noop) to avoid paying for
+ * formatting that is thrown away:
+ *
+ * <pre>{@code
+ * logging.appender.myappender.output=jfr:///
+ * logging.appender.myappender.encoder=jfr:///
+ * }</pre>
+ *
+ * Per-event-type enablement, thresholds, and stack trace capture are controlled the same
+ * way as any other JFR event, e.g. with {@code -XX:StartFlightRecording} or a
+ * {@code .jfc} settings file - not through Rainbow Gum properties. If a Flight Recorder
+ * session that enables the relevant event type is not running, {@link #write} does
+ * (cheaply) nothing.
+ */
+public final class JfrLogOutput implements LogOutput {
+
+	/**
+	 * JFR output (and paired encoder) URI scheme.
+	 */
+	public static final String JFR_SCHEME = "jfr";
+
+	private static final URI JFR_URI = URI.create(JFR_SCHEME + ":///");
+
+	/**
+	 * Creates a JFR output.
+	 */
+	public JfrLogOutput() {
+	}
+
+	@Override
+	public URI uri() {
+		return JFR_URI;
+	}
+
+	@Override
+	public void start(LogConfig config) {
+	}
+
+	@Override
+	public OutputType type() {
+		return OutputType.MEMORY;
+	}
+
+	@Override
+	public void write(LogEvent event, byte[] bytes, int off, int len, ContentType contentType) {
+		var jfrEvent = create(event.level());
+		if (jfrEvent == null || !jfrEvent.isEnabled()) {
+			return;
+		}
+		var message = new StringBuilder();
+		event.formattedMessage(message);
+		jfrEvent.message = message.toString();
+		jfrEvent.logger = event.loggerName();
+		var t = event.throwableOrNull();
+		if (t != null) {
+			var stackTrace = new StringBuilder();
+			ThrowableFormatter.appendThrowable(stackTrace, t);
+			jfrEvent.throwable = stackTrace.toString();
+		}
+		jfrEvent.commit();
+	}
+
+	private static @Nullable RainbowGumLogEvent create(java.lang.System.Logger.Level level) {
+		return switch (level) {
+			case TRACE -> new RainbowGumLogEvent.TraceEvent();
+			case DEBUG -> new RainbowGumLogEvent.DebugEvent();
+			case INFO -> new RainbowGumLogEvent.InfoEvent();
+			case WARNING -> new RainbowGumLogEvent.WarnEvent();
+			case ERROR -> new RainbowGumLogEvent.ErrorEvent();
+			case ALL, OFF -> null;
+		};
+	}
+
+	@Override
+	public void flush() {
+	}
+
+	@Override
+	public void close() {
+	}
+
+}

--- a/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/RainbowGumLogEvent.java
+++ b/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/RainbowGumLogEvent.java
@@ -1,0 +1,138 @@
+package io.jstach.rainbowgum.jfr;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+/**
+ * Base JFR event committed by {@link JfrLogOutput}, one concrete subclass per SLF4J /
+ * {@link java.lang.System.Logger.Level}, so each level can be independently
+ * enabled/disabled and thresholded through a Flight Recorder configuration ({@code .jfc})
+ * the same way any other JFR event type can.
+ * <p>
+ * {@link #throwable} is a plain formatted stack trace string rather than JFR's own
+ * {@code @StackTrace} capture: that JFR feature records the stack at the point
+ * {@link Event#commit()} is called (i.e. inside this module), which is not useful here,
+ * so it is disabled ({@link StackTrace @StackTrace(false)}) and the logged
+ * {@link Throwable}, if any, is captured as a field instead.
+ * <p>
+ * MDC / key values are not carried as fields: JFR custom event fields are limited to
+ * primitives, {@link String}, {@link Class} and {@link Thread}, so there is no direct
+ * representation for an arbitrary map. File an issue if you need this.
+ */
+@Category("Rainbow Gum")
+@StackTrace(false)
+public abstract sealed class RainbowGumLogEvent extends Event {
+
+	/**
+	 * The already-formatted log message, or null if there was none.
+	 */
+	@Label("Message")
+	public @Nullable String message;
+
+	/**
+	 * The logger name, or null if unavailable.
+	 */
+	@Label("Logger")
+	public @Nullable String logger;
+
+	/**
+	 * The logged throwable formatted as a stack trace string, or null if none was logged.
+	 */
+	@Label("Throwable")
+	public @Nullable String throwable;
+
+	RainbowGumLogEvent() {
+	}
+
+	/**
+	 * TRACE level event. Disabled by default ({@link Enabled @Enabled(false)}) since
+	 * TRACE logging is typically too high volume to want on by default in a recording.
+	 */
+	@Name("io.jstach.rainbowgum.Trace")
+	@Label("Trace")
+	@Description("A TRACE level Rainbow Gum log event.")
+	@Enabled(false)
+	public static final class TraceEvent extends RainbowGumLogEvent {
+
+		/**
+		 * Created by {@link JfrLogOutput}.
+		 */
+		TraceEvent() {
+		}
+
+	}
+
+	/**
+	 * DEBUG level event. Disabled by default ({@link Enabled @Enabled(false)}) since
+	 * DEBUG logging is typically too high volume to want on by default in a recording.
+	 */
+	@Name("io.jstach.rainbowgum.Debug")
+	@Label("Debug")
+	@Description("A DEBUG level Rainbow Gum log event.")
+	@Enabled(false)
+	public static final class DebugEvent extends RainbowGumLogEvent {
+
+		/**
+		 * Created by {@link JfrLogOutput}.
+		 */
+		DebugEvent() {
+		}
+
+	}
+
+	/**
+	 * INFO level event.
+	 */
+	@Name("io.jstach.rainbowgum.Info")
+	@Label("Info")
+	@Description("An INFO level Rainbow Gum log event.")
+	public static final class InfoEvent extends RainbowGumLogEvent {
+
+		/**
+		 * Created by {@link JfrLogOutput}.
+		 */
+		InfoEvent() {
+		}
+
+	}
+
+	/**
+	 * WARN level event.
+	 */
+	@Name("io.jstach.rainbowgum.Warn")
+	@Label("Warn")
+	@Description("A WARN level Rainbow Gum log event.")
+	public static final class WarnEvent extends RainbowGumLogEvent {
+
+		/**
+		 * Created by {@link JfrLogOutput}.
+		 */
+		WarnEvent() {
+		}
+
+	}
+
+	/**
+	 * ERROR level event.
+	 */
+	@Name("io.jstach.rainbowgum.Error")
+	@Label("Error")
+	@Description("An ERROR level Rainbow Gum log event.")
+	public static final class ErrorEvent extends RainbowGumLogEvent {
+
+		/**
+		 * Created by {@link JfrLogOutput}.
+		 */
+		ErrorEvent() {
+		}
+
+	}
+
+}

--- a/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/package-info.java
+++ b/rainbowgum-jfr/src/main/java/io/jstach/rainbowgum/jfr/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * A {@link io.jstach.rainbowgum.LogOutput} backed by <a href=
+ * "https://docs.oracle.com/en/java/javase/21/docs/api/jdk.jfr/module-summary.html">JDK
+ * Flight Recorder (JFR)</a>, inspired by
+ * <a href="https://github.com/mbien/JFRLog">JFRLog</a>.
+ * <p>
+ * The Service Loaded configurator adds this output to the output registry with URI scheme
+ * {@value io.jstach.rainbowgum.jfr.JfrLogOutput#JFR_SCHEME}, and a near zero-cost encoder
+ * under the same scheme (see {@link io.jstach.rainbowgum.jfr.JfrLogOutput} for why one is
+ * needed even though the encoded bytes are never used).
+ */
+@org.eclipse.jdt.annotation.NonNullByDefault
+package io.jstach.rainbowgum.jfr;

--- a/rainbowgum-jfr/src/main/java/module-info.java
+++ b/rainbowgum-jfr/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
+
+/**
+ * Provides a {@link io.jstach.rainbowgum.LogOutput} that commits each log event as a
+ * <a href="https://docs.oracle.com/en/java/javase/21/docs/api/jdk.jfr/module-summary.html">JDK
+ * Flight Recorder</a> event instead of writing bytes anywhere, with URI scheme
+ * {@value io.jstach.rainbowgum.jfr.JfrLogOutput#JFR_SCHEME}.
+ * <p>
+ * This is its own module (rather than in core) because it requires the JDK's
+ * {@code jdk.jfr} module, which is not something every application wants as a
+ * dependency.
+ *
+ * @provides RainbowGumServiceProvider
+ * @see io.jstach.rainbowgum.jfr.JfrLogOutput
+ * @see io.jstach.rainbowgum.jfr.RainbowGumLogEvent
+ */
+module io.jstach.rainbowgum.jfr {
+
+	exports io.jstach.rainbowgum.jfr;
+
+	requires transitive io.jstach.rainbowgum;
+	requires jdk.jfr;
+
+	requires static io.jstach.svc;
+	requires static org.eclipse.jdt.annotation;
+
+	provides RainbowGumServiceProvider with io.jstach.rainbowgum.jfr.JfrConfigurator;
+}

--- a/rainbowgum-jfr/src/test/java/io/jstach/rainbowgum/jfr/JfrLogOutputTest.java
+++ b/rainbowgum-jfr/src/test/java/io/jstach/rainbowgum/jfr/JfrLogOutputTest.java
@@ -1,0 +1,111 @@
+package io.jstach.rainbowgum.jfr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.System.Logger.Level;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
+import io.jstach.rainbowgum.LogOutput.ContentType.StandardContentType;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+class JfrLogOutputTest {
+
+	@Test
+	void testInfoEventIsRecorded(@TempDir Path dir) throws IOException {
+		Path recordingFile = dir.resolve("test.jfr");
+		try (Recording recording = new Recording()) {
+			recording.enable(RainbowGumLogEvent.InfoEvent.class);
+			recording.start();
+
+			var output = new JfrLogOutput();
+			Instant instant = Instant.ofEpochMilli(1);
+			LogEvent e = LogEvent
+				.ofAll(instant, "main", 1L, Level.INFO, "jfr-test", "hello", KeyValues.of(), null,
+						StandardMessageFormatter.SLF4J, List.of())
+				.freeze(instant);
+			output.write(e, new byte[0], 0, 0, StandardContentType.TEXT_PLAIN);
+
+			recording.stop();
+			recording.dump(recordingFile);
+		}
+
+		List<RecordedEvent> events = RecordingFile.readAllEvents(recordingFile);
+		assertEquals(1, events.size(), "expected exactly one recorded event: " + events);
+		RecordedEvent recorded = events.get(0);
+		assertEquals("io.jstach.rainbowgum.Info", recorded.getEventType().getName());
+		assertEquals("hello", recorded.getValue("message"));
+		assertEquals("jfr-test", recorded.getValue("logger"));
+	}
+
+	@Test
+	void testDisabledEventTypeIsNotRecorded(@TempDir Path dir) throws IOException {
+		Path recordingFile = dir.resolve("test.jfr");
+		try (Recording recording = new Recording()) {
+			// Only INFO is enabled; DEBUG defaults to disabled.
+			recording.enable(RainbowGumLogEvent.InfoEvent.class);
+			recording.start();
+
+			var output = new JfrLogOutput();
+			Instant instant = Instant.ofEpochMilli(1);
+			LogEvent e = LogEvent
+				.ofAll(instant, "main", 1L, Level.DEBUG, "jfr-test", "should not be recorded", KeyValues.of(), null,
+						StandardMessageFormatter.SLF4J, List.of())
+				.freeze(instant);
+			output.write(e, new byte[0], 0, 0, StandardContentType.TEXT_PLAIN);
+
+			recording.stop();
+			recording.dump(recordingFile);
+		}
+
+		List<RecordedEvent> events = RecordingFile.readAllEvents(recordingFile);
+		assertTrue(events.isEmpty(), "Got: " + events);
+	}
+
+	@Test
+	void testThrowableIsCapturedAsString(@TempDir Path dir) throws IOException {
+		Path recordingFile = dir.resolve("test.jfr");
+		try (Recording recording = new Recording()) {
+			recording.enable(RainbowGumLogEvent.ErrorEvent.class);
+			recording.start();
+
+			var output = new JfrLogOutput();
+			Instant instant = Instant.ofEpochMilli(1);
+			Throwable t = new RuntimeException("boom");
+			LogEvent e = LogEvent.of(Level.ERROR, "jfr-test", "failed", KeyValues.of(), t).freeze(instant);
+			output.write(e, new byte[0], 0, 0, StandardContentType.TEXT_PLAIN);
+
+			recording.stop();
+			recording.dump(recordingFile);
+		}
+
+		List<RecordedEvent> events = RecordingFile.readAllEvents(recordingFile);
+		assertEquals(1, events.size());
+		String throwable = events.get(0).getValue("throwable");
+		assertTrue(throwable.contains("java.lang.RuntimeException: boom"), "Got: " + throwable);
+	}
+
+	@Test
+	void testNoActiveRecordingDoesNotThrow() {
+		var output = new JfrLogOutput();
+		Instant instant = Instant.ofEpochMilli(1);
+		LogEvent e = LogEvent
+			.ofAll(instant, "main", 1L, Level.INFO, "jfr-test", "hello", KeyValues.of(), null,
+					StandardMessageFormatter.SLF4J, List.of())
+			.freeze(instant);
+		output.write(e, new byte[0], 0, 0, StandardContentType.TEXT_PLAIN);
+	}
+
+}


### PR DESCRIPTION
New optional module, separate from core since it requires the jdk.jfr module. JfrLogOutput commits each event as a JFR event instead of writing bytes, one event type per level (RainbowGumLogEvent.TraceEvent/ DebugEvent/InfoEvent/WarnEvent/ErrorEvent) so each can be independently enabled/thresholded/stack-traced through a normal .jfc configuration or -XX:StartFlightRecording, the same as any other JFR event - not through Rainbow Gum properties. TRACE/DEBUG default disabled (@Enabled(false)) since they're usually too high volume to want on by default in a recording. Inspired by https://github.com/mbien/JFRLog, adapted to Rainbow Gum's LogEvent/LogOutput model (one output class using Event.isEnabled() per instance, per the standard JFR custom-event idiom, rather than a SLF4J bridge).

MDC/key values aren't carried as fields since JFR custom event fields are limited to primitives/String/Class/Thread - documented as a deliberate scope cut, not an oversight.

Since LogOutput is always paired with an encoder even though this one never looks at the encoded bytes (it reads fields straight off the LogEvent passed alongside them instead), the configurator also registers a near-zero-cost encoder (LogFormatter.builder().build(), a documented noop) under the same "jfr" scheme, so pairing output=jfr:/// with encoder=jfr:/// skips formatting bytes that would just be thrown away. The output still has to format the message once itself (for the JFR "message" field) regardless of which encoder is paired with it - that part isn't avoidable, only the encoder's redundant formatting is.

Tests start a real in-process Recording, run events through the output, then read the dumped .jfr file back with RecordingFile and assert on the recorded fields - not just that commit() doesn't throw.

Documented in doc/overview.html's Outputs section.