### PR TITLE
Cover LogbackJsonEncoderConfigurator and LogstashEncoderConfigurator

### DIFF
--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderTest.java
@@ -15,10 +15,46 @@ import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogEvent;
 import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.RainbowGum;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 class LogbackJsonEncoderTest {
+
+	/*
+	 * Every other test in this file builds LogbackJsonEncoder directly (either via
+	 * LogbackJsonEncoderBuilder or LogbackJsonEncoder.of(...)), bypassing
+	 * LogbackJsonEncoderConfigurator (the ServiceLoader-registered URI-scheme resolution
+	 * path) entirely - it had 0% coverage. This goes through the real pipeline:
+	 * logging.appender.list.encoder=logback resolves via the configurator's registered
+	 * scheme, same as GelfEncoderTest/EcsEncoderTest's testFullLoadUri.
+	 */
+	@Test
+	void testFullLoadUri() throws Exception {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list:///
+				logging.appender.list.encoder=logback:///?prettyPrint=true
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new LogbackJsonEncoderConfigurator())
+			.build();
+		try (var r = RainbowGum.builder(config).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			r.router()
+				.eventBuilder("logback", System.Logger.Level.INFO)
+				.message("hello")
+				.threadId(1)
+				.timestamp(instant)
+				.log();
+			ListLogOutput output = (ListLogOutput) config.outputRegistry().output("list").orElseThrow();
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.startsWith("{\n "),
+					"expected pretty-printed output from ?prettyPrint=true, got: " + actual);
+			assertTrue(actual.contains("\"message\":\"hello\""), "Got: " + actual);
+		}
+	}
 
 	@Test
 	void testSimpleMessage() {

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
@@ -91,6 +91,42 @@ class LogstashEncoderTest {
 				e.getMessage());
 	}
 
+	/*
+	 * testMalformedZoneIdReportsErrorViaAddIfError above always fails before reaching
+	 * LogstashEncoderProvider.provide(ref)'s build() call, so the *successful* path
+	 * through the real ServiceLoader-registered URI-scheme resolution
+	 * (LogstashEncoderConfigurator -> LogstashEncoderProvider) was still only 47%
+	 * covered. This exercises it end to end, mirroring GelfEncoderTest/EcsEncoderTest's
+	 * testFullLoadUri.
+	 */
+	@Test
+	void testFullLoadUri() throws Exception {
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list:///
+				logging.appender.list.encoder=logstash:///?prettyPrint=true
+				logging.encoder.list.zoneId=UTC
+				""";
+		LogConfig config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new LogstashEncoderConfigurator())
+			.build();
+		try (var r = RainbowGum.builder(config).build().start()) {
+			Instant instant = Instant.ofEpochMilli(1);
+			r.router()
+				.eventBuilder("logstash", System.Logger.Level.INFO)
+				.message("hello")
+				.threadId(1)
+				.timestamp(instant)
+				.log();
+			ListLogOutput output = (ListLogOutput) config.outputRegistry().output("list").orElseThrow();
+			String actual = output.events().get(0).getValue();
+			assertTrue(actual.startsWith("{\n "),
+					"expected pretty-printed output from ?prettyPrint=true, got: " + actual);
+			assertTrue(actual.contains("\"message\":\"hello\""), "Got: " + actual);
+		}
+	}
+
 	@Test
 	void testMdcIsFlattenedTopLevel() throws Exception {
 		var config = LogConfig.builder().build();


### PR DESCRIPTION
LogbackJsonEncoderConfigurator was at 0% - LogbackJsonEncoderTest only ever builds the encoder directly (LogbackJsonEncoderBuilder or LogbackJsonEncoder.of(...)), never through the ServiceLoader-registered "logback" URI-scheme resolution path the configurator actually provides. Added testFullLoadUri mirroring GelfEncoderTest/ EcsEncoderTest's existing pattern.

LogstashEncoderConfigurator itself was 100% covered (via the malformed-zoneId test added previously), but its inner LogstashEncoderProvider - the part that actually resolves and builds the encoder - was only 47%: that test always fails before reaching build(). Added the same testFullLoadUri pattern here to exercise the successful path end to end.

Both now at 100% (Configurator + its EncoderProvider) per jacoco.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5