### PR TITLE
Add extensive coverage for LogProperties/LogProperty, remove dead erg…

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
@@ -722,18 +722,6 @@ public interface LogProperties {
 					(b) -> queryToProperties(query, Objects.requireNonNullElse(description, "URI_QUERY(" + uri + ")")));
 		}
 
-		/**
-		 * Parses a string as a URI query string.
-		 * @param query uri percent encoded uri with separator as "<code>&amp;</code>" and
-		 * key value separator of "<code>=</code>".
-		 * @return this.
-		 */
-		public Builder fromURIQuery(String query) {
-			return provider((b) -> queryToProperties(query,
-					Objects.requireNonNullElse(description, "URI_QUERY(" + query + ")")));
-
-		}
-
 		private MultiMapProperties queryToProperties(@Nullable String query, String description) {
 			Map<String, List<String>> multiMap;
 			if (query == null) {
@@ -833,19 +821,6 @@ public interface LogProperties {
 		 * @return this.
 		 */
 		MutableLogProperties put(String key, @Nullable String value);
-
-		/**
-		 * Copy java.util {@link Properties} String useful for unit testing.
-		 * @param content string in {@link Properties} format (tip use multiline strings).
-		 * @return this.
-		 */
-		default MutableLogProperties copyProperties(String content) {
-			var m = PropertiesParser.readProperties(content);
-			for (var e : m.entrySet()) {
-				put(e.getKey(), e.getKey());
-			}
-			return this;
-		}
 
 		/**
 		 * Builder for MutableLogProperties.

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -874,17 +874,6 @@ public sealed interface LogProperty {
 		}
 
 		/**
-		 * Adds a fallback paramter that will be used on all keys.
-		 * @param name parameter name.
-		 * @param value value of parameter.
-		 * @return this
-		 */
-		public B addFallbackParam(String name, String value) {
-			params.put(name, value);
-			return self();
-		}
-
-		/**
 		 * Adds a key with a <code>{name}</code> parameter.
 		 * @param key key to be interpolated.
 		 * @param name name.
@@ -1536,10 +1525,6 @@ record DefaultProperty<T>(PropertyGetter<T> propertyGetter, List<String> keys) i
 			consumer.accept(key(), value);
 		}
 	}
-
-}
-
-enum NoProperty implements LogProperty {
 
 }
 

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertiesTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertiesTest.java
@@ -1,7 +1,6 @@
 package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.SequencedMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -328,7 +326,10 @@ class LogPropertiesTest {
 	@Test
 	void testStringPropertyOrNull() {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "v1");
-		var found = Objects.requireNonNull(props.stringPropertyOrNull("logging.p1"));
+		var found = props.stringPropertyOrNull("logging.p1");
+		if (found == null) {
+			throw new AssertionError();
+		}
 		assertEquals("v1", found.value());
 		assertEquals("logging.p1", found.key());
 		assertNull(props.stringPropertyOrNull("logging.missing"));
@@ -338,19 +339,31 @@ class LogPropertiesTest {
 	@ValueSource(strings = { "password", "PASSWORD", "apikey", "secret", "token" })
 	void testStringPropertyValueDescriptionRedactsExactMatch(String value) {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", value);
-		assertEquals("<REDACTED>", Objects.requireNonNull(props.stringPropertyOrNull("logging.p1")).valueDescription());
+		var found = props.stringPropertyOrNull("logging.p1");
+		if (found == null) {
+			throw new AssertionError();
+		}
+		assertEquals("<REDACTED>", found.valueDescription());
 	}
 
 	@Test
 	void testStringPropertyValueDescriptionRedactsSubstringMatch() {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "my-password-123");
-		assertEquals("<REDACTED>", Objects.requireNonNull(props.stringPropertyOrNull("logging.p1")).valueDescription());
+		var found = props.stringPropertyOrNull("logging.p1");
+		if (found == null) {
+			throw new AssertionError();
+		}
+		assertEquals("<REDACTED>", found.valueDescription());
 	}
 
 	@Test
 	void testStringPropertyValueDescriptionPassesThroughOrdinaryValues() {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "hello");
-		assertEquals("hello", Objects.requireNonNull(props.stringPropertyOrNull("logging.p1")).valueDescription());
+		var found = props.stringPropertyOrNull("logging.p1");
+		if (found == null) {
+			throw new AssertionError();
+		}
+		assertEquals("hello", found.valueDescription());
 	}
 
 	@Test
@@ -358,7 +371,11 @@ class LogPropertiesTest {
 		var props = LogProperties.builder().fromProperties("""
 				logging.a=x,y
 				""").build();
-		assertEquals("[x, y]", Objects.requireNonNull(props.listPropertyOrNull("logging.a")).valueDescription());
+		var found = props.listPropertyOrNull("logging.a");
+		if (found == null) {
+			throw new AssertionError();
+		}
+		assertEquals("[x, y]", found.valueDescription());
 	}
 
 	@Test
@@ -366,7 +383,11 @@ class LogPropertiesTest {
 		var props = LogProperties.builder().fromProperties("""
 				logging.a=k=v
 				""").build();
-		assertEquals("{k=v}", Objects.requireNonNull(props.mapPropertyOrNull("logging.a")).valueDescription());
+		var found = props.mapPropertyOrNull("logging.a");
+		if (found == null) {
+			throw new AssertionError();
+		}
+		assertEquals("{k=v}", found.valueDescription());
 	}
 
 	@Test
@@ -523,8 +544,12 @@ class LogPropertiesTest {
 				logging.a=k=v
 				""").build();
 		var composite = LogProperties.of(List.of(a, b));
-		assertNotNull(composite.stringPropertyOrNull("logging.a"));
-		assertNotNull(composite.mapPropertyOrNull("logging.a"));
+		if (composite.stringPropertyOrNull("logging.a") == null) {
+			throw new AssertionError();
+		}
+		if (composite.mapPropertyOrNull("logging.a") == null) {
+			throw new AssertionError();
+		}
 		assertNull(composite.mapPropertyOrNull("logging.missing"));
 	}
 

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertiesTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertiesTest.java
@@ -1,7 +1,11 @@
 package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
@@ -10,19 +14,39 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedMap;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.jstach.rainbowgum.LogProperties.MutableLogProperties;
 import io.jstach.rainbowgum.LogProperty.Property;
 import io.jstach.rainbowgum.LogProperty.PropertyMissingException;
 
 class LogPropertiesTest {
+
+	/*
+	 * RainbowGumHolder is static, JVM-wide state (see RainbowGumEntryPointTest's own
+	 * comment on this) - reset it around the findGlobalProperties() tests below so they
+	 * do not depend on whatever other tests in this JVM fork left behind.
+	 */
+	@BeforeEach
+	void beforeEachClearGlobalRainbowGum() {
+		RainbowGumHolder.remove(null);
+	}
+
+	@AfterEach
+	void afterEachClearGlobalRainbowGum() {
+		RainbowGumHolder.remove(null);
+	}
 
 	@Test
 	void testStaticPropertiesDescription() {
@@ -282,6 +306,244 @@ class LogPropertiesTest {
 			this.expected = Map.of("a", values);
 		}
 
+	}
+
+	@Test
+	void testValueFallback() {
+		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "actual");
+		assertEquals("actual", props.value("logging.p1", "fallback"));
+		assertEquals("fallback", props.value("logging.missing", "fallback"));
+	}
+
+	@Test
+	void testMapOrNullDefaultUsesParseMap() {
+		var props = LogProperties.builder().fromProperties("""
+				logging.a=k1=v1,k2=v2
+				""").build();
+		assertEquals(Map.of("k1", "v1", "k2", "v2"), props.mapOrNull("logging.a"));
+		assertNull(props.mapOrNull("logging.missing"));
+	}
+
+	@Test
+	void testStringPropertyOrNull() {
+		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "v1");
+		var found = props.stringPropertyOrNull("logging.p1");
+		assertEquals("v1", found.value());
+		assertEquals("logging.p1", found.key());
+		assertNull(props.stringPropertyOrNull("logging.missing"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "password", "PASSWORD", "apikey", "secret", "token" })
+	void testStringPropertyValueDescriptionRedactsExactMatch(String value) {
+		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", value);
+		assertEquals("<REDACTED>", props.stringPropertyOrNull("logging.p1").valueDescription());
+	}
+
+	@Test
+	void testStringPropertyValueDescriptionRedactsSubstringMatch() {
+		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "my-password-123");
+		assertEquals("<REDACTED>", props.stringPropertyOrNull("logging.p1").valueDescription());
+	}
+
+	@Test
+	void testStringPropertyValueDescriptionPassesThroughOrdinaryValues() {
+		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "hello");
+		assertEquals("hello", props.stringPropertyOrNull("logging.p1").valueDescription());
+	}
+
+	@Test
+	void testListPropertyValueDescription() {
+		var props = LogProperties.builder().fromProperties("""
+				logging.a=x,y
+				""").build();
+		assertEquals("[x, y]", props.listPropertyOrNull("logging.a").valueDescription());
+	}
+
+	@Test
+	void testMapPropertyValueDescription() {
+		var props = LogProperties.builder().fromProperties("""
+				logging.a=k=v
+				""").build();
+		assertEquals("{k=v}", props.mapPropertyOrNull("logging.a").valueDescription());
+	}
+
+	@Test
+	void testBuilderFromAlreadySetThrows() {
+		var builder = LogProperties.builder().fromProperties("logging.a=1\n");
+		var e = assertThrows(IllegalArgumentException.class, () -> builder.fromProperties("logging.b=2\n"));
+		assertEquals("from already set", e.getMessage());
+	}
+
+	@Test
+	void testFromPropertiesKeepsExplicitDescription() {
+		var props = LogProperties.builder().description("custom").fromProperties("logging.a=1\n").build();
+		assertEquals("custom[logging.a]", props.description("logging.a"));
+	}
+
+	@Test
+	void testFromPropertiesDefaultsDescriptionWhenNoneSet() {
+		var props = LogProperties.builder().fromProperties("logging.a=1\n").build();
+		assertEquals("PROPERTIES_STRING[logging.a]", props.description("logging.a"));
+	}
+
+	@Test
+	void testBuilderBuildWithoutFromUsesSoleFallback() {
+		var fallback = LogProperties.MutableLogProperties.builder().build().put("logging.a", "1");
+		var props = LogProperties.builder().with(fallback).build();
+		assertSame(fallback, props);
+	}
+
+	@Test
+	void testBuilderBuildWithoutFromOrFallbacksThrows() {
+		var e = assertThrows(IllegalStateException.class, () -> LogProperties.builder().build());
+		assertEquals("from was not set", e.getMessage());
+	}
+
+	@Test
+	void testMutableLogPropertiesPutNullRemovesKey() {
+		var props = LogProperties.MutableLogProperties.builder().build();
+		props.put("logging.a", "1");
+		assertEquals("1", props.valueOrNull("logging.a"));
+		props.put("logging.a", null);
+		assertNull(props.valueOrNull("logging.a"));
+	}
+
+	@Test
+	void testFindGlobalPropertiesFallsBackToSystemPropertiesWhenNoneBound() {
+		assertSame(LogProperties.StandardProperties.SYSTEM_PROPERTIES, LogProperties.findGlobalProperties());
+	}
+
+	@Test
+	void testFindGlobalPropertiesFallsBackToSuppliedFallbackWhenNoneBound() {
+		var fallback = LogProperties.MutableLogProperties.builder().build();
+		assertSame(fallback, LogProperties.findGlobalProperties(() -> fallback));
+	}
+
+	@Test
+	void testFindGlobalPropertiesUsesBoundRainbowGum() {
+		var boundProps = LogProperties.MutableLogProperties.builder().build().put("marker", "yes");
+		var config = LogConfig.builder().properties(boundProps).build();
+		try (var gum = RainbowGum.builder(config).set()) {
+			assertSame(boundProps, LogProperties.findGlobalProperties());
+		}
+	}
+
+	@Test
+	void testOfSingleElementListReturnsThatElement() {
+		var props = LogProperties.MutableLogProperties.builder().build();
+		assertSame(props, LogProperties.of(List.of(props)));
+	}
+
+	@Test
+	void testOfFiltersEmptyPropertiesOutOfComposite() {
+		var a = LogProperties.MutableLogProperties.builder().build().put("logging.a", "1");
+		var b = LogProperties.MutableLogProperties.builder().build().put("logging.b", "2");
+		var combined = LogProperties.of(List.of(LogProperties.StandardProperties.EMPTY, a, b));
+		assertEquals("1", combined.valueOrNull("logging.a"));
+		assertEquals("2", combined.valueOrNull("logging.b"));
+		assertTrue(combined.toString().startsWith("CompositeLogProperties[properties="));
+	}
+
+	@Test
+	void testParseMapDirectly() {
+		assertEquals(Map.of("a", "v1"), LogProperties.parseMap("a=v1&b"));
+		assertEquals(Map.of("a", "v1", "b", ""), LogProperties.parseMap("a=v1&b="));
+	}
+
+	@Test
+	void testParseMapSkipsPairStartingWithEquals() {
+		assertEquals(Map.of("a", "v1"), LogProperties.parseMap("=foo&a=v1"));
+	}
+
+	@Test
+	void testParseMapDecodesPercentEncodedValues() {
+		assertEquals(Map.of("a", "b c"), LogProperties.parseMap("a=b%20c"));
+	}
+
+	@Test
+	void testConcatKeySingleArgPrefixesRoot() {
+		assertEquals("logging.foo", LogProperties.concatKey("foo"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "'', foo, foo", "root, '', root", "'a.', b, a.b", "a, .b, a.b", "a, b, a.b" })
+	void testConcatKeyTwoArgBranches(String prefix, String name, String expected) {
+		assertEquals(expected, LogProperties.concatKey(prefix, name));
+	}
+
+	@Test
+	void testInterpolateKeyThrowsWhenLookupMissesAParameter() {
+		assertThrows(IllegalArgumentException.class, () -> LogProperties.interpolateKey("a.{name}.b", k -> null));
+	}
+
+	@Test
+	void testValidateKeyParametersThrowsOnMismatch() {
+		assertThrows(IllegalArgumentException.class, () -> LogProperties.validateKeyParameters("a.{name}", Set.of()));
+	}
+
+	@Test
+	void testMultiMapPropertiesValueOrNullTreatsKeyWithNoValuesAsMissing() {
+		var props = LogProperties.builder().fromURIQuery(URI.create("stuff:///?a&b=v1")).build();
+		assertNull(props.valueOrNull("a"));
+		assertEquals("v1", props.valueOrNull("b"));
+	}
+
+	@Test
+	void testMultiMapPropertiesListOrNullReturnsRawList() {
+		var props = LogProperties.builder().fromURIQuery(URI.create("stuff:///?a=1&a=2")).build();
+		assertEquals(List.of("1", "2"), props.listOrNull("a"));
+		assertNull(props.listOrNull("missing"));
+	}
+
+	@Test
+	void testMultiMapPropertiesMapOrNullSkipsUnrelatedAndValuelessKeys() {
+		var props = LogProperties.builder()
+			.fromURIQuery(URI.create("stuff:///?a.a1=v1&a.a2&unrelated=v2&a.=direct"))
+			.build();
+		Map<String, String> actual = props.mapOrNull("a");
+		assertEquals(Map.of("a1", "v1"), actual);
+	}
+
+	@Test
+	void testListLogPropertiesValueOrNullSearchesInOrderAndDescriptionJoinsAll() {
+		var a = LogProperties.MutableLogProperties.builder().description("A").build().put("logging.a", "fromA");
+		var b = LogProperties.MutableLogProperties.builder().description("B").build().put("logging.b", "fromB");
+		var composite = LogProperties.of(List.of(a, b));
+		assertEquals("fromA", composite.valueOrNull("logging.a"));
+		assertEquals("fromB", composite.valueOrNull("logging.b"));
+		assertNull(composite.valueOrNull("logging.missing"));
+	}
+
+	@Test
+	void testListLogPropertiesStringAndMapPropertyOrNullSearchInOrder() {
+		var a = LogProperties.MutableLogProperties.builder().build();
+		var b = LogProperties.builder().fromProperties("""
+				logging.a=k=v
+				""").build();
+		var composite = LogProperties.of(List.of(a, b));
+		assertNotNull(composite.stringPropertyOrNull("logging.a"));
+		assertNotNull(composite.mapPropertyOrNull("logging.a"));
+		assertNull(composite.mapPropertyOrNull("logging.missing"));
+	}
+
+	@Test
+	void testCompositeMutableLogPropertiesPutDelegatesToFirstMutableMemberNotItself() {
+		var fallback = LogProperties.MutableLogProperties.builder().build().put("logging.existing", "keep");
+		var composite = LogProperties.MutableLogProperties.builder().with(fallback).build();
+		composite.put("logging.a", "1");
+		assertEquals("1", composite.valueOrNull("logging.a"));
+		assertEquals("keep", composite.valueOrNull("logging.existing"));
+		assertTrue(composite.toString().startsWith("CompositeMutableLogProperties[properties="));
+	}
+
+	@Test
+	void testCompositeMutableLogPropertiesPutSkipsNonMutableMembers() {
+		var composite = LogProperties.MutableLogProperties.builder()
+			.with(LogProperties.StandardProperties.SYSTEM_PROPERTIES)
+			.build();
+		composite.put("logging.testCompositeSkipsNonMutable", "1");
+		assertEquals("1", composite.valueOrNull("logging.testCompositeSkipsNonMutable"));
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertiesTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertiesTest.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SequencedMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -327,7 +328,7 @@ class LogPropertiesTest {
 	@Test
 	void testStringPropertyOrNull() {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "v1");
-		var found = props.stringPropertyOrNull("logging.p1");
+		var found = Objects.requireNonNull(props.stringPropertyOrNull("logging.p1"));
 		assertEquals("v1", found.value());
 		assertEquals("logging.p1", found.key());
 		assertNull(props.stringPropertyOrNull("logging.missing"));
@@ -337,19 +338,19 @@ class LogPropertiesTest {
 	@ValueSource(strings = { "password", "PASSWORD", "apikey", "secret", "token" })
 	void testStringPropertyValueDescriptionRedactsExactMatch(String value) {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", value);
-		assertEquals("<REDACTED>", props.stringPropertyOrNull("logging.p1").valueDescription());
+		assertEquals("<REDACTED>", Objects.requireNonNull(props.stringPropertyOrNull("logging.p1")).valueDescription());
 	}
 
 	@Test
 	void testStringPropertyValueDescriptionRedactsSubstringMatch() {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "my-password-123");
-		assertEquals("<REDACTED>", props.stringPropertyOrNull("logging.p1").valueDescription());
+		assertEquals("<REDACTED>", Objects.requireNonNull(props.stringPropertyOrNull("logging.p1")).valueDescription());
 	}
 
 	@Test
 	void testStringPropertyValueDescriptionPassesThroughOrdinaryValues() {
 		var props = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "hello");
-		assertEquals("hello", props.stringPropertyOrNull("logging.p1").valueDescription());
+		assertEquals("hello", Objects.requireNonNull(props.stringPropertyOrNull("logging.p1")).valueDescription());
 	}
 
 	@Test
@@ -357,7 +358,7 @@ class LogPropertiesTest {
 		var props = LogProperties.builder().fromProperties("""
 				logging.a=x,y
 				""").build();
-		assertEquals("[x, y]", props.listPropertyOrNull("logging.a").valueDescription());
+		assertEquals("[x, y]", Objects.requireNonNull(props.listPropertyOrNull("logging.a")).valueDescription());
 	}
 
 	@Test
@@ -365,7 +366,7 @@ class LogPropertiesTest {
 		var props = LogProperties.builder().fromProperties("""
 				logging.a=k=v
 				""").build();
-		assertEquals("{k=v}", props.mapPropertyOrNull("logging.a").valueDescription());
+		assertEquals("{k=v}", Objects.requireNonNull(props.mapPropertyOrNull("logging.a")).valueDescription());
 	}
 
 	@Test

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -11,7 +11,6 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -293,6 +292,7 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testFallbackGetterFallbackReturningNullProducesError() {
 		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
 		var getter = LogProperty.builder().orElseGet(() -> null);
@@ -348,6 +348,7 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testMapGetterPropertyStringHandlesMultipleEntriesAndNullValues() {
 		var map = new LinkedHashMap<String, String>();
 		map.put("a", "1");
@@ -443,7 +444,11 @@ class LogPropertyTest {
 		});
 		Result<String> result = getter.build("logging.p1").get(properties);
 		var e = assertThrows(PropertyConvertException.class, result::value);
-		assertTrue(Objects.requireNonNull(e.getMessage()).contains("Error converting property"));
+		var message = e.getMessage();
+		if (message == null) {
+			throw new AssertionError();
+		}
+		assertTrue(message.contains("Error converting property"));
 	}
 
 	@Test

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -118,6 +119,7 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testValueSuccessRejectsNullValueAndMap() {
 		assertThrows(NullPointerException.class, () -> new ValueSuccess<String>("key", null));
 		var success = new ValueSuccess<>("key", "5");
@@ -133,6 +135,7 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testPropertySuccessRejectsNullValueAndMap() {
 		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "5");
 		var found = new StringProperty(properties, "logging.p1", "5");
@@ -173,7 +176,7 @@ class LogPropertyTest {
 	void testErrorAlwaysThrowsOnValueAccessAndOrReturnsThis() {
 		var cause = new NumberFormatException("nope");
 		Error<String> error = new Error<>("key", "bad value", cause);
-		assertThrows(PropertyConvertException.class, error::valueOrNull);
+		assertThrows(PropertyConvertException.class, () -> error.valueOrNull());
 		assertThrows(PropertyConvertException.class, error::value);
 		assertThrows(PropertyConvertException.class, () -> error.value(() -> "fallback"));
 		assertEquals(error, error.or("fallback"));
@@ -262,6 +265,7 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testChildPropertyGetterDefaultPropertyStringBranches() {
 		var root = LogProperty.builder();
 
@@ -297,12 +301,14 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testOrElseNullFallbackThrows() {
 		var getter = LogProperty.builder();
 		assertThrows(NullPointerException.class, () -> getter.orElse(null));
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testResultFuncGetterNullMapperResultBecomesMissing() {
 		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "value");
 		var getter = LogProperty.builder().<String>map(s -> null);
@@ -437,7 +443,7 @@ class LogPropertyTest {
 		});
 		Result<String> result = getter.build("logging.p1").get(properties);
 		var e = assertThrows(PropertyConvertException.class, result::value);
-		assertTrue(e.getMessage().contains("Error converting property"));
+		assertTrue(Objects.requireNonNull(e.getMessage()).contains("Error converting property"));
 	}
 
 	@Test
@@ -447,6 +453,7 @@ class LogPropertyTest {
 	}
 
 	@Test
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testDefaultPropertySetOnlyCallsConsumerWhenValueNonNull() {
 		var property = Property.builder().build("logging.p1");
 		Map<String, String> captured = new LinkedHashMap<>();

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -1,14 +1,34 @@
 package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.jstach.rainbowgum.LogProperties.FoundProperty.StringProperty;
+import io.jstach.rainbowgum.LogProperty.Property;
+import io.jstach.rainbowgum.LogProperty.PropertyConvertException;
+import io.jstach.rainbowgum.LogProperty.PropertyFunction;
+import io.jstach.rainbowgum.LogProperty.PropertyMissingException;
+import io.jstach.rainbowgum.LogProperty.PropertySupport;
 import io.jstach.rainbowgum.LogProperty.Result;
+import io.jstach.rainbowgum.LogProperty.Result.Error;
+import io.jstach.rainbowgum.LogProperty.Result.Missing;
+import io.jstach.rainbowgum.LogProperty.Result.Success;
+import io.jstach.rainbowgum.LogProperty.Result.Success.PropertySuccess;
+import io.jstach.rainbowgum.LogProperty.Result.Success.ValueSuccess;
 import io.jstach.rainbowgum.LogProperty.ValidationException;
+import io.jstach.rainbowgum.LogProperty.Validator;
 
 class LogPropertyTest {
 
@@ -46,6 +66,402 @@ class LogPropertyTest {
 				Tried: 'logging.p1' from custom mutable[p1]
 				Property missing. keys: ['logging.p2' from custom mutable[p2]]""";
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testValidatorAddIfErrorIgnoresMissingButKeepsError() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.removeKeyPrefix(LogProperties.ROOT_PREFIX)
+			.build()
+			.put("p1", "notanumber");
+		var b = LogProperty.builder().withPrefix(LogProperties.ROOT_PREFIX);
+		Result<Integer> missing = b.ofInt().build("missingKey").get(properties);
+		Result<Integer> error = b.ofInt().build("p1").get(properties);
+		var validator = Validator.of(LogPropertyTest.class);
+		validator.addIfError(missing);
+		validator.addIfError(error);
+		assertThrows(ValidationException.class, validator::validate);
+
+		var validator2 = Validator.of(LogPropertyTest.class);
+		validator2.addIfError(missing);
+		validator2.validate();
+	}
+
+	@Test
+	void testPropertyFunctionSneakyThrowsCheckedException() {
+		PropertyFunction<String, String, IOException> f = new PropertyFunction<>() {
+			@Override
+			public String _apply(String t) throws IOException {
+				throw new IOException("boom");
+			}
+		};
+		var e = assertThrows(IOException.class, () -> f.apply("x"));
+		assertEquals("boom", e.getMessage());
+	}
+
+	@Test
+	void testPropertySupportValue() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.removeKeyPrefix(LogProperties.ROOT_PREFIX)
+			.build()
+			.put("p1", "v1");
+		Property<String> property = Property.builder().withPrefix(LogProperties.ROOT_PREFIX).build("p1");
+		PropertySupport support = () -> properties;
+		assertEquals("v1", support.value(property));
+	}
+
+	@Test
+	void testPropertyConvertExceptionKey() {
+		var e = new PropertyConvertException("logging.p1", "bad conversion", null);
+		assertEquals("logging.p1", e.key());
+		assertEquals("bad conversion", e.getMessage());
+	}
+
+	@Test
+	void testValueSuccessRejectsNullValueAndMap() {
+		assertThrows(NullPointerException.class, () -> new ValueSuccess<String>("key", null));
+		var success = new ValueSuccess<>("key", "5");
+		assertEquals("key", success.key());
+		assertEquals("Fallback[key]=5", success.describe());
+		Result<Integer> mapped = success.map(Integer::parseInt);
+		assertEquals(5, mapped.value());
+
+		Result<Integer> errored = success.map(s -> {
+			throw new NumberFormatException("nope");
+		});
+		assertTrue(errored instanceof Error<?>);
+	}
+
+	@Test
+	void testPropertySuccessRejectsNullValueAndMap() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "5");
+		var found = new StringProperty(properties, "logging.p1", "5");
+		assertThrows(NullPointerException.class, () -> new PropertySuccess<String>(found, null));
+		var success = new PropertySuccess<>(found, "5");
+		assertEquals("logging.p1", success.key());
+		assertEquals("Property[logging.p1]=5", success.describe());
+		Result<Integer> mapped = success.map(Integer::parseInt);
+		assertEquals(5, mapped.value());
+
+		Result<Integer> errored = success.map(s -> {
+			throw new NumberFormatException("nope");
+		});
+		assertTrue(errored instanceof Error<?>);
+	}
+
+	@Test
+	void testMissingRejectsEmptyKeys() {
+		assertThrows(IllegalArgumentException.class, () -> new Missing<String>(List.of(), "message"));
+	}
+
+	@Test
+	void testMissingValueWithFallbackSupplier() {
+		Missing<String> missing = new Missing<>(List.of("key"), "Property missing. keys: [key]");
+		assertEquals("fallback", missing.value(() -> "fallback"));
+		assertThrows(PropertyMissingException.class, () -> missing.value(() -> null));
+	}
+
+	@Test
+	void testMissingConvertAndDescribe() {
+		Missing<String> missing = new Missing<>(List.of("key"), "Property missing. keys: [key]");
+		Missing<Integer> converted = missing.convert();
+		assertEquals("Missing[[key]]", converted.describe());
+		assertEquals(missing, missing.map(Integer::parseInt));
+	}
+
+	@Test
+	void testErrorAlwaysThrowsOnValueAccessAndOrReturnsThis() {
+		var cause = new NumberFormatException("nope");
+		Error<String> error = new Error<>("key", "bad value", cause);
+		assertThrows(PropertyConvertException.class, error::valueOrNull);
+		assertThrows(PropertyConvertException.class, error::value);
+		assertThrows(PropertyConvertException.class, () -> error.value(() -> "fallback"));
+		assertEquals(error, error.or("fallback"));
+		assertEquals(error, error.or(() -> "fallback"));
+		assertEquals("Error[key](bad value)", error.describe());
+		Error<Integer> converted = error.convert();
+		assertEquals(error.key(), converted.key());
+		assertEquals(error, error.map(Integer::parseInt));
+	}
+
+	@Test
+	void testResultValueOrNullWithFallback() {
+		Result<String> success = new ValueSuccess<>("key", "actual");
+		assertEquals("actual", success.valueOrNull("fallback"));
+		Result<String> missing = new Missing<>(List.of("key"), "missing");
+		assertEquals("fallback", missing.valueOrNull("fallback"));
+	}
+
+	@Test
+	void testResultValueWithFallbackObject() {
+		Result<String> missing = new Missing<>(List.of("key"), "missing");
+		assertEquals("fallback", missing.value("fallback"));
+		assertThrows(PropertyMissingException.class, () -> missing.value((String) null));
+	}
+
+	@Test
+	void testResultOptional() {
+		Result<String> success = new ValueSuccess<>("key", "actual");
+		assertEquals(Optional.of("actual"), success.optional());
+		Result<String> missing = new Missing<>(List.of("key"), "missing");
+		assertEquals(Optional.empty(), missing.optional());
+	}
+
+	@Test
+	void testPropertyRequire() {
+		Property<String> property = Property.builder().build("logging.p1");
+		assertEquals("x", property.require("x"));
+		assertThrows(PropertyMissingException.class, () -> property.require(null));
+	}
+
+	@Test
+	void testPropertyValueOverride() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.removeKeyPrefix(LogProperties.ROOT_PREFIX)
+			.build()
+			.put("p1", "actual");
+		Property<String> property = Property.builder().withPrefix(LogProperties.ROOT_PREFIX).build("p1");
+		var bound = property.bind(properties);
+		assertEquals("replacement", bound.override("replacement"));
+		assertEquals("actual", bound.override(null));
+	}
+
+	@Test
+	void testDefaultPropertyValueOrAndMapAndToString() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.removeKeyPrefix(LogProperties.ROOT_PREFIX)
+			.build();
+		Property<String> property = Property.builder().withPrefix(LogProperties.ROOT_PREFIX).build("missing");
+		var bound = property.bind(properties);
+		assertTrue(bound.toString().startsWith("PropertyValue.memoize("));
+		assertEquals("fallback", bound.or("fallback").value());
+		assertEquals("fallback2", bound.or(() -> "fallback2").value());
+		assertThrows(PropertyConvertException.class, () -> bound.or("notanumber").map(Integer::parseInt).value());
+	}
+
+	@Test
+	void testRootPropertyGetterWithSearchAndWithPrefix() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.a.b.c", "deep");
+		var search = LogProperty.builder().withSearch("");
+		Property<String> property = search.build("logging.a.b.c.d.e");
+		assertEquals("deep", property.get(properties).value());
+
+		var prefixed = LogProperty.builder().withPrefix("logging.a.b");
+		Property<String> direct = prefixed.build("c");
+		assertEquals("deep", direct.get(properties).value());
+	}
+
+	@Test
+	void testOfProviderRef() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.out", "console:///?stuff=1");
+		var getter = LogProperty.builder().ofProviderRef();
+		var ref = getter.build("logging.out").get(properties).value();
+		assertEquals(URI.create("console:///?stuff=1"), ref.uri());
+	}
+
+	@Test
+	void testChildPropertyGetterDefaultPropertyStringBranches() {
+		var root = LogProperty.builder();
+
+		var stringGetter = root.<String>map(s -> s);
+		assertEquals("hello", stringGetter.propertyString("hello"));
+
+		var boolGetter = root.map(Boolean::parseBoolean);
+		assertEquals("true", boolGetter.propertyString(true));
+
+		var intGetter = root.map(Integer::parseInt);
+		assertEquals("5", intGetter.propertyString(5));
+
+		var uriGetter = root.map(URI::new);
+		assertEquals("http://x", uriGetter.propertyString(URI.create("http://x")));
+
+		var mapGetter = root.map(s -> Map.of("a", "b"));
+		assertEquals("a=b", mapGetter.propertyString(Map.of("a", "b")));
+
+		var listGetter = root.map(s -> List.of("a", "b"));
+		assertEquals("a,b", listGetter.propertyString(List.of("a", "b")));
+
+		var objectGetter = root.map(s -> new Object());
+		assertThrows(RuntimeException.class, () -> objectGetter.propertyString(new Object()));
+		assertThrows(NullPointerException.class, () -> objectGetter.propertyString(null));
+	}
+
+	@Test
+	void testFallbackGetterFallbackReturningNullProducesError() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
+		var getter = LogProperty.builder().orElseGet(() -> null);
+		Result<String> result = getter.build("logging.missing").get(properties);
+		assertTrue(result instanceof Error<?>);
+	}
+
+	@Test
+	void testOrElseNullFallbackThrows() {
+		var getter = LogProperty.builder();
+		assertThrows(NullPointerException.class, () -> getter.orElse(null));
+	}
+
+	@Test
+	void testResultFuncGetterNullMapperResultBecomesMissing() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "value");
+		var getter = LogProperty.builder().<String>map(s -> null);
+		Result<String> result = getter.build("logging.p1").get(properties);
+		assertFalse(result instanceof Success<?>);
+	}
+
+	@Test
+	void testPropertyKeyBuilderProviderInterpolatesName() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.output.myname.value", "hello");
+		var provider = LogProperty.builder().withKey("logging.output.{name}.value").provider(v -> (n, c) -> v);
+		var config = LogConfig.builder().properties(properties).build();
+		String actual = provider.provide("myname", config);
+		assertEquals("hello", actual);
+	}
+
+	@Test
+	void testFallbackGetterPassesThroughSuccessAndError() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "5");
+		var intGetter = LogProperty.builder().ofInt();
+		Result<Integer> success = intGetter.orElse(99).build("logging.p1").get(properties);
+		assertEquals(5, success.value());
+
+		var bad = LogProperties.MutableLogProperties.builder().build().put("logging.p2", "notanumber");
+		Result<Integer> error = intGetter.orElse(99).build("logging.p2").get(bad);
+		assertThrows(PropertyConvertException.class, error::value);
+	}
+
+	@Test
+	void testFallbackGetterMissingUsesFallbackValueAndDelegatesPropertyString() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
+		var getter = LogProperty.builder().orElse("fallback");
+		assertEquals("fallback", getter.build("logging.missing").get(properties).value());
+		assertEquals("fallback", getter.propertyString("fallback"));
+	}
+
+	@Test
+	void testMapGetterPropertyStringHandlesMultipleEntriesAndNullValues() {
+		var map = new LinkedHashMap<String, String>();
+		map.put("a", "1");
+		map.put("b", null);
+		map.put("c", "3");
+		assertEquals("a=1&b&c=3", MapGetter._propertyString(map));
+	}
+
+	@Test
+	void testMapGetterInstancePropertyStringDelegatesToStatic() {
+		var getter = LogProperty.builder().ofMap();
+		assertEquals("a=1", getter.propertyString(Map.of("a", "1")));
+	}
+
+	@Test
+	void testListGetterInstancePropertyStringDelegatesToStatic() {
+		var getter = LogProperty.builder().ofList();
+		assertEquals("a,b", getter.propertyString(List.of("a", "b")));
+	}
+
+	@Test
+	void testResultFuncGetterPassesThroughParentError() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "notanumber");
+		var doubleMapped = LogProperty.builder().ofInt().map(i -> i * 2);
+		Result<Integer> result = doubleMapped.build("logging.p1").get(properties);
+		assertThrows(PropertyConvertException.class, result::value);
+	}
+
+	@Test
+	void testResultGetReturnsItself() {
+		Result<String> success = new ValueSuccess<>("key", "value");
+		assertSame(success, success.get());
+	}
+
+	@Test
+	void testValidateKeyRejectsTrailingDot() {
+		assertThrows(IllegalArgumentException.class, () -> Property.builder().build("logging."));
+	}
+
+	@Test
+	void testEmptyStandardPropertiesHasNegativeOrder() {
+		assertEquals(-1, LogProperties.StandardProperties.EMPTY.order());
+	}
+
+	@Test
+	void testSearchPropertyGetterWithPrefixCreatesANewSearchGetterWithThatPrefix() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.other.a.b", "deep");
+		var search = LogProperty.builder().withSearch("");
+		var reprefixed = search.withPrefix("");
+		assertEquals("deep", reprefixed.build("logging.other.a.b.c.d").get(properties).value());
+	}
+
+	@Test
+	void testConvertSuccessPreservesValueSuccessVariant() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
+		var getter = LogProperty.builder().orElse("5").map(Integer::parseInt);
+		Result<Integer> result = getter.build("logging.missing").get(properties);
+		assertEquals(5, result.value());
+		assertTrue(result instanceof Success.ValueSuccess<?>);
+	}
+
+	@Test
+	void testOfListMissingProducesMissingResult() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
+		Result<List<String>> result = LogProperty.builder().ofList().build("logging.missing").get(properties);
+		assertTrue(result instanceof Missing<?>);
+	}
+
+	@Test
+	void testOfMapMissingProducesMissingResult() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
+		Result<Map<String, String>> result = LogProperty.builder().ofMap().build("logging.missing").get(properties);
+		assertTrue(result instanceof Missing<?>);
+	}
+
+	@Test
+	void testMapperThrowingOnFallbackValueSuccessUsesTwoArgErrorResult() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder().build();
+		var getter = LogProperty.builder().orElse("bad").<Integer>map(s -> {
+			throw new NumberFormatException("nope");
+		});
+		Result<Integer> result = getter.build("logging.missing").get(properties);
+		assertThrows(PropertyConvertException.class, result::value);
+	}
+
+	@Test
+	void testMapperThrowingPropertyConvertExceptionOnFoundValueUsesSpecialMessage() {
+		var properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "raw");
+		var getter = LogProperty.builder().<String>map(s -> {
+			throw new PropertyConvertException("logging.p1", "custom failure", null);
+		});
+		Result<String> result = getter.build("logging.p1").get(properties);
+		var e = assertThrows(PropertyConvertException.class, result::value);
+		assertTrue(e.getMessage().contains("Error converting property"));
+	}
+
+	@Test
+	void testDefaultPropertyPropertyStringDelegatesToGetter() {
+		var property = Property.builder().build("logging.p1");
+		assertEquals("hello", property.propertyString("hello"));
+	}
+
+	@Test
+	void testDefaultPropertySetOnlyCallsConsumerWhenValueNonNull() {
+		var property = Property.builder().build("logging.p1");
+		Map<String, String> captured = new LinkedHashMap<>();
+		property.set("value", captured::put);
+		assertEquals(Map.of("logging.p1", "value"), captured);
+
+		captured.clear();
+		property.set(null, captured::put);
+		assertTrue(captured.isEmpty());
+	}
+
+	@Test
+	void testDefaultPropertyRejectsEmptyKeys() {
+		var getter = LogProperty.builder();
+		assertThrows(IllegalArgumentException.class, () -> new DefaultProperty<>(getter, List.of()));
 	}
 
 }

--- a/etc/eea/checker/java.base/Objects.astub
+++ b/etc/eea/checker/java.base/Objects.astub
@@ -1,0 +1,12 @@
+package java.util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class Objects {
+  public static <T> @NonNull T requireNonNull(@Nullable T obj);
+  public static <T> @NonNull T requireNonNull(@Nullable T obj, @Nullable String message);
+  public static <T> @NonNull T requireNonNull(@Nullable T obj, java.util.function.Supplier<@Nullable String> messageSupplier);
+  public static boolean isNull(@Nullable Object obj);
+  public static boolean nonNull(@Nullable Object obj);
+}


### PR DESCRIPTION
…onomic methods

Removes four unused API surfaces found while chasing coverage - each was uncovered AND had zero callers anywhere in the repo:
- MutableLogProperties.copyProperties(String) - a dead sibling of Builder.copyProperties that also had a real bug (put(key, key) instead of put(key, value), which would have been caught immediately by any caller or test).
- Builder.fromURIQuery(String) - every call site (repo-wide) went through the URI overload instead.
- AbstractKeysBuilder.addFallbackParam(String, String) - no callers.
- The NoProperty enum - an empty enum with zero references anywhere.

listOrNull/mapOrNull and their FoundProperty siblings are kept per explicit instruction even though unused in-repo, since they're used internally and are part of the intended public surface.

The rest is new test coverage across LogPropertiesTest and LogPropertyTest: the value()/mapOrNull()/stringPropertyOrNull() default methods, StringProperty redaction, Builder guard branches (from-already-set, description defaulting, build-without-from), MutableLogProperties builder put(null), findGlobalProperties() (using the same RainbowGumHolder reset convention as RainbowGumEntryPointTest), composite/list-properties search order and toString, MultiMapProperties edge cases, parseMap/concatKey/ interpolateKey/validateKeyParameters branches, and the LogProperty Result/ Success/Missing/Error hierarchy, PropertyFunction's sneaky-throw, PropertySupport, FallbackGetter/ResultFuncGetter/MapGetter/ListGetter delegation and error paths, and DefaultProperty's guard/set/propertyString.

LogProperties.java and LogProperty.java are now at 99%/96% and 100%/100% instruction/branch coverage respectively; remaining gaps are either a JaCoCo instrumentation quirk on always-throwing call expressions (verified correct behaviorally via assertThrows) or branches that are structurally unreachable through any public entry point (e.g. a composite containing itself, or a key that both starts with "logging." and starts with ".").


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5