### PR TITLE
Remove LogPublisherRegistry's pull-style status()

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -432,7 +432,7 @@ final class DefaultLogConfig implements LogConfig {
 		this.changePublisher = changeable ? new DefaultChangePublisher() : IgnoreChangePublisher.INSTANT;
 		this.outputRegistry = DefaultOutputRegistry.of(registry);
 		this.encoderRegistry = DefaultEncoderRegistry.of();
-		this.publisherRegistry = DefaultPublisherRegistry.of(registry);
+		this.publisherRegistry = DefaultPublisherRegistry.of();
 	}
 
 	class DefaultChangePublisher extends AbstractChangePublisher {

--- a/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
@@ -1,9 +1,7 @@
 package io.jstach.rainbowgum;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.jstach.rainbowgum.LogProperty.Property;
 import io.jstach.rainbowgum.LogPublisher.PublisherFactory;
 import io.jstach.rainbowgum.LogPublisher.PublisherProvider;
-import io.jstach.rainbowgum.LogResponse.Status;
 import io.jstach.rainbowgum.publisher.BlockingQueueAsyncLogPublisher;
 import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
 
@@ -37,12 +34,6 @@ public sealed interface LogPublisherRegistry extends LogPublisher.PublisherProvi
 	 * @param publisherProvider provider.
 	 */
 	public void register(String scheme, LogPublisher.PublisherProvider publisherProvider);
-
-	/**
-	 * Will retrieve the status of all publishers usually for health checking.
-	 * @return list of status of publishers.
-	 */
-	public List<LogResponse> status();
 
 	/**
 	 * This is URI scheme for the async publisher used by the publisher builder. Call
@@ -92,14 +83,7 @@ public sealed interface LogPublisherRegistry extends LogPublisher.PublisherProvi
 
 final class DefaultPublisherRegistry implements LogPublisherRegistry {
 
-	private final ServiceRegistry serviceRegistry;
-
 	private final ConcurrentHashMap<String, PublisherProvider> providers = new ConcurrentHashMap<String, LogPublisher.PublisherProvider>();
-
-	public DefaultPublisherRegistry(ServiceRegistry serviceRegistry) {
-		super();
-		this.serviceRegistry = serviceRegistry;
-	}
 
 	@Override
 	public PublisherFactory provide(LogProviderRef ref) {
@@ -122,23 +106,13 @@ final class DefaultPublisherRegistry implements LogPublisherRegistry {
 	 * Creates a publisher registry instance.
 	 * @return publisher registry.
 	 */
-	static LogPublisherRegistry of(ServiceRegistry serviceRegistry) {
-		var r = new DefaultPublisherRegistry(serviceRegistry);
+	static LogPublisherRegistry of() {
+		var r = new DefaultPublisherRegistry();
 		for (var p : DefaultPublisherProviders.values()) {
 			r.register(p.scheme(), p);
 			r.register(BUILTIN_SCHEME_PREFIX + p.scheme(), p);
 		}
 		return r;
-	}
-
-	@Override
-	public List<LogResponse> status() {
-		// LogPublisher no longer has its own status() to query - status reporting is
-		// being replaced with a pushed API next release.
-		List<LogResponse> responses = new ArrayList<>();
-		serviceRegistry.forEach(LogPublisher.class,
-				(name, pub) -> responses.add(new Response(LogPublisher.class, name, Status.StandardStatus.OK)));
-		return responses;
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/publisher/BlockingQueueAsyncLogPublisherTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/publisher/BlockingQueueAsyncLogPublisherTest.java
@@ -67,15 +67,6 @@ class BlockingQueueAsyncLogPublisherTest {
 			}
 			latch.await();
 			out.println("done");
-			// LogPublisher no longer reports its own status (e.g. queue depth) - status
-			// reporting is being replaced with a pushed API next release, so this is
-			// now always StandardStatus.OK regardless of the publisher's real state.
-			var responses = g.config().publisherRegistry().status();
-			String actual = """
-					[Response[type=interface io.jstach.rainbowgum.LogPublisher, name=default, status=OK]]
-					""".trim();
-			String expected = responses.toString();
-			assertEquals(expected, actual);
 		}
 		List<String> lines = output.events().stream().map(e -> e.getValue().trim()).toList();
 		int i = 0;


### PR DESCRIPTION
The last remaining piece of the old status() API - LogOutput, LogPublisher, LogAppender, LogOutputRegistry, and LogResponse's MetricStatus/QueueStatus/AggregateStatus were already removed earlier.

Removing status() left DefaultPublisherRegistry's ServiceRegistry field unused (it existed only to iterate publishers for status()), so DefaultPublisherRegistry.of() no longer takes one; updated its one caller in DefaultLogConfig accordingly.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5