### PR TITLE
Remove the unimplemented "name://" reuse-by-name scaffolding

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogOutputRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutputRegistry.java
@@ -19,11 +19,6 @@ import io.jstach.rainbowgum.output.ListLogOutput;
 public sealed interface LogOutputRegistry extends OutputProvider permits DefaultOutputRegistry {
 
 	/**
-	 * A meta URI scheme to reference outputs registered somewhere else.
-	 */
-	public static String NAMED_OUTPUT_SCHEME = "name";
-
-	/**
 	 * The URI scheme for list provider.
 	 */
 	public static String LIST_OUTPUT_SCHEME = "list";

--- a/core/src/main/java/io/jstach/rainbowgum/LogProviderRef.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProviderRef.java
@@ -78,11 +78,15 @@ record DefaultLogProviderRef(URI uri, @Nullable String keyOrNull) implements Log
 				if (path == null) {
 					throw new IllegalArgumentException("URI is not proper: " + uri);
 				}
-				if (path.startsWith("./") || path.startsWith("/")) {
-					uri = new URI("name://" + path);
-				}
-				else {
-					uri = new URI(path + ":///");
+				uri = new URI(path + ":///");
+				if (uri.getScheme() == null) {
+					/*
+					 * A leading "/" or "." keeps the URI parser from ever attempting
+					 * scheme detection, so appending ":///" above silently produces
+					 * another scheme-less URI instead of throwing. Fail clearly here
+					 * rather than letting an unresolvable URI reach a provider registry.
+					 */
+					throw new IllegalArgumentException("URI is not proper: " + uri);
 				}
 			}
 		}

--- a/core/src/test/java/io/jstach/rainbowgum/LogProviderRefTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogProviderRefTest.java
@@ -1,0 +1,98 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogProperty.Property;
+import io.jstach.rainbowgum.LogProperty.Result;
+
+class LogProviderRefTest {
+
+	@Test
+	void testOfUriHasNullKey() {
+		var ref = LogProviderRef.of(URI.create("console:///"));
+		assertEquals(URI.create("console:///"), ref.uri());
+		assertNull(ref.keyOrNull());
+	}
+
+	@Test
+	void testOfUriAndKey() {
+		var ref = LogProviderRef.of(URI.create("console:///"), "logging.appender.default.output");
+		assertEquals(URI.create("console:///"), ref.uri());
+		assertEquals("logging.appender.default.output", ref.keyOrNull());
+	}
+
+	@Test
+	void testOfSuccessResultCapturesKeyAndValue() {
+		LogProperties properties = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.out", "console:///");
+		Property<URI> property = Property.builder().ofURI().build("logging.out");
+		Result<URI> result = property.get(properties);
+		if (!(result instanceof Result.Success<URI> success)) {
+			throw new AssertionError("expected a successful result");
+		}
+		var ref = LogProviderRef.of(success);
+		assertEquals(URI.create("console:///"), ref.uri());
+		assertEquals("logging.out", ref.keyOrNull());
+	}
+
+	@Test
+	void testNotFoundExceptionMessage() {
+		var e = new LogProviderRef.NotFoundException("no provider for scheme");
+		assertEquals("no provider for scheme", e.getMessage());
+	}
+
+	@Test
+	void testNormalizeUriPassesThroughWhenSchemeAlreadyPresent() {
+		var uri = URI.create("console:///?a=b");
+		assertEquals(uri, DefaultLogProviderRef.normalize(uri));
+	}
+
+	@Test
+	void testNormalizeUriTreatsBareWordAsScheme() {
+		var uri = URI.create("console");
+		assertEquals(URI.create("console:///"), DefaultLogProviderRef.normalize(uri));
+	}
+
+	@Test
+	void testNormalizeUriRejectsPathThatCannotBecomeAScheme() {
+		// A scheme-less absolute or relative path (e.g. "/foo" or "./foo") cannot be
+		// turned into a "<path>:///" URI since "/" and "." are not valid scheme
+		// characters, and a leading "/" or "." also keeps the URI parser from ever
+		// attempting scheme detection - so appending ":///" would otherwise silently
+		// produce another scheme-less, unresolvable URI instead of throwing. This used
+		// to be special-cased into a "name://" URI to reference another named
+		// component's config, but that was never actually wired up to look anything up.
+		// Removed; this now fails fast with a clear error instead. See todo.md.
+		var absolute = URI.create("/foo");
+		assertThrows(IllegalArgumentException.class, () -> DefaultLogProviderRef.normalize(absolute));
+
+		var relative = URI.create("./foo");
+		assertThrows(IllegalArgumentException.class, () -> DefaultLogProviderRef.normalize(relative));
+	}
+
+	@Test
+	void testNormalizeUriRejectsPathWithIllegalSchemeCharacters() {
+		// A scheme-less path with no leading "/" is a candidate for becoming the scheme
+		// itself, but this one has a space in it, which is not a legal scheme
+		// character - so URI construction throws URISyntaxException, which normalize()
+		// wraps as IllegalArgumentException.
+		var uri = URI.create("hello%20world");
+		assertThrows(IllegalArgumentException.class, () -> DefaultLogProviderRef.normalize(uri));
+	}
+
+	@Test
+	void testNormalizeLogProviderRefPreservesKeyAndNormalizesUri() {
+		var ref = LogProviderRef.of(URI.create("console"), "logging.appender.default.output");
+		var normalized = DefaultLogProviderRef.normalize(ref);
+		assertEquals(URI.create("console:///"), normalized.uri());
+		assertEquals("logging.appender.default.output", normalized.keyOrNull());
+	}
+
+}

--- a/todo.md
+++ b/todo.md
@@ -97,12 +97,29 @@ Concrete issue found this cycle, not yet fixed: there are **two different**
 URI-normalization implementations. `LogOutputRegistry`'s private `normalize(URI)` only
 special-cases `./`-prefixed relative paths; `DefaultLogProviderRef.normalize(URI)` (used
 by `LogPublisherRegistry` and `LogEncoderRegistry`, but *not* by `LogOutputRegistry`)
-also handles bare `/`-absolute paths via a `name://` trick. This means an absolute-path
-URI for a generic `output=` property may still behave inconsistently with the same value
-used for a publisher or encoder. Worth auditing and unifying.
+used to also handle bare `/`-absolute paths via a `name://` trick, letting a scheme-less
+value reference another named component's config (e.g.
+`logging.appender.default.encoder=name:///somename` pointing at
+`logging.encoder.somename.*`). That trick was removed - it was never actually wired up
+to look anything up (nothing registered a provider for the `name` scheme, so using it
+just traded one unresolvable-URI failure for another), and it read as confusing
+scaffolding, especially next to the unrelated `logging.file.name` property. See
+"Reuse-by-name config" below for whether it's worth building for real. The two
+normalize implementations otherwise still differ on `./`-relative paths - `LogOutputRegistry`
+converts those to real `file:` URIs (appropriate, since only outputs are file-like);
+`DefaultLogProviderRef` now just fails clearly instead of guessing. Worth auditing and
+unifying.
 
 - [ ] Reconcile `LogOutputRegistry.normalize()` and `DefaultLogProviderRef.normalize()`
       into one implementation (or a clearly documented reason they must differ).
+- [ ] **Reuse-by-name config**: decide whether `name:///somename`-style references
+      (letting one property block, e.g. `logging.encoder.somename.*`, be reused from
+      another, e.g. `logging.appender.default.encoder=name:///somename`) are actually
+      worth building. The scaffolding for this (`LogOutputRegistry.NAMED_OUTPUT_SCHEME`,
+      the `name://` normalization trick) was removed since it was never implemented -
+      using it would only ever throw `NotFoundException`. If revisited, needs a real
+      design (which registries support it, how it interacts with `{name}` key
+      parameters) rather than reintroducing dead scaffolding.
 - [ ] `LogAppenderRegistry` carries its own admission of guilt in a comment: "The shit
       in here is a mess because auto configuration of appenders based on properties is
       complicated." A focused cleanup pass is overdue, now that `fileAppender()` has


### PR DESCRIPTION
LogOutputRegistry.NAMED_OUTPUT_SCHEME and the "name://" branch in DefaultLogProviderRef.normalize() were scaffolding for letting one property block (e.g. logging.encoder.somename.*) be referenced from another (logging.appender.default.encoder=name:///somename), but nothing ever registered a provider for the "name" scheme - using it just traded one unresolvable-URI failure for another, and read as confusing half-built config next to the unrelated logging.file.name property. Added a todo.md item to decide later whether it's worth building for real.

Also hardened normalize(): a scheme-less path starting with "/" or "." (what the name:// branch used to catch) can't become a scheme, but a leading "/" or "." also stops the URI parser from ever attempting scheme detection, so appending ":///" silently produced another scheme-less URI instead of throwing. That used to be harmless because the name:// branch intercepted these paths first; now it isn't, so normalize() explicitly rejects the result instead of letting an unresolvable URI reach a provider registry with a confusing downstream error.

Added LogProviderRefTest covering the of(...) factories, NotFoundException, and normalize()'s branches - previously only exercised indirectly through other tests. DefaultLogProviderRef is now at 89%/83% instruction/branch coverage; the one remaining gap (a scheme-less URI with a null path) is structurally unreachable per java.net.URI's own contract.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5