### PR TITLE
Add end-to-end permutation coverage for Appenders flags/asSingle/asList

### DIFF
--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -1,0 +1,166 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.Appenders;
+import io.jstach.rainbowgum.LogAppenderFlagTest.CountingListLogOutput;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+/**
+ * End-to-end permutation coverage across every {@link AppenderFlag} combination and every
+ * {@link Appenders} "as" mode ({@link Appenders#asSingle()},
+ * {@link Appenders#asSingleSharedLock()}, {@link Appenders#asList()}) - a baseline safety
+ * net ahead of a planned {@link LogAppender} refactor, so the refactor doesn't silently
+ * change behavior for some flag/mode combination nobody happened to test.
+ * <p>
+ * {@code asList()} has no real production caller today - only {@code asSingle()}/
+ * {@code asSingleSharedLock()} are used by the built-in DEFAULT/SYNC/ASYNC publisher
+ * factories (see {@code LogPublisherRegistry.DefaultPublisherProviders}). It exists for a
+ * future fanout-style publisher; {@link FanoutSyncLogPublisher} is a small synchronous
+ * test publisher built to exercise it the way a real one eventually would - see that
+ * class for details. Reentrant-append behavior (a naughty output that logs during its own
+ * write) genuinely differs between the three modes and is covered separately in
+ * {@link AppenderAsModeReentryTest}, rather than folded into this permutation, since it
+ * needs a different kind of stimulus than a single plain event.
+ */
+class AppenderAsModeFlagPermutationTest {
+
+	enum AsMode {
+
+		SINGLE, SINGLE_SHARED_LOCK, LIST;
+
+	}
+
+	record CombinationCase(AsMode mode, Set<AppenderFlag> flags) {
+		@Override
+		public String toString() {
+			return mode + " " + flags;
+		}
+	}
+
+	static Stream<Arguments> permutations() {
+		List<Arguments> args = new ArrayList<>();
+		for (var flags : powerSet(AppenderFlag.values())) {
+			for (var mode : AsMode.values()) {
+				args.add(Arguments.of(new CombinationCase(mode, flags)));
+			}
+		}
+		return args.stream();
+	}
+
+	private static List<Set<AppenderFlag>> powerSet(AppenderFlag[] values) {
+		List<Set<AppenderFlag>> result = new ArrayList<>();
+		int n = values.length;
+		for (int mask = 0; mask < (1 << n); mask++) {
+			var set = EnumSet.noneOf(AppenderFlag.class);
+			for (int i = 0; i < n; i++) {
+				if ((mask & (1 << i)) != 0) {
+					set.add(values[i]);
+				}
+			}
+			result.add(set);
+		}
+		return result;
+	}
+
+	@ParameterizedTest
+	@MethodSource("permutations")
+	void testPermutation(CombinationCase testCase) {
+		var mode = testCase.mode();
+		var flags = testCase.flags();
+
+		LogConfig config = LogConfig.builder().build();
+		var outputA = new CountingListLogOutput();
+		var outputB = new CountingListLogOutput();
+		List<LogProvider<LogAppender>> providers = List.of(
+				LogAppender.builder("a").encoder(LogFormatter.builder().message().encoder()).output(outputA).build(),
+				LogAppender.builder("b").encoder(LogFormatter.builder().message().encoder()).output(outputB).build());
+		var appenders = new Appenders("test-route", config, providers).flags(flags);
+
+		LogPublisher publisher = switch (mode) {
+			case SINGLE -> new DefaultSyncLogPublisher(appenders.asSingle());
+			case SINGLE_SHARED_LOCK -> new DefaultSyncLogPublisher(appenders.asSingleSharedLock());
+			case LIST -> new FanoutSyncLogPublisher(appenders.asList());
+		};
+
+		publisher.start(config);
+		try {
+			publisher.log(TestEventBuilder.of().build(b -> b.message("hello")));
+		}
+		finally {
+			publisher.close();
+		}
+
+		// Every appender in the group receives the event regardless of mode - that is
+		// the whole point of asList()'s fanout publisher matching what the composite
+		// modes already do internally.
+		assertEquals(List.of("hello"), outputA.events().stream().map(e -> e.getValue()).toList());
+		assertEquals(List.of("hello"), outputB.events().stream().map(e -> e.getValue()).toList());
+
+		int expectedFlushes = flags.contains(AppenderFlag.DISABLE_IMMEDIATE_FLUSH) ? 0 : 1;
+		assertEquals(expectedFlushes, outputA.flushCount, "outputA flush count");
+		assertEquals(expectedFlushes, outputB.flushCount, "outputB flush count");
+
+		Class<?> expectedAppenderClass = flags.contains(AppenderFlag.REUSE_BUFFER) ? ReuseBufferLogAppender.class
+				: DefaultLogAppender.class;
+		for (var direct : directAppenders(mode, publisher)) {
+			assertInstanceOf(expectedAppenderClass, direct);
+		}
+	}
+
+	private static List<DirectLogAppender> directAppenders(AsMode mode, LogPublisher publisher) {
+		return switch (mode) {
+			case SINGLE -> switch (((DefaultSyncLogPublisher) publisher).appender()) {
+				case IndependentLockCompositeLogAppender c -> List.of(c.components());
+				case DirectLogAppender d -> List.of(d);
+				default -> throw new AssertionError("unexpected appender type");
+			};
+			case SINGLE_SHARED_LOCK -> switch (((DefaultSyncLogPublisher) publisher).appender()) {
+				case CompositeLogAppender c -> List.of(c.components());
+				case DirectLogAppender d -> List.of(d);
+				default -> throw new AssertionError("unexpected appender type");
+			};
+			case LIST ->
+				((FanoutSyncLogPublisher) publisher).appenders().stream().map(a -> (DirectLogAppender) a).toList();
+		};
+	}
+
+	/*
+	 * The rest of this file drives Appenders directly (matching LogAppenderFlagTest's
+	 * established style) rather than through a full RainbowGum route, since building 48
+	 * full RainbowGum instances would be needlessly slow and the "as" modes are an
+	 * Appenders-level concern anyway. This one test instead wires FanoutSyncLogPublisher
+	 * in through a real route's PublisherFactory - exactly how a real fanout publisher
+	 * would plug in - to confirm asList() genuinely works end-to-end through the normal
+	 * RainbowGum bootstrap path, not just when driven directly.
+	 */
+	@Test
+	void testFanoutPublisherPluggedInThroughARealRainbowGumRoute() {
+		var outputA = new ListLogOutput();
+		var outputB = new ListLogOutput();
+		LogConfig config = LogConfig.builder().build();
+		try (var gum = RainbowGum.builder(config).route(r -> {
+			r.appender("a", a -> a.output(outputA).encoder(LogFormatter.builder().message().newline().encoder()));
+			r.appender("b", a -> a.output(outputB).encoder(LogFormatter.builder().message().newline().encoder()));
+			r.publisher((name, cfg, appenders) -> new FanoutSyncLogPublisher(appenders.asList()));
+		}).build().start()) {
+			gum.router().eventBuilder("test", System.Logger.Level.INFO).message("fanned out").log();
+		}
+		assertEquals("fanned out\n", outputA.toString());
+		assertEquals("fanned out\n", outputB.toString());
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
@@ -1,0 +1,162 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.jstach.rainbowgum.AppenderAsModeFlagPermutationTest.AsMode;
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.Appenders;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+/**
+ * REENTRY_DROP/REENTRY_LOG behave identically for a single appender (see
+ * {@link LogAppenderFlagTest}), but the three {@link Appenders} "as" modes wire the
+ * reentry-checking lock at different scopes when more than one appender is combined,
+ * which changes what a <em>sibling</em> appender sees during a reentrant call:
+ * <ul>
+ * <li>{@code asSingleSharedLock()} ({@link CompositeLogAppender}) enforces the check
+ * <strong>once</strong>, at the composite level, using one lock shared by all appenders -
+ * a reentrant call is dropped in its entirety before it reaches any appender.</li>
+ * <li>{@code asSingle()}'s default ({@link IndependentLockCompositeLogAppender}) and
+ * {@code asList()} (via {@link FanoutSyncLogPublisher}, which loops the same way) both
+ * give every appender its own independent lock and do no locking at the fan-out level
+ * itself - so a reentrant call only gets dropped for the specific appender that's
+ * reentering its own lock; every other appender still receives it, nested ahead of the
+ * event that triggered the reentry in the first place.</li>
+ * </ul>
+ * This is exactly the kind of surprising, easy-to-break-silently behavior worth pinning
+ * down before a {@link LogAppender} refactor.
+ */
+class AppenderAsModeReentryTest {
+
+	ByteArrayOutputStream metaLogBytes = new ByteArrayOutputStream();
+
+	PrintStream metaLogStream = new PrintStream(metaLogBytes);
+
+	@BeforeEach
+	void before() {
+		MetaLog.output = () -> metaLogStream;
+	}
+
+	@AfterEach
+	void after() {
+		MetaLog.output = () -> System.err;
+	}
+
+	static Stream<Arguments> modesAndReentryFlags() {
+		List<Arguments> args = new ArrayList<>();
+		for (var mode : AsMode.values()) {
+			for (var flag : List.of(AppenderFlag.REENTRY_DROP, AppenderFlag.REENTRY_LOG)) {
+				args.add(Arguments.of(mode, flag));
+			}
+		}
+		return args.stream();
+	}
+
+	@ParameterizedTest
+	@MethodSource("modesAndReentryFlags")
+	void testReentryBehaviorDiffersByMode(AsMode mode, AppenderFlag reentryFlag) {
+		LogConfig config = LogConfig.builder().build();
+		// naughty: logs a second event from within its own output write.
+		var outputA = new ListLogOutput();
+		// innocent bystander.
+		var outputB = new ListLogOutput();
+
+		LogPublisher[] publisherHolder = new LogPublisher[1];
+		outputA.setConsumer((e, s) -> {
+			if (e.message().equals("event1")) {
+				publisherHolder[0].log(TestEventBuilder.of().build(b -> b.message("event2")));
+			}
+		});
+
+		/*
+		 * The reentry flag has to be set BOTH on each appender's own builder AND via
+		 * Appenders.flags(...) to actually take effect across all three modes - found the
+		 * hard way while writing this test, and worth pinning down since it is a
+		 * genuinely confusing inconsistency in how flags flow to the lock that actually
+		 * does the reentry check:
+		 *
+		 * - An individual DirectLogAppender's *lock* (as opposed to its flags field, used
+		 * only for immediateFlush/REUSE_BUFFER selection) is fixed once, from whatever
+		 * flags were on its builder at construction (LockLogAppender.withFlags always
+		 * reuses `this.lock` unchanged, no matter what flags are merged in later) - so
+		 * asSingle() (IndependentLockCompositeLogAppender, which merges flags
+		 * per-appender via withFlags but never calls changeLock) and asList() (which
+		 * never composites at all) only honor a REENTRY_DROP/REENTRY_LOG set on the
+		 * *appender builder*; Appenders.flags(...) alone does nothing for them. -
+		 * asSingleSharedLock() (CompositeLogAppender) does the opposite: it builds a
+		 * brand new outer lock from Appenders.flags(...) and unconditionally replaces
+		 * every inner appender's lock with an always-allow-reentry wrapper via
+		 * changeLock(directLock) - so a REENTRY_DROP/REENTRY_LOG set only on the appender
+		 * builder is silently discarded, and only Appenders.flags(...) works.
+		 */
+		List<LogProvider<LogAppender>> providers = List.of(
+				LogAppender.builder("a")
+					.encoder(LogFormatter.builder().message().encoder())
+					.output(outputA)
+					.flag(reentryFlag)
+					.build(),
+				LogAppender.builder("b")
+					.encoder(LogFormatter.builder().message().encoder())
+					.output(outputB)
+					.flag(reentryFlag)
+					.build());
+		var appenders = new Appenders("test-route", config, providers).flags(Set.of(reentryFlag));
+
+		LogPublisher publisher = switch (mode) {
+			case SINGLE -> new DefaultSyncLogPublisher(appenders.asSingle());
+			case SINGLE_SHARED_LOCK -> new DefaultSyncLogPublisher(appenders.asSingleSharedLock());
+			case LIST -> new FanoutSyncLogPublisher(appenders.asList());
+		};
+		publisherHolder[0] = publisher;
+
+		publisher.start(config);
+		try {
+			publisher.log(TestEventBuilder.of().build(b -> b.message("event1")));
+		}
+		finally {
+			publisher.close();
+		}
+
+		List<String> aMessages = outputA.events().stream().map(e -> e.getKey().message()).toList();
+		List<String> bMessages = outputB.events().stream().map(e -> e.getKey().message()).toList();
+
+		// A always only sees event1 - it drops its own reentrant call regardless of
+		// mode, since that check is about A's own lock either way.
+		assertEquals(List.of("event1"), aMessages);
+
+		switch (mode) {
+			case SINGLE_SHARED_LOCK ->
+				// The shared composite lock rejects the reentrant call before it
+				// reaches any appender, so B never sees event2 at all.
+				assertEquals(List.of("event1"), bMessages);
+			case SINGLE, LIST ->
+				// B's lock is independent and not held, so the nested reentrant call
+				// (which happens *during* A's write, i.e. before the outer loop moves
+				// on to B) delivers event2 to B first, then the outer loop delivers
+				// event1 to B as normal.
+				assertEquals(List.of("event2", "event1"), bMessages);
+		}
+
+		if (reentryFlag == AppenderFlag.REENTRY_LOG) {
+			String diagnostic = metaLogBytes.toString(StandardCharsets.UTF_8);
+			assertTrue(diagnostic.contains("reentrant appender"),
+					() -> "expected reentry diagnostic for mode " + mode + ", got: " + diagnostic);
+		}
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/FanoutSyncLogPublisher.java
+++ b/core/src/test/java/io/jstach/rainbowgum/FanoutSyncLogPublisher.java
@@ -1,0 +1,63 @@
+package io.jstach.rainbowgum;
+
+import java.util.List;
+
+/**
+ * A synchronous publisher built to exercise {@link LogAppender.Appenders#asList()}, which
+ * - unlike {@link LogAppender.Appenders#asSingle()}/
+ * {@link LogAppender.Appenders#asSingleSharedLock()} - has no real production caller yet
+ * (see {@code LogPublisherRegistry.DefaultPublisherProviders}, which only ever calls
+ * {@code asSingle()}). {@code asList()} exists for a future <em>fanout</em>-style
+ * publisher: one that pushes each event to every appender independently rather than
+ * combining them into one composite appender first.
+ * <p>
+ * This one is deliberately the simplest possible fanout: no composite wrapping, no shared
+ * lock - each appender in the list keeps the independent lock it was built with, and is
+ * appended to directly, in list order. Unlike {@link IndependentLockCompositeLogAppender}
+ * (what {@code asSingle()} without {@code SHARED_APPENDER_LOCK} produces), there is no
+ * single {@link LogAppender} object wrapping the list - the fan-out happens here, at the
+ * publisher level, which is exactly what a real fanout publisher (e.g. one that pushes to
+ * per-appender queues/threads instead of a synchronous loop) would also do.
+ */
+final class FanoutSyncLogPublisher implements LogPublisher.SyncLogPublisher {
+
+	private final List<? extends LogAppender> appenders;
+
+	FanoutSyncLogPublisher(List<? extends LogAppender> appenders) {
+		this.appenders = appenders;
+	}
+
+	@Override
+	public void log(LogEvent event) {
+		for (var appender : appenders) {
+			appender.append(event);
+		}
+	}
+
+	@Override
+	public void start(LogConfig config) {
+		for (var appender : appenders) {
+			appender.start(config);
+		}
+	}
+
+	@Override
+	public void close() {
+		for (var appender : appenders) {
+			appender.close();
+		}
+	}
+
+	/*
+	 * Exposed for unit test, matching DefaultSyncLogPublisher's own precedent.
+	 */
+	List<? extends LogAppender> appenders() {
+		return this.appenders;
+	}
+
+	@Override
+	public String toString() {
+		return "FanoutSyncLogPublisher[appenders=" + appenders + "]";
+	}
+
+}


### PR DESCRIPTION
Baseline safety net ahead of the planned LogAppender refactor: every AppenderFlag combination (2^4 = 16) crossed with all three Appenders "as" modes (asSingle/asSingleSharedLock/asList) = 48 cases, each verifying event delivery to every appender, correct flush behavior, and the right underlying appender class.

asList() had no test coverage at all - it also has no real production caller yet (only asSingle()/asSingleSharedLock() are used by the built-in publisher factories); it exists for a future fanout-style publisher. Added FanoutSyncLogPublisher, a small synchronous test publisher that exercises it the way a real one eventually would: each appender in the list keeps its own independent lock, appended to directly with no composite wrapping. One test wires it through a real RainbowGum route's PublisherFactory to confirm it plugs in exactly like a production publisher would, not just when driven directly.

REENTRY_DROP/REENTRY_LOG interact with the three modes in a genuinely subtle, easy-to-break-silently way once more than one appender is combined - covered separately in AppenderAsModeReentryTest since it needs a different stimulus (a naughty output that logs during its own write) than the main permutation. Comments there document two real findings hit while writing it: (1) asSingleSharedLock's composite lock rejects a reentrant call in its entirety before it reaches any appender, while asSingle()/asList()'s independent locks only drop it for the specific reentering appender - every other appender still receives it, nested ahead of the event that triggered the reentry; (2) a REENTRY_DROP/REENTRY_LOG flag has to be set both on each appender's own builder AND via Appenders.flags(...) to actually take effect across all three modes, because an individual appender's lock is fixed at build time (independent-lock modes) while the shared-lock composite instead builds a fresh lock from Appenders.flags(...) and discards each inner appender's own. Worth keeping in mind for the refactor.

Coverage: IndependentLockCompositeLogAppender and CompositeLogAppender now 100%/100%, AppenderLock and its REENTRY_DROP/REENTRY_LOG/default variants 100%/100%, Appenders (asSingle/asSingleSharedLock/asList) up to 85%/68%. No production code changes.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5