### PR TITLE
Push LevelResolver.java coverage to 100% across every class

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -736,10 +736,13 @@ final class GroupLevelResolver implements LevelConfig {
 		}
 		Map<String, Level> loggerToLevels = new LinkedHashMap<>();
 		for (var e : groupToLevels.entrySet()) {
-			List<String> loggers = groupToLoggers.get(e.getKey());
-			if (loggers == null || loggers.isEmpty()) {
-				continue;
-			}
+			/*
+			 * groupToLevels's keys are always a subset of groupToLoggers's own keys
+			 * (built by iterating groupToLoggers.entrySet() above), whose values are
+			 * already guaranteed non-empty by the filter() when groupToLoggers was
+			 * populated - so this lookup can never actually be null or empty.
+			 */
+			List<String> loggers = Objects.requireNonNull(groupToLoggers.get(e.getKey()));
 			for (var logger : loggers) {
 				loggerToLevels.put(logger, e.getValue());
 			}

--- a/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
@@ -2,15 +2,21 @@ package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.System.Logger.Level;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.jstach.rainbowgum.LevelResolver.LevelConfig;
 import io.jstach.rainbowgum.LogFormatter.LevelFormatter;
 import io.jstach.rainbowgum.LogRouter.RouteFlag;
 import io.jstach.rainbowgum.output.ListLogOutput;
@@ -326,6 +332,155 @@ class LevelResolverTest {
 
 	private static Stream<Arguments> routeLevels() {
 		return EnumCombinations.args(Level.class, Level.class, Level.class);
+	}
+
+	@Test
+	void testOffReturnsStaticOffResolver() {
+		assertSame(StaticLevelResolver.OFF, LevelResolver.off());
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "ALL, TRACE", "all, TRACE", "TRACE, TRACE", "FINEST, TRACE", "DEBUG, DEBUG", "FINE, DEBUG",
+			"INFO, INFO", "WARN, WARNING", "WARNING, WARNING", "ERROR, ERROR", "SEVERE, ERROR", "OFF, OFF", })
+	void testParseLevelAliasesAndCaseInsensitivity(String input, Level expected) {
+		assertEquals(expected, LevelResolver.parseLevel(input));
+	}
+
+	@Test
+	void testParseLevelRejectsUnknownInput() {
+		assertThrows(IllegalArgumentException.class, () -> LevelResolver.parseLevel("bogus"));
+	}
+
+	@Test
+	void testLevelConfigOfEmptyCollectionIsOff() {
+		assertSame(StaticLevelResolver.OFF, LevelConfig.of(List.of()));
+	}
+
+	/*
+	 * SingleLevelResolver constructed directly with ALL - the public ofStaticMap path
+	 * always normalizes ALL to TRACE first via allToTrace, so this is the only way to
+	 * exercise LevelConfig's private allToNull(ALL) branch (as opposed to
+	 * allToNull(null), already covered by every other up-path search miss in this file).
+	 */
+	@Test
+	void testUpPathSearchTreatsAllLevelAsNoOpinion() {
+		LevelConfig resolver = new SingleLevelResolver("foo", Level.ALL);
+		assertEquals(Level.ALL, resolver.resolveLevel("foo"));
+	}
+
+	@Test
+	void testBuilderOfResolversWithNoResolversIsAll() {
+		assertSame(StaticLevelResolver.ALL, LevelResolver.Builder.ofResolvers(List.of()));
+	}
+
+	@Test
+	void testBuilderOfStaticMapWithNoLevelsIsAll() {
+		assertSame(StaticLevelResolver.ALL, LevelResolver.Builder.ofStaticMap(Map.of()));
+	}
+
+	@Test
+	void testCompositeLevelResolverFlattensNestedComposites() {
+		var inner = CompositeLevelResolver.of(List.of(StaticLevelResolver.DEBUG, StaticLevelResolver.INFO));
+		var outer = (CompositeLevelResolver) CompositeLevelResolver.of(List.of(inner, StaticLevelResolver.ERROR));
+		assertEquals(3, outer.resolvers().length);
+	}
+
+	@Test
+	void testCompositeLevelResolverFallsBackToDefaultLevelWhenEveryResolverIsAll() {
+		var resolver = new CompositeLevelResolver(new LevelResolver[] { StaticLevelResolver.ALL }, Level.WARNING);
+		assertEquals(Level.WARNING, resolver.resolveLevel("anything"));
+	}
+
+	@Test
+	void testCompositeLevelResolverClearCascadesToEveryResolver() {
+		int[] clearCount = new int[2];
+		LevelResolver a = new LevelResolver() {
+			@Override
+			public Level resolveLevel(String name) {
+				return Level.ALL;
+			}
+
+			@Override
+			public void clear() {
+				clearCount[0]++;
+			}
+		};
+		LevelResolver b = new LevelResolver() {
+			@Override
+			public Level resolveLevel(String name) {
+				return Level.ALL;
+			}
+
+			@Override
+			public void clear() {
+				clearCount[1]++;
+			}
+		};
+		var resolver = CompositeLevelResolver.of(List.of(a, b));
+		resolver.clear();
+		assertEquals(1, clearCount[0]);
+		assertEquals(1, clearCount[1]);
+	}
+
+	@Test
+	void testPriorityLevelResolverFlattensNestedPriorityResolvers() {
+		var inner = (PriorityLevelResolver) PriorityLevelResolver
+			.of(List.of(StaticLevelResolver.ALL, StaticLevelResolver.INFO));
+		var outer = (PriorityLevelResolver) PriorityLevelResolver.of(List.of(inner, StaticLevelResolver.ERROR));
+		assertEquals(3, outer.resolvers().length);
+	}
+
+	@Test
+	void testPriorityLevelResolverOfEmptyIsAll() {
+		assertSame(StaticLevelResolver.ALL, PriorityLevelResolver.of(List.of()));
+	}
+
+	@Test
+	void testPriorityLevelResolverOfSingleReturnsThatResolverUnwrapped() {
+		var resolver = LevelResolver.off();
+		assertSame(resolver, PriorityLevelResolver.of(List.of(resolver)));
+	}
+
+	@Test
+	void testGroupLevelResolverResolveLevelDelegatesDirectly() {
+		var props = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.groups", "sql")
+			.put("logging.group.sql", "com.sql")
+			.put("logging.level.sql", "DEBUG");
+		var resolver = GroupLevelResolver.of(props);
+		assertEquals(Level.DEBUG, resolver.resolveLevel("com.sql.blah"));
+	}
+
+	@Test
+	void testGroupLevelResolverClearRepopulatesFromCurrentProperties() {
+		var props = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.groups", "sql")
+			.put("logging.group.sql", "com.sql")
+			.put("logging.level.sql", "DEBUG");
+		var resolver = GroupLevelResolver.of(props);
+		assertEquals(Level.DEBUG, resolver.resolveLevel("com.sql.blah"));
+		props.put("logging.level.sql", "ERROR");
+		resolver.clear();
+		assertEquals(Level.ERROR, resolver.resolveLevel("com.sql.blah"));
+	}
+
+	/*
+	 * A group with no loggers (an empty logging.group.<name> value parses to an empty
+	 * list) is filtered out before it ever gets a chance to contribute a level - its
+	 * logging.level.<name> setting has nothing to attach to and must not surface for any
+	 * logger name.
+	 */
+	@Test
+	void testGroupLevelResolverIgnoresGroupWithNoLoggers() {
+		var props = LogProperties.MutableLogProperties.builder()
+			.build()
+			.put("logging.groups", "empty")
+			.put("logging.group.empty", "")
+			.put("logging.level.empty", "DEBUG");
+		var resolver = GroupLevelResolver.of(props);
+		assertEquals(Level.ALL, resolver.resolveLevel("com.anything"));
 	}
 
 }


### PR DESCRIPTION
Added targeted unit tests for the standalone/static-factory paths the existing heavy integration tests (which only ever exercise LevelResolver through a full RainbowGum route) never reached directly: parseLevel's SLF4J/JUL aliases (FINEST/FINE/WARN/SEVERE) and its invalid-input throw, off(), LevelConfig.of/Builder.ofResolvers/Builder.ofStaticMap's empty- collection branches, CompositeLevelResolver/PriorityLevelResolver's nested-flattening and empty/single-element shortcuts, CompositeLevelResolver's default-level fallback and clear() cascade, and GroupLevelResolver's resolveLevel()/clear() called directly rather than only indirectly through a wrapping composite. Also directly exercises LevelConfig's private allToNull(Level.ALL) branch via a SingleLevelResolver constructed with ALL directly, which the public API can't reach (it always normalizes ALL to TRACE first).

Found and removed one genuinely dead defensive null/empty check in GroupLevelResolver.populate(): the loop it guards can only ever see keys that came from iterating groupToLoggers.entrySet() earlier in the same method, whose values are already guaranteed non-empty by the filter() applied when groupToLoggers was first populated - so groupToLoggers.get(...) there can never actually return null or empty. Replaced with Objects.requireNonNull to make that invariant explicit instead of leaving unreachable dead code coverage would never close.

Every class in LevelResolver.java is now at 100% instruction/branch coverage. Full reactor build and all three analyzer profiles (nullaway/ checkerframework/errorprone) pass.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5