### PR TITLE
Remove LogRouter.ofLevel(...) and LevelRouter

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -67,19 +67,6 @@ public sealed interface LogRouter extends LogLifecycle {
 	}
 
 	/**
-	 * Creates a <strong>static</strong> router based on the level. Use a
-	 * {@link LevelResolver} to resolve the level first.
-	 * @param logger to publish events that are equal or above level.
-	 * @param level threshold of the router.
-	 * @return immutable static router.
-	 * @apiNote This method is for facades that do not have named level methods but are
-	 * passed the level on every log method like the System Logger.
-	 */
-	public static LogRouter ofLevel(LogEventLogger logger, Level level) {
-		return new LevelRouter(level, logger);
-	}
-
-	/**
 	 * A route is similar to a SLF4J Logger or System Logger but has a much simpler
 	 * contract.
 	 *
@@ -562,35 +549,6 @@ public sealed interface LogRouter extends LogLifecycle {
 
 	}
 
-}
-
-record LevelRouter(Level loggerLevel, LogEventLogger logger) implements LogRouter, Route {
-
-	@Override
-	public void start(LogConfig config) {
-	}
-
-	@Override
-	public void close() {
-	}
-
-	@Override
-	public void log(LogEvent event) {
-		logger.log(event);
-	}
-
-	@Override
-	public boolean isEnabled() {
-		return true;
-	}
-
-	@Override
-	public Route route(String loggerName, Level level) {
-		if (LevelResolver.checkEnabled(level, loggerLevel)) {
-			return this;
-		}
-		return Routes.NotFound;
-	}
 }
 
 record SimpleRouter(String name, LogPublisher publisher, LevelResolver levelResolver) implements Router, Route {

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
@@ -154,11 +154,6 @@ public abstract class RainbowGumSystemLoggerFinder extends System.LoggerFinder {
 				router = LogRouter.global();
 			}
 			else {
-				// var rootRouter = gum.router();
-				// var levelResolver = rootRouter.levelResolver();
-				// var level = levelResolver.resolveLevel(loggerName);
-				// var logger = rootRouter.route(loggerName, level);
-				// router = LogRouter.ofLevel(logger, level);
 				router = gum.router();
 			}
 			return router;


### PR DESCRIPTION
Both were unused - the only reference anywhere in the repo was a commented-out, already-abandoned alternative in
RainbowGumSystemLoggerFinder.InitRouterProvider.router(), which is now cleaned up too since it referenced the removed API.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5