### PR TITLE
Add property to disable slf4j cache loggers

### DIFF
--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
@@ -5,14 +5,15 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
 import io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType;
 import io.jstach.rainbowgum.LogEventLogger;
+import io.jstach.rainbowgum.LogProperty;
 import io.jstach.rainbowgum.LogRouter.RootRouter;
 import io.jstach.rainbowgum.RainbowGum;
 import io.jstach.rainbowgum.slf4j.spi.LoggerDecoratorService;
@@ -20,7 +21,7 @@ import io.jstach.rainbowgum.slf4j.spi.LoggerDecoratorService.DepthAwareLogger;
 
 class RainbowGumLoggerFactory implements ILoggerFactory {
 
-	private final ConcurrentMap<String, Logger> loggerMap;
+	private final LoggerCache cache;
 
 	/*
 	 * Spring Boot (and anything else with its own pre-boot bootstrap sequence) can
@@ -49,18 +50,32 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 	 */
 	private final Consumer<RainbowGum> onGlobalChange = gum -> this.rainbowGum = gum;
 
-	public RainbowGumLoggerFactory(RainbowGum rainbowGum, RainbowGumMDCAdapter mdc) {
+	static RainbowGumLoggerFactory of(RainbowGum rainbowGum, RainbowGumMDCAdapter mdc) {
+		var v = LogProperty.Validator.of(RainbowGumLoggerFactory.class);
+		var disableCacheProperty = rainbowGum.config()
+			.properties()
+			.forKey(RainbowGumSLF4JServiceProvider.DISABLE_LOGGER_CACHE)
+			.ofBoolean()
+			.or(false)
+			.validate(v);
+		v.validate();
+		LoggerCache cache = disableCacheProperty.value() ? NoLoggerCache.INSTANCE
+				: new ConcurrentMapLoggerCache(new ConcurrentHashMap<>());
+		return new RainbowGumLoggerFactory(rainbowGum, mdc, cache);
+	}
+
+	RainbowGumLoggerFactory(RainbowGum rainbowGum, RainbowGumMDCAdapter mdc, LoggerCache cache) {
 		super();
-		this.loggerMap = new ConcurrentHashMap<>();
 		this.rainbowGum = rainbowGum;
 		this.decorator = LoggerDecorator.of(rainbowGum);
 		this.mdc = mdc;
 		RainbowGum.onGlobalChange(onGlobalChange);
+		this.cache = cache;
 	}
 
 	@Override
 	public Logger getLogger(String name) {
-		Logger simpleLogger = loggerMap.get(name);
+		Logger simpleLogger = cache.get(name);
 		if (simpleLogger != null) {
 			return simpleLogger;
 		}
@@ -93,8 +108,8 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 					newLogger = LevelLogger.of(slf4jLevel, handler);
 				}
 			}
-			Logger decorated = decorator.decorate(currentRainbowGum, newLogger);
-			Logger oldInstance = loggerMap.putIfAbsent(name, decorated);
+			Logger decorated = decorator.decorate(rainbowGum, newLogger);
+			Logger oldInstance = cache.put(name, decorated);
 			return oldInstance == null ? decorated : oldInstance;
 		}
 	}
@@ -185,6 +200,54 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 				return logger;
 			}
 
+		}
+
+	}
+
+	interface LoggerCache {
+
+		@Nullable
+		Logger get(String name);
+
+		@Nullable
+		Logger put(String name, Logger logger);
+
+	}
+
+	enum NoLoggerCache implements LoggerCache {
+
+		INSTANCE;
+
+		@Override
+		public @Nullable Logger get(String name) {
+			return null;
+		}
+
+		@Override
+		public @Nullable Logger put(String name, Logger logger) {
+			return null;
+		}
+
+	}
+
+	static final class ConcurrentMapLoggerCache implements LoggerCache {
+
+		private final ConcurrentHashMap<String, Logger> cache;
+
+		ConcurrentMapLoggerCache(ConcurrentHashMap<String, Logger> cache) {
+			super();
+			this.cache = cache;
+		}
+
+		@Override
+		public @Nullable Logger get(String name) {
+			return cache.get(name);
+		}
+
+		// putIfAbsent
+		@Override
+		public @Nullable Logger put(String name, Logger logger) {
+			return cache.putIfAbsent(name, logger);
 		}
 
 	}

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumSLF4JServiceProvider.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumSLF4JServiceProvider.java
@@ -7,6 +7,7 @@ import org.slf4j.helpers.BasicMarkerFactory;
 import org.slf4j.spi.MDCAdapter;
 import org.slf4j.spi.SLF4JServiceProvider;
 
+import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.RainbowGum;
 import io.jstach.svc.ServiceProvider;
 
@@ -15,6 +16,17 @@ import io.jstach.svc.ServiceProvider;
  */
 @ServiceProvider(SLF4JServiceProvider.class)
 public class RainbowGumSLF4JServiceProvider implements SLF4JServiceProvider {
+
+	// static constant is here because this is the only class public
+	/**
+	 * Normally when {@link ILoggerFactory#getLogger(String)} is called the resulting
+	 * logger is cached. This flag will disable that and is a failsafe if you have code
+	 * base that creates loggers with names that change all the time (e.g.
+	 * <code>getLogger(requestId)</code>) which would cause a memory explosion in the
+	 * cache. However note that currently the level resolvers do cache so that would need
+	 * to be disabled as well with custom level resolvers.
+	 */
+	public static final String DISABLE_LOGGER_CACHE = LogProperties.ROOT_PREFIX + "slf4j.disableLoggerCache";
 
 	/**
 	 * Declare the version of the SLF4J API this implementation is compiled against. The
@@ -82,7 +94,7 @@ public class RainbowGumSLF4JServiceProvider implements SLF4JServiceProvider {
 	 * @param rainbowGum which gum to use for logger factory.
 	 */
 	public void initialize(RainbowGum rainbowGum) {
-		loggerFactory = new RainbowGumLoggerFactory(rainbowGum, mdcAdapter);
+		loggerFactory = RainbowGumLoggerFactory.of(rainbowGum, mdcAdapter);
 	}
 
 }

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/AbstractFilteringLoggerTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/AbstractFilteringLoggerTest.java
@@ -89,7 +89,7 @@ class AbstractFilteringLoggerTest {
 		RainbowGum gum = gum(config);
 		RainbowGumMDCAdapter mdc = new RainbowGumMDCAdapter();
 		gum.start();
-		var rawFactory = new RainbowGumLoggerFactory(gum, mdc);
+		var rawFactory = RainbowGumLoggerFactory.of(gum, mdc);
 		var previous = (DepthAwareLogger) rawFactory.getLogger("test");
 		return factory.apply(previous);
 	}

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/IssuesTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/IssuesTest.java
@@ -20,7 +20,7 @@ class IssuesTest {
 		 * logger.error("Hello, World!", IllegalArgumentException()) }
 		 */
 		try (var gum = gum().start()) {
-			RainbowGumLoggerFactory factory = new RainbowGumLoggerFactory(gum, new RainbowGumMDCAdapter());
+			RainbowGumLoggerFactory factory = RainbowGumLoggerFactory.of(gum, new RainbowGumMDCAdapter());
 			var logger = factory.getLogger("issue70");
 			logger.info("Hello, World!");
 			logger.error("Hello, World!", new IllegalArgumentException());

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerDecoratorTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/LoggerDecoratorTest.java
@@ -38,7 +38,7 @@ class LoggerDecoratorTest {
 		RainbowGum gum = gum(config);
 		RainbowGumMDCAdapter mdc = new RainbowGumMDCAdapter();
 		try (var g = gum.start()) {
-			var factory = new RainbowGumLoggerFactory(gum, mdc);
+			var factory = RainbowGumLoggerFactory.of(gum, mdc);
 			var logger = factory.getLogger("test");
 			logger.info("hello");
 		}

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactoryTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactoryTest.java
@@ -47,7 +47,7 @@ class RainbowGumLoggerFactoryTest {
 		System.out.println(lr);
 
 		var mdc = new RainbowGumMDCAdapter();
-		RainbowGumLoggerFactory factory = new RainbowGumLoggerFactory(rainbowgum, mdc);
+		RainbowGumLoggerFactory factory = RainbowGumLoggerFactory.of(rainbowgum, mdc);
 		Consumer<Logger> consumer = (logger) -> {
 			mdc.put("status", "alive");
 			logger.info("Eric");
@@ -84,7 +84,7 @@ class RainbowGumLoggerFactoryTest {
 			route.level(System.Logger.Level.OFF, "silent");
 			route.appender("list", a -> a.output(list));
 		}).build();
-		var factory = new RainbowGumLoggerFactory(gum, new RainbowGumMDCAdapter());
+		var factory = RainbowGumLoggerFactory.of(gum, new RainbowGumMDCAdapter());
 		var logger = factory.getLogger("silent");
 		assertInstanceOf(LevelLogger.OffLogger.class, logger);
 	}
@@ -107,7 +107,7 @@ class RainbowGumLoggerFactoryTest {
 				logging.change=true
 				""";
 		var rainbowgum = gum(LogProperties.builder().fromProperties(global).build());
-		var factory = new RainbowGumLoggerFactory(rainbowgum, new RainbowGumMDCAdapter());
+		var factory = RainbowGumLoggerFactory.of(rainbowgum, new RainbowGumMDCAdapter());
 
 		int threadCount = 8;
 		var barrier = new java.util.concurrent.CyclicBarrier(threadCount);
@@ -156,7 +156,7 @@ class RainbowGumLoggerFactoryTest {
 
 		assertTrue(rainbowgum.config().changePublisher().isEnabled("mychange"));
 
-		RainbowGumLoggerFactory factory = new RainbowGumLoggerFactory(rainbowgum, new RainbowGumMDCAdapter());
+		RainbowGumLoggerFactory factory = RainbowGumLoggerFactory.of(rainbowgum, new RainbowGumMDCAdapter());
 		var logger = factory.getLogger("mychange");
 		assertInstanceOf(LevelChangeable.class, logger);
 		assertTrue(logger.isErrorEnabled());
@@ -210,7 +210,7 @@ class RainbowGumLoggerFactoryTest {
 
 		assertTrue(rainbowgum.config().changePublisher().isEnabled("mychange"));
 
-		RainbowGumLoggerFactory factory = new RainbowGumLoggerFactory(rainbowgum, new RainbowGumMDCAdapter());
+		RainbowGumLoggerFactory factory = RainbowGumLoggerFactory.of(rainbowgum, new RainbowGumMDCAdapter());
 		var logger = factory.getLogger("mychange");
 		assertTrue(logger.isErrorEnabled());
 		assertFalse(logger.isDebugEnabled());
@@ -237,7 +237,7 @@ class RainbowGumLoggerFactoryTest {
 				logging.level=WARNING
 				""").build();
 		var rainbowgum = gum(props);
-		RainbowGumLoggerFactory factory = new RainbowGumLoggerFactory(rainbowgum, new RainbowGumMDCAdapter());
+		RainbowGumLoggerFactory factory = RainbowGumLoggerFactory.of(rainbowgum, new RainbowGumMDCAdapter());
 		var logger = factory.getLogger("anything");
 		assertInstanceOf(LevelChangeable.class, logger);
 	}
@@ -262,7 +262,7 @@ class RainbowGumLoggerFactoryTest {
 		try {
 			var bootstrapOutput = new ListLogOutput();
 			var bootstrapGum = gum(bootstrapOutput, LogProperties.StandardProperties.EMPTY);
-			var factory = new RainbowGumLoggerFactory(bootstrapGum, new RainbowGumMDCAdapter());
+			var factory = RainbowGumLoggerFactory.of(bootstrapGum, new RainbowGumMDCAdapter());
 			factory.getLogger("before.swap").info("via bootstrap gum");
 			assertEquals("INFO via bootstrap gum\n", bootstrapOutput.toString());
 			bootstrapOutput.events().clear();
@@ -316,7 +316,7 @@ class RainbowGumLoggerFactoryTest {
 				.properties(LogProperties.builder().fromProperties(preBootProperties).build())
 				.build();
 			var bootstrapGum = RainbowGum.queued(bootstrapConfig);
-			var factory = new RainbowGumLoggerFactory(bootstrapGum, new RainbowGumMDCAdapter());
+			var factory = RainbowGumLoggerFactory.of(bootstrapGum, new RainbowGumMDCAdapter());
 			var logger = factory.getLogger("bootstrap.logger");
 			assertInstanceOf(LevelChangeable.class, logger,
 					"logging.change=level must make this a replaceable logger, same as Spring's pre-boot properties");


### PR DESCRIPTION
Eventually need to have a failsafe of disabling cache across the board if some application chooses because of logger name explosion.