### PR TITLE
Add logging.jul.root.level escape hatch for JUL/rainbow gum level div…

### DIFF
--- a/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/JULConfigurator.java
+++ b/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/JULConfigurator.java
@@ -2,6 +2,7 @@ package io.jstach.rainbowgum.jul;
 
 import java.util.logging.Logger;
 
+import io.jstach.rainbowgum.LevelResolver;
 import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.LogProperty.Property;
@@ -22,10 +23,29 @@ public final class JULConfigurator implements Configurator, AutoCloseable {
 	public static final String JUL_DISABLE_PROPERTY = "logging.jul.disable";
 
 	/**
-	 * If true will not set the root loggers level to whatever the curreint rainbow gums
-	 * global level default is.
+	 * If true will not set the root loggers level at all, leaving it to whatever JUL
+	 * itself is separately configured with (e.g. via <code>logging.properties</code>),
+	 * entirely independent of rainbow gum.
 	 */
 	public static final String JUL_LEVEL_DISABLE_PROPERTY = "logging.jul.level.disable";
+
+	/**
+	 * Explicitly sets the JUL root loggers level (e.g. <code>ALL</code>,
+	 * <code>TRACE</code>, <code>DEBUG</code>, <code>INFO</code>...). JUL's own
+	 * <code>Logger.isLoggable()</code> gate runs before a record ever reaches the JUL
+	 * handler, using JUL's own (separately configured, hierarchical) per-logger level
+	 * tree - not rainbow gum's - so a logger name with a rainbow gum route or package
+	 * level override <em>more verbose</em> than whatever the JUL root ends up at will
+	 * have its records silently dropped before rainbow gum's own (correct) route level
+	 * check ever runs. Setting this to <code>ALL</code> disables JUL's own gate entirely
+	 * and delegates all level filtering to rainbow gum's router, at the cost of JUL no
+	 * longer being able to cheaply pre-filter disabled calls itself (no {@code LogRecord}
+	 * allocation or lazy message {@code Supplier} avoidance for below-threshold calls).
+	 * If this property is not set, the JUL root level is instead synced to rainbow gum's
+	 * global default level ({@code logging.level}), which is cheaper for the common case
+	 * but shares the same limitation for any more-verbose per-package override.
+	 */
+	public static final String JUL_ROOT_LEVEL_PROPERTY = "logging.jul.root.level";
 
 	static final Property<Boolean> JUL_DISABLE_PROPERTY_ = Property.builder()
 		.ofBoolean() //
@@ -34,6 +54,10 @@ public final class JULConfigurator implements Configurator, AutoCloseable {
 	static final Property<Boolean> JUL_LEVEL_DISABLE_PROPERTY_ = Property.builder()
 		.ofBoolean() //
 		.build(JUL_LEVEL_DISABLE_PROPERTY);
+
+	static final Property<System.Logger.Level> JUL_ROOT_LEVEL_PROPERTY_ = Property.builder()
+		.build(JUL_ROOT_LEVEL_PROPERTY)
+		.map(LevelResolver::parseLevel);
 
 	private volatile boolean installed = false;
 
@@ -56,7 +80,20 @@ public final class JULConfigurator implements Configurator, AutoCloseable {
 		if (!disableLevel) {
 			var logger = Logger.getLogger("");
 			if (logger != null) {
-				var systemLevel = traceToAll(config.levelResolver().resolveLevel(""));
+				/*
+				 * An explicit logging.jul.root.level wins outright (the caller knows what
+				 * they want, e.g. ALL for full correctness at the cost of JUL no longer
+				 * being able to cheaply pre-filter disabled calls itself). Otherwise fall
+				 * back to syncing with rainbow gum's own global default level, same as
+				 * before - cheap for the common case, but a route/package level override
+				 * more verbose than the global default will still be silently dropped by
+				 * JUL's own gate before it ever reaches SystemLoggerQueueJULHandler's own
+				 * (correct) route.isEnabled() check. logging.jul.root.level is the escape
+				 * hatch for that.
+				 */
+				var explicitRootLevel = JUL_ROOT_LEVEL_PROPERTY_.get(config.properties()).valueOrNull();
+				var systemLevel = explicitRootLevel != null ? explicitRootLevel
+						: traceToAll(config.levelResolver().resolveLevel(""));
 				logger.setLevel(julLevel(systemLevel));
 			}
 		}
@@ -117,7 +154,7 @@ public final class JULConfigurator implements Configurator, AutoCloseable {
 
 	}
 
-	private java.util.logging.Level julLevel(System.Logger.Level level) {
+	private static java.util.logging.Level julLevel(System.Logger.Level level) {
 		var julLevel = switch (level) {
 			case TRACE -> java.util.logging.Level.FINEST;
 			case DEBUG -> java.util.logging.Level.FINE;

--- a/test/rainbowgum-test-jdk/src/test/java/io/jstach/rainbowgum/test/jdk/JDKSetupTest.java
+++ b/test/rainbowgum-test-jdk/src/test/java/io/jstach/rainbowgum/test/jdk/JDKSetupTest.java
@@ -202,6 +202,44 @@ class JDKSetupTest {
 		});
 	}
 
+	/*
+	 * By default JUL's root level is only synced to rainbow gum's global default level,
+	 * not to any more specific per-package override - so a package configured more
+	 * verbose than the global default is silently dropped by JUL's own
+	 * Logger.isLoggable() gate before SystemLoggerQueueJULHandler.publish() (and its own
+	 * correct route.isEnabled() check) ever runs. logging.jul.root.level=ALL is the
+	 * documented escape hatch: it disables JUL's own gate entirely and lets rainbow gum's
+	 * router make the real decision.
+	 */
+	@Order(14)
+	@Test
+	void testJulRootLevelPropertyLetsMoreVerbosePackageOverrideThrough() throws InterruptedException {
+		doInLock(() -> {
+			String pkg = "root.level.pkg";
+
+			ListLogOutput droppedOutput = new ListLogOutput();
+			var droppedProps = LogProperties.MutableLogProperties.builder()
+				.build()
+				.put("logging.level." + pkg, "DEBUG");
+			try (var gum = JDKSetup.run(droppedOutput, Level.INFO, droppedProps)) {
+				Logger.getLogger(pkg).fine("hidden");
+			}
+			assertEquals("", droppedOutput.toString());
+
+			ListLogOutput visibleOutput = new ListLogOutput();
+			var visibleProps = LogProperties.MutableLogProperties.builder()
+				.build()
+				.put("logging.level." + pkg, "DEBUG")
+				.put(JULConfigurator.JUL_ROOT_LEVEL_PROPERTY, "ALL");
+			try (var gum = JDKSetup.run(visibleOutput, Level.INFO, visibleProps)) {
+				Logger.getLogger(pkg).fine("visible");
+			}
+			assertTrue(visibleOutput.toString().contains("visible"),
+					"logging.jul.root.level=ALL should let a more verbose per-package override reach rainbow gum's router: "
+							+ visibleOutput);
+		});
+	}
+
 	@Order(15)
 	@ParameterizedTest
 	@EnumSource(System.Logger.Level.class)


### PR DESCRIPTION
…ergence

JUL's own Logger.isLoggable() gate runs before a record ever reaches SystemLoggerQueueJULHandler, using JUL's own (separately configured) per-logger level tree - not rainbow gum's. Syncing the JUL root only to rainbow gum's global default level (as JULConfigurator already did) means a route/package level override more verbose than the global default (e.g. logging.level.com.example=DEBUG with a global default of INFO) is silently dropped by JUL before it ever reaches rainbow gum's own (correct) route.isEnabled() check.

Forcing the JUL root to ALL unconditionally would fix that, but it's a worse default: it defeats JUL's own cheap isLoggable() pre-filtering for every sub-threshold call, not just the divergent ones - LogRecord allocation, Supplier evaluation, and Handler dispatch all happen before rainbow gum's router gets a chance to filter, for every JUL logger in the app. 126 existing JDKSetupTest assertions around lazy Supplier message evaluation would regress if this were the default.

logging.jul.root.level is a new, explicit opt-in: when set, it wins outright and is used as the JUL root level as-is (e.g. ALL for full correctness at the accepted perf cost). When unset, behavior is unchanged - the JUL root stays synced to the global default level, same as before.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5