### PR TITLE
Split JUL integration out of rainbowgum-jdk into new rainbowgum-jul module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>rainbowgum-jul</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>rainbowgum-slf4j</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1139,6 +1144,7 @@
   <modules>
     <module>core</module>
     <module>rainbowgum-slf4j</module>
+    <module>rainbowgum-jul</module>
     <module>rainbowgum-jdk</module>
     <module>rainbowgum</module>
     <module>rainbowgum-disruptor</module>

--- a/rainbowgum-jdk/src/main/java/io/jstach/rainbowgum/jdk/systemlogger/SystemLoggingFactory.java
+++ b/rainbowgum-jdk/src/main/java/io/jstach/rainbowgum/jdk/systemlogger/SystemLoggingFactory.java
@@ -1,16 +1,27 @@
 package io.jstach.rainbowgum.jdk.systemlogger;
 
 import io.jstach.rainbowgum.LogProperties;
-import io.jstach.rainbowgum.jdk.jul.JULConfigurator;
 import io.jstach.rainbowgum.systemlogger.RainbowGumSystemLoggerFinder;
 import io.jstach.svc.ServiceProvider;
 
 /**
  * System Logger rainbow gum implementation. Unlike the SLF4J implementation
  * <strong>Rainbow Gum does not cache System Loggers</strong> by name!
+ * <p>
+ * This no longer eagerly installs the <code>java.util.logging</code> handler itself -
+ * that happens via the normal
+ * {@link io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator} pass (see
+ * {@code io.jstach.rainbowgum.jul.JULConfigurator}, found via
+ * {@link java.util.ServiceLoader} if the <code>rainbowgum-jul</code> artifact is present)
+ * once a real Rainbow Gum actually loads, whether triggered eagerly by this very class
+ * (see {@link RainbowGumSystemLoggerFinder.InitOption#CHECK}) or later by SLF4J. Any
+ * <code>java.util.logging</code> calls made before that point are no worse off than the
+ * System.Logger events this class already queues until a real Rainbow Gum loads.
+ * <p>
+ * To keep just the handler installation disabled while still depending on it, see
+ * {@code io.jstach.rainbowgum.jul.JULConfigurator#JUL_DISABLE_PROPERTY}.
  *
  * @see #INITIALIZE_RAINBOW_GUM_PROPERTY
- * @see JULConfigurator#JUL_DISABLE_PROPERTY
  */
 @ServiceProvider(System.LoggerFinder.class)
 public final class SystemLoggingFactory extends RainbowGumSystemLoggerFinder {
@@ -31,7 +42,6 @@ public final class SystemLoggingFactory extends RainbowGumSystemLoggerFinder {
 
 	protected SystemLoggingFactory(LogProperties properties) {
 		super(() -> initOption(properties));
-		JULConfigurator.install(properties);
 	}
 
 }

--- a/rainbowgum-jdk/src/main/java/module-info.java
+++ b/rainbowgum-jdk/src/main/java/module-info.java
@@ -3,15 +3,15 @@
  * adapters for the built-in JDK logging facilities. The impetus for this is
  * these logging facilities can be used very early in the JDK boot processes
  * well before logging has fully initialized. Furthermore the JDK
- * itself recommends that 
+ * itself recommends that
  * {@link java.lang.System.LoggerFinder#LoggerFinder() heavy initialization should not happen}.
- * 
+ *
  * <p>
  * The integration will make sure that neither the System.Logger or
  * java.util.logging will initialize Rainbow Gum too early by queueing the
- * events if a 
- * {@link io.jstach.rainbowgum.spi.RainbowGumServiceProvider.RainbowGumEagerLoad} 
- * implementation is found (SLF4J facade implements this to indicate it will load Rainbow Gum). 
+ * events if a
+ * {@link io.jstach.rainbowgum.spi.RainbowGumServiceProvider.RainbowGumEagerLoad}
+ * implementation is found (SLF4J facade implements this to indicate it will load Rainbow Gum).
  * When a Rainbow Gum initializes and
  * {@linkplain io.jstach.rainbowgum.RainbowGum#set(Supplier) set as global} the
  * events will be replayed. If the events level are equal to
@@ -20,7 +20,7 @@
  * is something catastrophic has happened that will probably cause Rainbow Gum
  * to never load and thus never replay the events and you will not be able to
  * figure out what happened. If no
- * {@link io.jstach.rainbowgum.spi.RainbowGumServiceProvider.RainbowGumEagerLoad} 
+ * {@link io.jstach.rainbowgum.spi.RainbowGumServiceProvider.RainbowGumEagerLoad}
  * is found the SystemLogger will initialize Rainbow Gum. You can change the queuing
  * threshold and error level outputting with System properties:
  * </p>
@@ -39,50 +39,41 @@
  * Rainbow Gum on Sytem.Logger usage if using  <code>io.jstach.rainbowgum.slf4j</code> module)</li>
  * </ul>
  * An alternative to using the SLF4J bridge if eager initialization is desired is
- * to set a System property with 
- * <code>{@value io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory#INITIALIZE_RAINBOW_GUM_PROPERTY}</code> 
+ * to set a System property with
+ * <code>{@value io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory#INITIALIZE_RAINBOW_GUM_PROPERTY}</code>
  * to
  * the values in {@link io.jstach.rainbowgum.systemlogger.RainbowGumSystemLoggerFinder.InitOption}.
  * however that maybe difficult if one cannot set system properties before loading logging.
  * <p>
- * To disable installation of the java.util.logging handler set the property:
- * {@value io.jstach.rainbowgum.jdk.jul.JULConfigurator#JUL_DISABLE_PROPERTY}
- * to <code>true</code>. Alternatively if in a custom modular environment using jlink and
- * the module <code>java.logging</code> is not included the handler will not be installed.
- * Furthermore
- * <strong>the module <code>java.logging</code> is not required and thus
- * jlink might not automatically include it as it is <code>requires static</code>.
- * </strong>
+ * The <code>java.util.logging</code> handler installation itself (that routes
+ * <code>java.util.logging.Logger</code> usage through Rainbow Gum) lives in the separate
+ * <code>io.jstach.rainbowgum.jul</code> module, which this module depends on by default.
+ * To opt out of it entirely, exclude the <code>rainbowgum-jul</code> artifact (this
+ * module has no compile-time dependency on it - it is purely a runtime companion
+ * discovered via {@link java.util.ServiceLoader}). To keep the dependency but disable
+ * just the handler installation, see
+ * {@code io.jstach.rainbowgum.jul.JULConfigurator#JUL_DISABLE_PROPERTY}.
  * </p>
- * 
+ *
  * <em> <strong>NOTE:</strong> While the JDK System.Logger is good for low level
  * libraries it's API (and Rainbow Gum implementation) is not designed for
  * performance. For applications and frameworks that do a lot of logging the
  * SLF4J facade is the preferred choice. </em>
  * <p>
  * Because the logger names of System.Logger and JUL are far less likely
- * to be actual class names and could be anything 
+ * to be actual class names and could be anything
  * (unlike SLF4J which encourages class names and static loggers) Rainbow Gum
  * does not cache System.Loggers.
- * 
+ *
  * @provides System.LoggerFinder
- * @provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider
  */
 module io.jstach.rainbowgum.jdk {
 
-	exports io.jstach.rainbowgum.jdk.jul;
-
 	requires io.jstach.rainbowgum;
 	requires io.jstach.rainbowgum.systemlogger;
-	
-	/*
-	 * TODO perhaps a separate module for
-	 * the java.logging handler
-	 */
-	requires static java.logging;
+
 	requires static org.eclipse.jdt.annotation;
 	requires static io.jstach.svc;
 
 	provides System.LoggerFinder with io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory;
-	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider with io.jstach.rainbowgum.jdk.jul.JULConfigurator;
 }

--- a/rainbowgum-jul/pom.xml
+++ b/rainbowgum-jul/pom.xml
@@ -7,8 +7,8 @@
     <artifactId>rainbowgum-maven-parent</artifactId>
     <version>0.10.0-SNAPSHOT</version>
   </parent>
-  <artifactId>rainbowgum-jdk</artifactId>
-  <name>rainbowgum-jdk</name>
+  <artifactId>rainbowgum-jul</artifactId>
+  <name>rainbowgum-jul</name>
   <properties>
     <doc.resources>../</doc.resources>
     <parent.root>${basedir}/..</parent.root>
@@ -17,15 +17,6 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rainbowgum-systemlogger</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rainbowgum-jul</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.jstach.pistachio</groupId>

--- a/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/JULConfigurator.java
+++ b/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/JULConfigurator.java
@@ -1,4 +1,4 @@
-package io.jstach.rainbowgum.jdk.jul;
+package io.jstach.rainbowgum.jul;
 
 import java.util.logging.Logger;
 

--- a/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/SystemLoggerQueueJULHandler.java
+++ b/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/SystemLoggerQueueJULHandler.java
@@ -1,4 +1,4 @@
-package io.jstach.rainbowgum.jdk.jul;
+package io.jstach.rainbowgum.jul;
 
 import java.lang.System.Logger.Level;
 import java.time.Instant;

--- a/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/package-info.java
+++ b/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/package-info.java
@@ -2,4 +2,4 @@
  * JUL implementation.
  */
 @org.eclipse.jdt.annotation.NonNullByDefault
-package io.jstach.rainbowgum.jdk.jul;
+package io.jstach.rainbowgum.jul;

--- a/rainbowgum-jul/src/main/java/module-info.java
+++ b/rainbowgum-jul/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/**
+ * Rainbow Gum JUL (<code>java.util.logging</code>) integration. This module installs a
+ * {@link java.util.logging.Handler} on the JUL root logger so that any
+ * <code>java.util.logging.Logger</code> usage (including from libraries and frameworks
+ * that log via JUL directly, e.g. embedded Tomcat) is routed through Rainbow Gum.
+ * <p>
+ * This is a separate module (rather than being bundled directly into
+ * <code>io.jstach.rainbowgum.jdk</code>) specifically so that it can be opted out of by
+ * simply excluding this artifact, instead of relying on a properties-based disable flag.
+ * To disable installation of the handler while still depending on this module set the
+ * property:
+ * {@value io.jstach.rainbowgum.jul.JULConfigurator#JUL_DISABLE_PROPERTY} to
+ * <code>true</code>. Alternatively if in a custom modular environment using jlink and
+ * the module <code>java.logging</code> is not included the handler will not be
+ * installed. Furthermore <strong>the module <code>java.logging</code> is not required
+ * and thus jlink might not automatically include it as it is
+ * <code>requires static</code>.</strong>
+ *
+ * @provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider
+ */
+module io.jstach.rainbowgum.jul {
+
+	exports io.jstach.rainbowgum.jul;
+
+	requires io.jstach.rainbowgum;
+
+	requires static java.logging;
+	requires static org.eclipse.jdt.annotation;
+	requires static io.jstach.svc;
+
+	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider with io.jstach.rainbowgum.jul.JULConfigurator;
+
+}

--- a/rainbowgum/pom.xml
+++ b/rainbowgum/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>rainbowgum-jdk</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-jul</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!-- The below are just for code snippts and are not actual depedendencies -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring/rainbowgum-spring-boot3-starter/pom.xml
+++ b/spring/rainbowgum-spring-boot3-starter/pom.xml
@@ -36,6 +36,23 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <!--
+          Rainbow gum's own java.util.logging handler is currently slower than
+          desired under Spring Boot (embedded Tomcat is JUL-heavy). Note that
+          RainbowGumLoggingSystemFactory replaces Spring Boot's LoggingSystem entirely,
+          so Spring Boot's own Logback-specific jul-to-slf4j wiring
+          (LogbackLoggingSystem) never runs here either - excluding this artifact means
+          java.util.logging output (e.g. from embedded Tomcat) is not captured at all
+          for now, not redirected elsewhere. Excluding this artifact (rather than
+          rainbowgum-jdk) keeps io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory
+          (the System.Logger bridge) intact.
+        -->
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>rainbowgum-jul</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring/rainbowgum-spring-boot4-starter/pom.xml
+++ b/spring/rainbowgum-spring-boot4-starter/pom.xml
@@ -36,6 +36,23 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <!--
+          Rainbow gum's own java.util.logging handler is currently slower than
+          desired under Spring Boot (embedded Tomcat is JUL-heavy). Note that
+          RainbowGumLoggingSystemFactory replaces Spring Boot's LoggingSystem entirely,
+          so Spring Boot's own Logback-specific jul-to-slf4j wiring
+          (LogbackLoggingSystem) never runs here either - excluding this artifact means
+          java.util.logging output (e.g. from embedded Tomcat) is not captured at all
+          for now, not redirected elsewhere. Excluding this artifact (rather than
+          rainbowgum-jdk) keeps io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory
+          (the System.Logger bridge) intact.
+        -->
+        <exclusion>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>rainbowgum-jul</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/test/rainbowgum-test-jdk/pom.xml
+++ b/test/rainbowgum-test-jdk/pom.xml
@@ -11,5 +11,9 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-jdk</artifactId>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-jul</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/test/rainbowgum-test-jdk/src/test/java/io/jstach/rainbowgum/test/jdk/JDKSetupTest.java
+++ b/test/rainbowgum-test-jdk/src/test/java/io/jstach/rainbowgum/test/jdk/JDKSetupTest.java
@@ -41,8 +41,8 @@ import io.jstach.rainbowgum.LogFormatter.LevelFormatter;
 import io.jstach.rainbowgum.LogProperties;
 import io.jstach.rainbowgum.LogProperties.MutableLogProperties;
 import io.jstach.rainbowgum.RainbowGum;
-import io.jstach.rainbowgum.jdk.jul.JULConfigurator;
 import io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory;
+import io.jstach.rainbowgum.jul.JULConfigurator;
 import io.jstach.rainbowgum.output.ListLogOutput;
 import io.jstach.rainbowgum.systemlogger.RainbowGumSystemLoggerFinder.InitOption;
 
@@ -1005,15 +1005,24 @@ class JDKSetupTest {
 		assertFalse(JULConfigurator.isInstalled());
 
 		var logger = System.getLogger("before.load");
-		assertTrue(JULConfigurator.isInstalled());
+		/*
+		 * SystemLoggingFactory no longer eagerly installs the JUL handler itself - that
+		 * now only happens via the normal Configurator pass once a real rainbow gum loads
+		 * (see below). Unlike System.Logger events (which this class queues and replays),
+		 * a raw java.util.logging call made in this window would not be captured, so it
+		 * is deliberately not exercised here - only once a real rainbow gum has loaded
+		 * and installed the handler.
+		 */
+		assertFalse(JULConfigurator.isInstalled());
 
 		logger.log(Level.INFO, "Hello {0} from System.Logger!", "Gum");
-		var jul = Logger.getLogger("before.load");
-		jul.log(java.util.logging.Level.INFO, "Hello {0} from JUL Logger!", "Gum");
 		assertNull(RainbowGum.getOrNull(), "Rainbow Gum should not be loaded yet.");
 		ListLogOutput output = new ListLogOutput();
 		try (var gum = JDKSetup.run(output, System.Logger.Level.INFO, LogProperties.StandardProperties.EMPTY)) {
 			assertNotNull(RainbowGum.getOrNull());
+			assertTrue(JULConfigurator.isInstalled());
+			var jul = Logger.getLogger("before.load");
+			jul.log(java.util.logging.Level.INFO, "Hello {0} from JUL Logger!", "Gum");
 			String actual = output.toString();
 			String expected = """
 					00:00:00.000 [main] INFO  before.load - Hello Gum from System.Logger!


### PR DESCRIPTION
rainbowgum-jdk bundled both the System.Logger bridge (jdk.systemlogger) and the java.util.logging Handler installation (jdk.jul) in one jar, with no way to opt out of the JUL half short of a properties-based disable flag - not a real option for Spring Boot, which needs the System.Logger bridge but wants to skip rainbow gum's JUL handler (currently slower than desired, e.g. under JUL-heavy embedded Tomcat).

Moves JULConfigurator/SystemLoggerQueueJULHandler into a new rainbowgum-jul module (package renamed io.jstach.rainbowgum.jdk.jul -> io.jstach.rainbowgum.jul to match), which rainbowgum-jdk depends on by default so existing consumers see no change. Consumers can now exclude just rainbowgum-jul (keeping rainbowgum-jdk, and with it the System.Logger bridge) instead of losing both.

SystemLoggingFactory no longer eagerly calls JULConfigurator.install() directly from its constructor - that was rainbowgum-jdk's only compile-time reference to the jul package, and removing it means rainbowgum-jul can be a true runtime-only companion (JPMS's uses/provides service-binding resolves it automatically without rainbowgum-jdk needing any `requires`, static or otherwise, once nothing in its own code references the package). JUL handler installation now happens exclusively via the normal RainbowGumServiceProvider.Configurator pass once a real Rainbow Gum loads - System.Logger events made before that point were already queued and replayed by SystemLoggingFactory's existing design; a raw java.util.logging call made in that same window is not (JUL has no analogous queue), which is an accepted, narrow tradeoff versus the alternative of pulling in a hard compile-time dependency for it.

Wires the boot3/boot4 Spring Boot starters to exclude rainbowgum-jul specifically (not rainbowgum-jdk) from their rainbowgum dependency. Note this leaves java.util.logging output (e.g. embedded Tomcat) uncaptured under Spring Boot for now: RainbowGumLoggingSystemFactory replaces Spring Boot's LoggingSystem entirely, so Spring Boot's own Logback-specific jul-to-slf4j wiring never runs either way.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5