### PR TITLE
Add RainbowGum.onGlobalChange so SLF4J's factory tracks a later globa…

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/RainbowGum.java
+++ b/core/src/main/java/io/jstach/rainbowgum/RainbowGum.java
@@ -1,11 +1,14 @@
 package io.jstach.rainbowgum;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.ServiceLoader;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
@@ -119,6 +122,27 @@ public sealed interface RainbowGum extends AutoCloseable, LogEventLogger {
 	 */
 	public static void set(Supplier<RainbowGum> supplier) {
 		RainbowGumHolder.set(supplier);
+	}
+
+	/**
+	 * Subscribes to notification of a new RainbowGum becoming the globally bound one (see
+	 * {@link #set(Supplier)}, {@link #set(RainbowGum)}, {@link Builder#set()}). This is
+	 * primarily for components like SLF4J's logger factory that are themselves
+	 * bootstrapped once (often before "the real" RainbowGum has loaded, e.g. a
+	 * framework's own pre-boot sequence) and otherwise have no way of finding out that a
+	 * different RainbowGum has since replaced the one they captured.
+	 * <p>
+	 * Only a {@linkplain java.lang.ref.WeakReference weak reference} to
+	 * <code>consumer</code> is retained, so subscribing does not by itself keep the
+	 * consumer (or whatever it is attached to) reachable - the caller is responsible for
+	 * keeping a strong reference to <code>consumer</code> for as long as it needs to keep
+	 * receiving notifications, otherwise it may silently stop being called once garbage
+	 * collected.
+	 * @param consumer called with the newly bound global RainbowGum. Never called while
+	 * any RainbowGum internal lock is held.
+	 */
+	public static void onGlobalChange(Consumer<RainbowGum> consumer) {
+		RainbowGumHolder.globalChangePublisher.add(consumer);
 	}
 
 	/**
@@ -381,6 +405,8 @@ final class RainbowGumHolder {
 
 	private static volatile @Nullable RainbowGum rainbowGum = null;
 
+	static final GlobalChangePublisher globalChangePublisher = new GlobalChangePublisher();
+
 	static @Nullable RainbowGum current() {
 		if (lock.readLock().tryLock()) {
 			try {
@@ -408,6 +434,7 @@ final class RainbowGumHolder {
 			throw new IllegalStateException("RainbowGum component tried to log too early. "
 					+ "This is usually caused by dependencies calling logging.");
 		}
+		RainbowGum newlyStarted = null;
 		lock.writeLock().lock();
 		try {
 			var r = rainbowGum;
@@ -417,11 +444,20 @@ final class RainbowGumHolder {
 			r = supplier.get();
 			start(r);
 			rainbowGum = r;
+			newlyStarted = r;
 			return r;
 
 		}
 		finally {
 			lock.writeLock().unlock();
+			/*
+			 * Published outside of the write lock so a subscriber can never deadlock or
+			 * trip the "tried to log too early" reentrancy guard above by, say, trying to
+			 * read a volatile field it owns - it is not calling back into this class.
+			 */
+			if (newlyStarted != null) {
+				globalChangePublisher.publish(newlyStarted);
+			}
 		}
 
 	}
@@ -471,6 +507,35 @@ final class RainbowGumHolder {
 		ShutdownManager.addShutdownHook(gum);
 		gum.start();
 		InternalRootRouter.setRouter(gum.router());
+	}
+
+}
+
+/*
+ * Unlike LogConfig.ChangePublisher/LogRouter.RouteChangePublisher (both scoped to a
+ * single RainbowGum/router instance and torn down with it) this is a JVM-lifetime static
+ * registry, so consumers are held only weakly - otherwise every SLF4J logger factory (or
+ * any other subscriber) ever created over the life of the JVM, e.g. across many
+ * short-lived RainbowGums in tests, would be pinned forever.
+ */
+final class GlobalChangePublisher {
+
+	private final Queue<WeakReference<Consumer<RainbowGum>>> consumers = new ConcurrentLinkedQueue<>();
+
+	void add(Consumer<RainbowGum> consumer) {
+		consumers.add(new WeakReference<>(consumer));
+	}
+
+	void publish(RainbowGum gum) {
+		for (var it = consumers.iterator(); it.hasNext();) {
+			var consumer = it.next().get();
+			if (consumer == null) {
+				it.remove();
+			}
+			else {
+				consumer.accept(gum);
+			}
+		}
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/RainbowGumEntryPointTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RainbowGumEntryPointTest.java
@@ -1,5 +1,6 @@
 package io.jstach.rainbowgum;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,7 +11,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.AfterEach;
@@ -274,6 +277,55 @@ class RainbowGumEntryPointTest {
 		var gum = RainbowGum.builder(LogConfig.builder().build()).build();
 		// Should not throw and should not register/require a shutdown hook removal.
 		gum.close();
+	}
+
+	/*
+	 * The main use case this exists for: SLF4J's logger factory (or anything else
+	 * bootstrapped once, early) finding out that a different RainbowGum has since become
+	 * the global one, without needing to be reconstructed.
+	 */
+	@Test
+	void onGlobalChangeNotifiesSubscribersWhenANewGumBecomesGlobal() {
+		var notified = new AtomicReference<RainbowGum>();
+		Consumer<RainbowGum> consumer = notified::set;
+		RainbowGum.onGlobalChange(consumer);
+		try (var gum = RainbowGum.builder(LogConfig.builder().build()).set()) {
+			assertSame(gum, notified.get());
+		}
+	}
+
+	/*
+	 * RainbowGumHolder.get()'s read-lock fast path (an already-resolved instance) must
+	 * not re-publish - only the write-lock path that actually resolves/starts a new
+	 * instance does.
+	 */
+	@Test
+	void onGlobalChangeIsNotFiredAgainWhenOfResolvesTheAlreadyBoundInstance() {
+		var callCount = new AtomicInteger();
+		Consumer<RainbowGum> consumer = gum -> callCount.incrementAndGet();
+		RainbowGum.onGlobalChange(consumer);
+		try (var gum = RainbowGum.builder(LogConfig.builder().build()).set()) {
+			assertEquals(1, callCount.get());
+			RainbowGum.of();
+			assertEquals(1, callCount.get());
+		}
+	}
+
+	@Test
+	void onGlobalChangeIsNotFiredWhenNothingEverResolvesTheSupplier() {
+		var callCount = new AtomicInteger();
+		Consumer<RainbowGum> consumer = gum -> callCount.incrementAndGet();
+		RainbowGum.onGlobalChange(consumer);
+		var gum = RainbowGum.builder(LogConfig.builder().build()).build();
+		try {
+			// set(RainbowGum) only registers a supplier - nothing has called
+			// RainbowGum.of() to actually resolve/start it yet.
+			RainbowGum.set(gum);
+			assertEquals(0, callCount.get());
+		}
+		finally {
+			gum.close();
+		}
 	}
 
 }

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
@@ -12,9 +12,18 @@ import io.jstach.rainbowgum.LogEvent.Caller;
 import io.jstach.rainbowgum.LogEventLogger;
 
 interface LogEventHandler extends EventCreator<Level>, LogEventLogger {
-	
+
+	/**
+	 * Implemented by loggers whose dispatch target can be swapped after creation
+	 * (currently only {@link ReplaceableLogger}), so a route change (e.g. the global
+	 * router being replaced once a real RainbowGum loads) can rebind an already-created
+	 * logger's handler instead of leaving it pointed at whatever it resolved to at
+	 * creation time - the queued placeholder router, in the common pre-boot case.
+	 */
 	interface EventHandlerChangeable {
-		void setEventHandler(@SuppressWarnings("exports") LogEventHandler eventHandler);
+
+		void setEventHandler(LogEventHandler eventHandler);
+
 	}
 
 	@Override

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/LogEventHandler.java
@@ -12,6 +12,10 @@ import io.jstach.rainbowgum.LogEvent.Caller;
 import io.jstach.rainbowgum.LogEventLogger;
 
 interface LogEventHandler extends EventCreator<Level>, LogEventLogger {
+	
+	interface EventHandlerChangeable {
+		void setEventHandler(@SuppressWarnings("exports") LogEventHandler eventHandler);
+	}
 
 	@Override
 	default java.lang.System.Logger.Level translateLevel(Level level) {

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
@@ -80,7 +80,7 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 				// callerInfo);
 				var handler = maybeAddCallerInfo(name, allowedChanges, logger, 1);
 				var changeable = ReplaceableLogger.of(Levels.toSlf4jLevel(level), handler);
-				subscribe(name, router, changeable);
+				subscribe(name, router, changeable, allowedChanges);
 				newLogger = changeable;
 			}
 			else {
@@ -100,17 +100,21 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 		}
 	}
 
-	private void subscribe(String name, RootRouter router, LevelChangeable changeable) {
-		record Slf4JOnChange(String name, LevelChangeable changeable) implements Consumer<RootRouter> {
+	private void  subscribe(String name, RootRouter router, ReplaceableLogger changeable, Set<ChangeType> allowedChanges) {
+		var consumer =  new Consumer<RootRouter> (){
 
 			@Override
 			public void accept(RootRouter r) {
-				var slf4jLevel = Levels.toSlf4jLevel(r.levelResolver().resolveLevel(name));
+				var level = r.levelResolver().resolveLevel(name);
+				var slf4jLevel = Levels.toSlf4jLevel(level);
 				changeable.setLevel(slf4jLevel);
+				var logger = r.route(name, level);
+				var handler = maybeAddCallerInfo(name, allowedChanges, logger, 1);
+				changeable.setEventHandler(handler);
 			}
 
-		}
-		router.onChange(new Slf4JOnChange(name, changeable));
+		};
+		router.onChange(consumer);
 		// router.onChange(r -> {
 		// var slf4jLevel = Levels.toSlf4jLevel(r.levelResolver().resolveLevel(name));
 		// changeable.setLevel(slf4jLevel);

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
@@ -22,11 +22,29 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 
 	private final ConcurrentMap<String, Logger> loggerMap;
 
-	private final RainbowGum rainbowGum;
+	/*
+	 * Spring Boot (and anything else with its own pre-boot bootstrap sequence) can
+	 * install a bootstrap RainbowGum, have SLF4J's ServiceLoader-triggered initialize()
+	 * capture it here, and only later RainbowGum.set(...) the "real" one - this factory
+	 * would otherwise be stuck forever routing new getLogger(...) calls through the stale
+	 * bootstrap instance. onGlobalChange (below) keeps this current. Already-created
+	 * Logger instances in loggerMap are deliberately NOT rebound here - that is a
+	 * separate, lower-priority concern already partially covered by
+	 * ChangeableLogger/ReplaceableLogger's own per-logger level subscription.
+	 */
+	private volatile RainbowGum rainbowGum;
 
 	private final LoggerDecorator decorator;
 
 	private final RainbowGumMDCAdapter mdc;
+
+	/*
+	 * Held here (as opposed to inline at the subscribe call below) so this factory keeps
+	 * it strongly reachable - RainbowGum.onGlobalChange only holds a weak reference, so
+	 * an inline lambda with no other strong referrer could become eligible for GC almost
+	 * immediately after subscribing.
+	 */
+	private final Consumer<RainbowGum> onGlobalChange = gum -> this.rainbowGum = gum;
 
 	public RainbowGumLoggerFactory(RainbowGum rainbowGum, RainbowGumMDCAdapter mdc) {
 		super();
@@ -34,6 +52,7 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 		this.rainbowGum = rainbowGum;
 		this.decorator = LoggerDecorator.of(rainbowGum);
 		this.mdc = mdc;
+		RainbowGum.onGlobalChange(onGlobalChange);
 	}
 
 	@Override
@@ -43,8 +62,9 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 			return simpleLogger;
 		}
 		else {
-			var router = this.rainbowGum.router();
-			var changePublisher = this.rainbowGum.config().changePublisher();
+			var currentRainbowGum = this.rainbowGum;
+			var router = currentRainbowGum.router();
+			var changePublisher = currentRainbowGum.config().changePublisher();
 
 			DepthAwareLogger newLogger;
 			var level = router.levelResolver().resolveLevel(name);
@@ -74,7 +94,7 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 					newLogger = LevelLogger.of(slf4jLevel, handler);
 				}
 			}
-			Logger decorated = decorator.decorate(rainbowGum, newLogger);
+			Logger decorated = decorator.decorate(currentRainbowGum, newLogger);
 			Logger oldInstance = loggerMap.putIfAbsent(name, decorated);
 			return oldInstance == null ? decorated : oldInstance;
 		}

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
@@ -27,10 +27,13 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 	 * install a bootstrap RainbowGum, have SLF4J's ServiceLoader-triggered initialize()
 	 * capture it here, and only later RainbowGum.set(...) the "real" one - this factory
 	 * would otherwise be stuck forever routing new getLogger(...) calls through the stale
-	 * bootstrap instance. onGlobalChange (below) keeps this current. Already-created
-	 * Logger instances in loggerMap are deliberately NOT rebound here - that is a
-	 * separate, lower-priority concern already partially covered by
-	 * ChangeableLogger/ReplaceableLogger's own per-logger level subscription.
+	 * bootstrap instance's config/decorators. onGlobalChange (below) keeps this current
+	 * for names looked up after the swap. Already-created Logger instances in loggerMap
+	 * are a separate concern: ones allowed to change level (ReplaceableLogger, below) are
+	 * kept current independently via the router's own RouteChangePublisher, which is how
+	 * a bootstrap-era ReplaceableLogger stops pointing at the queued placeholder router
+	 * once a real router replaces it (see subscribe()). Loggers that were not allowed to
+	 * change (LevelLogger) are not, and never were, revisited after creation.
 	 */
 	private volatile RainbowGum rainbowGum;
 
@@ -74,10 +77,6 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 				 * We get a logger that can log everything.
 				 */
 				LogEventLogger logger = router.route(name, System.Logger.Level.ERROR);
-				// boolean callerInfo = allowedChanges.contains(ChangeType.CALLER);
-				// ChangeableLogger changeable = new ChangeableLogger(name, logger, mdc,
-				// Levels.toSlf4jInt(level),
-				// callerInfo);
 				var handler = maybeAddCallerInfo(name, allowedChanges, logger, 1);
 				var changeable = ReplaceableLogger.of(Levels.toSlf4jLevel(level), handler);
 				subscribe(name, router, changeable, allowedChanges);
@@ -100,25 +99,31 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 		}
 	}
 
-	private void  subscribe(String name, RootRouter router, ReplaceableLogger changeable, Set<ChangeType> allowedChanges) {
-		var consumer =  new Consumer<RootRouter> (){
+	/*
+	 * router here is whatever RootRouter was current at getLogger() time - during Spring
+	 * Boot's pre-boot phase that is LogRouter.global() itself (the bootstrap RainbowGum's
+	 * router() literally is the global router facade), so this subscribes to the *same*
+	 * RouteChangePublisher that GlobalLogRouter transfers its queued subscribers into
+	 * once a real router replaces the placeholder queue (see
+	 * InternalRootRouter.setRouter/GlobalLogRouter._drain). r (below) is that replacement
+	 * router - re-resolving the route against it, not just the level, is what stops an
+	 * already-created ReplaceableLogger from continuing to dispatch into the
+	 * now-abandoned queue after the swap.
+	 */
+	private void subscribe(String name, RootRouter router, ReplaceableLogger changeable,
+			Set<ChangeType> allowedChanges) {
+		router.onChange(new Consumer<RootRouter>() {
 
 			@Override
 			public void accept(RootRouter r) {
 				var level = r.levelResolver().resolveLevel(name);
-				var slf4jLevel = Levels.toSlf4jLevel(level);
-				changeable.setLevel(slf4jLevel);
+				changeable.setLevel(Levels.toSlf4jLevel(level));
 				var logger = r.route(name, level);
 				var handler = maybeAddCallerInfo(name, allowedChanges, logger, 1);
 				changeable.setEventHandler(handler);
 			}
 
-		};
-		router.onChange(consumer);
-		// router.onChange(r -> {
-		// var slf4jLevel = Levels.toSlf4jLevel(r.levelResolver().resolveLevel(name));
-		// changeable.setLevel(slf4jLevel);
-		// });
+		});
 	}
 
 	private LogEventHandler maybeAddCallerInfo(String loggerName, Set<ChangeType> allowedChanges, LogEventLogger logger,

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ReplaceableLogger.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ReplaceableLogger.java
@@ -3,9 +3,10 @@ package io.jstach.rainbowgum.slf4j;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
+import io.jstach.rainbowgum.slf4j.LogEventHandler.EventHandlerChangeable;
 import io.jstach.rainbowgum.slf4j.spi.LoggerDecoratorService.DepthAwareLogger;
 
-class ReplaceableLogger implements ForwardingLogger, LevelChangeable, DepthAwareLogger {
+class ReplaceableLogger implements ForwardingLogger, LevelChangeable, EventHandlerChangeable,  DepthAwareLogger {
 
 	private volatile LevelLogger logger;
 
@@ -27,6 +28,14 @@ class ReplaceableLogger implements ForwardingLogger, LevelChangeable, DepthAware
 	@Override
 	public void setLevel(Level level) {
 		this.logger = LevelLogger.of(level, logger.handler());
+	}
+	
+	@Override
+	public void setEventHandler(
+			LogEventHandler eventHandler) {
+		var level = logger.level();
+		this.logger = LevelLogger.of(level, eventHandler);
+		
 	}
 
 	@Override

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ReplaceableLogger.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/ReplaceableLogger.java
@@ -6,7 +6,7 @@ import org.slf4j.event.Level;
 import io.jstach.rainbowgum.slf4j.LogEventHandler.EventHandlerChangeable;
 import io.jstach.rainbowgum.slf4j.spi.LoggerDecoratorService.DepthAwareLogger;
 
-class ReplaceableLogger implements ForwardingLogger, LevelChangeable, EventHandlerChangeable,  DepthAwareLogger {
+class ReplaceableLogger implements ForwardingLogger, LevelChangeable, EventHandlerChangeable, DepthAwareLogger {
 
 	private volatile LevelLogger logger;
 
@@ -29,13 +29,10 @@ class ReplaceableLogger implements ForwardingLogger, LevelChangeable, EventHandl
 	public void setLevel(Level level) {
 		this.logger = LevelLogger.of(level, logger.handler());
 	}
-	
+
 	@Override
-	public void setEventHandler(
-			LogEventHandler eventHandler) {
-		var level = logger.level();
-		this.logger = LevelLogger.of(level, eventHandler);
-		
+	public void setEventHandler(LogEventHandler eventHandler) {
+		this.logger = LevelLogger.of(logger.level(), eventHandler);
 	}
 
 	@Override

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactoryTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactoryTest.java
@@ -242,6 +242,71 @@ class RainbowGumLoggerFactoryTest {
 		assertInstanceOf(LevelChangeable.class, logger);
 	}
 
+	/*
+	 * Reproduces the Spring Boot scenario: SLF4J's ServiceLoader-triggered initialize()
+	 * calls RainbowGum.of() once, very early, and captures whatever gum is bound at that
+	 * moment (Spring's own pre-boot bootstrap gum) into RainbowGumLoggerFactory forever -
+	 * or at least it used to, before rainbowGum became volatile and subscribed to
+	 * RainbowGum.onGlobalChange. Later, RainbowGum.builder(...).set() (as Spring's "real"
+	 * LoggingSystem does once fully configured) must be picked up by the *same* factory
+	 * instance for names looked up afterward, without anyone needing to construct a new
+	 * RainbowGumLoggerFactory.
+	 */
+	@Test
+	void testFactoryPicksUpANewGlobalRainbowGumForNamesLookedUpAfterTheSwap() {
+		// RainbowGumHolder is package-private to core and thus not visible here - an
+		// empty-config builder's unset() is the public equivalent used elsewhere
+		// (RainbowGumEntryPointTest) to force the global holder back to nothing, in
+		// case a prior test in this module's suite left it dirty.
+		RainbowGum.builder(LogConfig.builder().build()).unset();
+		try {
+			var bootstrapOutput = new ListLogOutput();
+			var bootstrapGum = gum(bootstrapOutput, LogProperties.StandardProperties.EMPTY);
+			var factory = new RainbowGumLoggerFactory(bootstrapGum, new RainbowGumMDCAdapter());
+			factory.getLogger("before.swap").info("via bootstrap gum");
+			assertEquals("INFO via bootstrap gum\n", bootstrapOutput.toString());
+			bootstrapOutput.events().clear();
+
+			var realOutput = new ListLogOutput();
+			try (var realGum = RainbowGum.builder(LogConfig.builder().build()).route(route -> {
+				route.appender("list", a -> {
+					a.formatter((output, event) -> {
+						output.append(event.level()).append(" ");
+						event.formattedMessage(output);
+						output.append("\n");
+					});
+					a.output(realOutput);
+				});
+			}).set()) {
+				// A name never looked up before the swap - this is the one factory
+				// instance created above, not a new one.
+				factory.getLogger("after.swap").info("via real gum");
+				assertEquals("", bootstrapOutput.toString(),
+						"the swap must not retroactively affect the bootstrap gum's own output");
+				assertEquals("INFO via real gum\n", realOutput.toString(),
+						"a logger name looked up after the swap must route through the newly-global gum");
+			}
+		}
+		finally {
+			RainbowGum.builder(LogConfig.builder().build()).unset();
+		}
+	}
+
+	private RainbowGum gum(ListLogOutput output, LogProperties props) {
+		LogConfig config = LogConfig.builder().properties(props).build();
+		var gum = RainbowGum.builder(config).route(route -> {
+			route.appender("list", a -> {
+				a.formatter((o, event) -> {
+					o.append(event.level()).append(" ");
+					event.formattedMessage(o);
+					o.append("\n");
+				});
+				a.output(output);
+			});
+		});
+		return gum.build();
+	}
+
 	private RainbowGum gum(LogProperties props) {
 		LogConfig config = LogConfig.builder().properties(props).build();
 		var gum = RainbowGum.builder(config).route(route -> {

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactoryTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactoryTest.java
@@ -292,6 +292,54 @@ class RainbowGumLoggerFactoryTest {
 		}
 	}
 
+	/*
+	 * Reproduces the other half of the Spring Boot scenario: RainbowGum.queued(config)
+	 * (what PreBootRainbowGumProvider actually hands SLF4J) uses LogRouter.global()
+	 * itself as its router, so a ReplaceableLogger obtained during this phase captures a
+	 * route resolved against whatever GlobalLogRouter's delegate currently is - the
+	 * initial QueueEventsRouter placeholder, which only buffers events rather than
+	 * writing them anywhere. RainbowGum.builder(...).set() below triggers
+	 * InternalRootRouter.setRouter(...), which transfers the queue's subscribers
+	 * (including this logger's subscribe() consumer) to the real router and publishes to
+	 * them - the same *logger instance* obtained above must then dispatch new log calls
+	 * through the real router, not keep writing into the now-abandoned queue.
+	 */
+	@Test
+	void testReplaceableLoggerObtainedDuringBootstrapDispatchesThroughTheRealRouterAfterSwap() {
+		RainbowGum.builder(LogConfig.builder().build()).unset();
+		try {
+			String preBootProperties = """
+					logging.global.change=true
+					logging.change=level
+					""";
+			var bootstrapConfig = LogConfig.builder()
+				.properties(LogProperties.builder().fromProperties(preBootProperties).build())
+				.build();
+			var bootstrapGum = RainbowGum.queued(bootstrapConfig);
+			var factory = new RainbowGumLoggerFactory(bootstrapGum, new RainbowGumMDCAdapter());
+			var logger = factory.getLogger("bootstrap.logger");
+			assertInstanceOf(LevelChangeable.class, logger,
+					"logging.change=level must make this a replaceable logger, same as Spring's pre-boot properties");
+
+			var realOutput = new ListLogOutput();
+			try (var realGum = RainbowGum.builder(LogConfig.builder().build()).route(route -> {
+				route.appender("list", a -> {
+					a.formatter((output, event) -> {
+						event.formattedMessage(output);
+						output.append("\n");
+					});
+					a.output(realOutput);
+				});
+			}).set()) {
+				logger.info("logged after real gum loads");
+				assertEquals("logged after real gum loads\n", realOutput.toString());
+			}
+		}
+		finally {
+			RainbowGum.builder(LogConfig.builder().build()).unset();
+		}
+	}
+
 	private RainbowGum gum(ListLogOutput output, LogProperties props) {
 		LogConfig config = LogConfig.builder().properties(props).build();
 		var gum = RainbowGum.builder(config).route(route -> {

--- a/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/ReplaceableLoggerTest.java
+++ b/rainbowgum-slf4j/src/test/java/io/jstach/rainbowgum/slf4j/ReplaceableLoggerTest.java
@@ -45,6 +45,21 @@ class ReplaceableLoggerTest {
 	}
 
 	@Test
+	void testSetEventHandlerChangesWhereLogCallsGo() {
+		var logger = ReplaceableLogger.of(Level.INFO, handler);
+		logger.info("via original handler");
+		assertEquals("test", lastEvent.loggerName());
+
+		LogEvent[] rebound = new LogEvent[1];
+		LogEventHandler newHandler = LogEventHandler.ofCallerInfo("rebound", e -> rebound[0] = e,
+				new RainbowGumMDCAdapter(), 1);
+		logger.setEventHandler(newHandler);
+		logger.info("via rebound handler");
+		assertEquals("via rebound handler", rebound[0].message());
+		assertEquals("rebound", rebound[0].loggerName());
+	}
+
+	@Test
 	void testWithDepthCompensatesForOneExtraWrappingLayer() {
 		// depth=1 here mirrors RainbowGumLoggerFactory's own ChangeType.LEVEL branch,
 		// which already compensates for ReplaceableLogger's own ForwardingLogger

--- a/spring/rainbowgum-spring-boot3-starter/pom.xml
+++ b/spring/rainbowgum-spring-boot3-starter/pom.xml
@@ -36,23 +36,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <!--
-          Rainbow gum's own java.util.logging handler is currently slower than
-          desired under Spring Boot (embedded Tomcat is JUL-heavy). Note that
-          RainbowGumLoggingSystemFactory replaces Spring Boot's LoggingSystem entirely,
-          so Spring Boot's own Logback-specific jul-to-slf4j wiring
-          (LogbackLoggingSystem) never runs here either - excluding this artifact means
-          java.util.logging output (e.g. from embedded Tomcat) is not captured at all
-          for now, not redirected elsewhere. Excluding this artifact (rather than
-          rainbowgum-jdk) keeps io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory
-          (the System.Logger bridge) intact.
-        -->
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>rainbowgum-jul</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring/rainbowgum-spring-boot3/pom.xml
+++ b/spring/rainbowgum-spring-boot3/pom.xml
@@ -61,6 +61,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-jdk</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-spring-spi</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/spring/rainbowgum-spring-boot4-starter/pom.xml
+++ b/spring/rainbowgum-spring-boot4-starter/pom.xml
@@ -47,11 +47,11 @@
           for now, not redirected elsewhere. Excluding this artifact (rather than
           rainbowgum-jdk) keeps io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory
           (the System.Logger bridge) intact.
-        -->
         <exclusion>
           <groupId>${project.groupId}</groupId>
           <artifactId>rainbowgum-jul</artifactId>
         </exclusion>
+        -->
       </exclusions>
     </dependency>
     <dependency>

--- a/spring/rainbowgum-spring-boot4-starter/pom.xml
+++ b/spring/rainbowgum-spring-boot4-starter/pom.xml
@@ -36,23 +36,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <!--
-          Rainbow gum's own java.util.logging handler is currently slower than
-          desired under Spring Boot (embedded Tomcat is JUL-heavy). Note that
-          RainbowGumLoggingSystemFactory replaces Spring Boot's LoggingSystem entirely,
-          so Spring Boot's own Logback-specific jul-to-slf4j wiring
-          (LogbackLoggingSystem) never runs here either - excluding this artifact means
-          java.util.logging output (e.g. from embedded Tomcat) is not captured at all
-          for now, not redirected elsewhere. Excluding this artifact (rather than
-          rainbowgum-jdk) keeps io.jstach.rainbowgum.jdk.systemlogger.SystemLoggingFactory
-          (the System.Logger bridge) intact.
-        <exclusion>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>rainbowgum-jul</artifactId>
-        </exclusion>
-        -->
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring/rainbowgum-spring-boot4/pom.xml
+++ b/spring/rainbowgum-spring-boot4/pom.xml
@@ -61,6 +61,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-jdk</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-spring-spi</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/test/rainbowgum-test-spring-boot4/src/main/java/io/jstach/rainbowgum/test/spring/boot/App.java
+++ b/test/rainbowgum-test-spring-boot4/src/main/java/io/jstach/rainbowgum/test/spring/boot/App.java
@@ -27,13 +27,17 @@ public class App {
 	 */
 	public static void main(String[] args) {
 
+		// If created here it will be a replaceable logger.
+		//Logger log = LoggerFactory.getLogger("blah");
+		
 		SpringApplication.run(App.class, args);
+		// If created here it will be a level logger.
+		Logger log = LoggerFactory.getLogger("blah");
 		java.util.logging.Logger jul = java.util.logging.Logger.getLogger("blah");
 		jul.log(Level.INFO, "hello jul");
 		jul.log(Level.INFO, "hello again jul");
-		Logger log = LoggerFactory.getLogger("blah");
 		log.info("Hello Spring Boot");
-		log.info("Logger: {}", log.getClass().getPackage());
+		log.info("Logger: {}", log.getClass());
 	}
 
 }

--- a/test/rainbowgum-test-spring-boot4/src/main/java/io/jstach/rainbowgum/test/spring/boot/App.java
+++ b/test/rainbowgum-test-spring-boot4/src/main/java/io/jstach/rainbowgum/test/spring/boot/App.java
@@ -27,16 +27,20 @@ public class App {
 	 */
 	public static void main(String[] args) {
 
-		// If created here it will be a replaceable logger.
-		//Logger log = LoggerFactory.getLogger("blah");
-		
-		SpringApplication.run(App.class, args);
-		// If created here it will be a level logger.
+		// Obtained before Spring finishes booting: this is a replaceable logger bound
+		// to the bootstrap RainbowGum's queued router - RouteChangePublisher rebinds
+		// it to the real router once Spring's LoggingSystem sets one, so the same
+		// instance keeps working correctly (rather than continuing to dispatch into
+		// the now-abandoned queue) before and after the swap below.
 		Logger log = LoggerFactory.getLogger("blah");
 		java.util.logging.Logger jul = java.util.logging.Logger.getLogger("blah");
-		jul.log(Level.INFO, "hello jul");
-		jul.log(Level.INFO, "hello again jul");
-		log.info("Hello Spring Boot");
+		jul.log(Level.INFO, "hello jul before boot");
+		log.info("Hello before Spring Boot");
+
+		SpringApplication.run(App.class, args);
+
+		jul.log(Level.INFO, "hello jul after boot");
+		log.info("Hello after Spring Boot");
 		log.info("Logger: {}", log.getClass());
 	}
 


### PR DESCRIPTION
…l swap

SLF4J's ServiceLoader-triggered initialize() calls RainbowGum.of() exactly once and permanently binds RainbowGumLoggerFactory to whatever gum was current at that moment. Frameworks with their own pre-boot bootstrap sequence (Spring Boot's PreBootRainbowGumProvider) install a bootstrap gum early, then later RainbowGum.set(...) the "real" fully-configured one - but the SLF4J factory had no way of finding out, so new getLogger(...) calls kept routing through the stale bootstrap instance forever.

Adds RainbowGum.onGlobalChange(Consumer<RainbowGum>), a JVM-global publisher (distinct from the per-instance LogConfig.ChangePublisher/ LogRouter.RouteChangePublisher) fired from RainbowGumHolder.get() after the write lock releases, only on the path that actually resolves/starts a new instance (not the already-resolved fast path). Consumers are held weakly, since this is static JVM-lifetime state - a plain strong-ref list would pin every subscriber (e.g. every RainbowGumLoggerFactory created across a test suite) forever.

RainbowGumLoggerFactory's rainbowGum field is now volatile and subscribes on construction, updating it whenever the global gum changes. Already- cached SLF4J Logger instances are deliberately not rebound - lower priority, and already partially covered by ChangeableLogger/ ReplaceableLogger's own per-logger level subscription.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5