### PR TITLE
Mirror slf4j javadoc link for CI reliability, fix a stale-bytes bug i…

### DIFF
--- a/bin/src/main/java/io/jstach/script/JavadocJavascript.java
+++ b/bin/src/main/java/io/jstach/script/JavadocJavascript.java
@@ -19,6 +19,19 @@ public class JavadocJavascript {
 
 	final static String DOC_ROOT = "../";
 
+	/*
+	 * pom.xml's slf4j.javadoc.link property points the javadoc-plugin's <links> config
+	 * at a mirror of just the small element-list index file (not the real javadoc
+	 * site) by default, since www.slf4j.org is sometimes unreachable from GitHub
+	 * Actions - see that property's comment for the full explanation. Any generated
+	 * cross-reference hrefs need to be pointed back at the real site before
+	 * publishing. deploy-release builds already use the real URL directly, so this is
+	 * a no-op safety net for them, not their primary fix.
+	 */
+	static final String SLF4J_MIRROR_LINK = "https://jstach.io/doc/mirrors/slf4j/api/";
+
+	static final String SLF4J_REAL_LINK = "https://www.slf4j.org/api/";
+
 	public static void main(String[] args) {
 		try {
 			if (args.length > 0) {
@@ -72,7 +85,7 @@ public class JavadocJavascript {
 			}
 		}
 		if (found) {
-			Files.write(htmlPath, processed, StandardOpenOption.WRITE);
+			Files.write(htmlPath, processed, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
 		}
 		else {
 			out.println("header not found for: " + htmlPath);
@@ -96,7 +109,7 @@ public class JavadocJavascript {
 			}
 		}
 		if (found) {
-			Files.write(searchJs, processed, StandardOpenOption.WRITE);
+			Files.write(searchJs, processed, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
 		}
 		else {
 			throw new IOException("search.focus not found");
@@ -108,7 +121,8 @@ public class JavadocJavascript {
 		List<String> lines = Files.readAllLines(htmlPath);
 		List<String> processed = new ArrayList<>();
 		boolean found = false;
-		for (String line : lines) {
+		for (String rawLine : lines) {
+			String line = fixMirroredLinks(rawLine);
 			if (line.startsWith("</body>")) {
 				found = true;
 				processed.add(scriptTag("https://cdnjs.cloudflare.com/ajax/libs/tocbot/4.18.2/tocbot.min.js"));
@@ -124,7 +138,13 @@ public class JavadocJavascript {
 			}
 		}
 		if (found) {
-			Files.write(htmlPath, processed, StandardOpenOption.WRITE);
+			/*
+			 * TRUNCATE_EXISTING matters here specifically because fixMirroredLinks can
+			 * shrink a line (the mirror URL is longer than the real one) - WRITE alone
+			 * only overwrites from the start, leaving stale trailing bytes from the
+			 * previous (longer) version of the file if the new content is shorter.
+			 */
+			Files.write(htmlPath, processed, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
 		}
 		else {
 			out.println("body tag not found for: " + htmlPath);
@@ -133,6 +153,10 @@ public class JavadocJavascript {
 
 	static String scriptTag(String src) {
 		return "<script src=\"" + src + "\"></script>";
+	}
+
+	static String fixMirroredLinks(String line) {
+		return line.replace(SLF4J_MIRROR_LINK, SLF4J_REAL_LINK);
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,16 @@
     <pistachio.version>0.1.2</pistachio.version>
     <jstachio.version>1.3.7</jstachio.version>
     <slf4j.version>2.0.18</slf4j.version>
-    <!-- 
+    <!--
+      https://www.slf4j.org/api/ is sometimes unreachable from GitHub Actions
+      (fetching element-list for javadoc <link> fails the build), so this defaults to
+      a mirrored copy of just that one small index file hosted on our own GitHub
+      Pages. The deploy-release profile overrides this back to the real slf4j.org URL,
+      and doc/JavadocJavascript.java rewrites any mirror links that do make it into
+      generated HTML back to the real URL as a safety net.
+    -->
+    <slf4j.javadoc.link>https://jstach.io/doc/mirrors/slf4j/api/</slf4j.javadoc.link>
+    <!--
       This is needed because of moditect generating
       the module-info for the annotation processing
       jar which angers the javadoc system.
@@ -563,7 +572,7 @@
               </tags>
               <failOnWarnings>true</failOnWarnings>
               <links>
-                <link>https://www.slf4j.org/api/</link>
+                <link>${slf4j.javadoc.link}</link>
               </links>
               <javadocDirectory>${parent.root}/doc</javadocDirectory>
               <excludePackageNames>
@@ -758,7 +767,8 @@
       </activation>
       <properties>
         <maven.build.cache.enabled>false</maven.build.cache.enabled>
-      </properties> 
+        <slf4j.javadoc.link>https://www.slf4j.org/api/</slf4j.javadoc.link>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/rainbowgum-jdk/src/main/java/io/jstach/rainbowgum/jdk/systemlogger/SystemLoggingFactory.java
+++ b/rainbowgum-jdk/src/main/java/io/jstach/rainbowgum/jdk/systemlogger/SystemLoggingFactory.java
@@ -40,6 +40,11 @@ public final class SystemLoggingFactory extends RainbowGumSystemLoggerFinder {
 
 	}
 
+	/**
+	 * For subclasses/testing that need to supply properties directly rather than through
+	 * the no-arg constructor's {@link LogProperties#findGlobalProperties()}.
+	 * @param properties properties to resolve the init option from.
+	 */
 	protected SystemLoggingFactory(LogProperties properties) {
 		super(() -> initOption(properties));
 	}


### PR DESCRIPTION
…n JavadocJavascript

www.slf4j.org (Hostinger-hosted, unrelated to GitHub - confirmed via DNS/IP lookup before relying on this) is sometimes unreachable from GitHub Actions, failing the build when maven-javadoc-plugin's <links> config tries to fetch its element-list. New slf4j.javadoc.link property defaults to a mirror of just that one small index file, hosted at jstach.io/doc/mirrors/slf4j/api/ (jstachio/jstachio.github.io, same GitHub Pages site this project already publishes its own javadoc to - reachable from GitHub Actions by definition). deploy-release overrides the property back to the real slf4j.org URL, and JavadocJavascript.java (run only for the aggregate "doc" site build) rewrites any mirror links that do make it into generated HTML back to the real URL as a safety net, so the published site is correct either way.

Along the way, found and fixed a real bug in JavadocJavascript.java: its Files.write(path, lines, StandardOpenOption.WRITE) calls never truncated the target file. Every existing transformation there only ever grew file content (adding script tags, etc.), so this never manifested - the new link-fixing transformation is the first one that can shrink a line (the mirror URL is longer than the real one), and without TRUNCATE_EXISTING that left stale trailing bytes from the previous, longer version of the file. Confirmed with a minimal repro before fixing all three Files.write call sites.

Also fixes an unrelated pre-existing javadoc warning (a protected constructor with no comment) in SystemLoggingFactory, found because the "doc" aggregate profile - which merges in show=protected - surfaces it where the default show=public per-module build does not; failOnWarnings=true was failing the aggregate build on it.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5