### PR TITLE
Add THREAD_LOCAL_BUFFER appender flag

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -103,6 +103,30 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 */
 		THREAD_LOCAL_BUFFER,
 		/**
+		 * Like {@link #THREAD_LOCAL_BUFFER} (a reused per-thread buffer, encoding done
+		 * outside any lock) except the final write to the output is protected by a plain
+		 * {@code synchronized} block (the JVM's intrinsic monitor) instead of the
+		 * {@link ReentrantLock}-based {@code AppenderLock} every other flag combination
+		 * uses.
+		 * <p>
+		 * The Java language has no way to acquire a monitor in one method call and
+		 * release it in another the way {@code AppenderLock.lock()}/{@code unlock()}
+		 * works, so this is not a pluggable lock strategy on top of the existing
+		 * appenders - it is a separate appender implementation with the critical section
+		 * written as a literal {@code synchronized} block. Consequently
+		 * {@link #REENTRY_DROP} and {@link #REENTRY_LOG} - which rely on
+		 * {@code AppenderLock}'s {@code ReentrantLock} for same-thread reentrancy
+		 * detection - are ignored if this flag is set.
+		 * <p>
+		 * Experimental: motivated by Log4j2's own garbage-free appenders using
+		 * {@code synchronized} rather than a {@code java.util.concurrent} lock around
+		 * their buffer-transfer step, and prior microbenchmarking suggesting the JVM's
+		 * intrinsic monitor can outperform {@link ReentrantLock} here. Takes precedence
+		 * over {@link #THREAD_LOCAL_BUFFER} (redundant if both are set) but not
+		 * {@link #REUSE_BUFFER}.
+		 */
+		SYNCHRONIZED_THREAD_LOCAL_BUFFER,
+		/**
 		 * By default the appender will call flush on each item appended or if in async
 		 * batch mode for each batch. This flag disables that behavior so that flushing is
 		 * left up to the output (or an external mechanism) instead.
@@ -573,6 +597,9 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
 			return new ReuseBufferLogAppender(name, output, encoder, flags, lock);
 		}
+		if (flags.contains(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags);
+		}
 		if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
 		}
@@ -805,6 +832,9 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
 			return new ReuseBufferLogAppender(name, output, encoder, flags, lock);
 		}
+		if (flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags);
+		}
 		if (flags.contains(LogAppender.AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
 		}
@@ -982,6 +1012,95 @@ final class ThreadLocalBufferLogAppender extends LockLogAppender implements Inte
 		finally {
 			lock.unlock();
 		}
+	}
+
+}
+
+/*
+ * Like ThreadLocalBufferLogAppender (per-thread reused buffer, encode outside any lock)
+ * but the final write is protected by a plain `synchronized` block on this appender's own
+ * monitor instead of AppenderLock/ReentrantLock. Does not extend LockLogAppender - there
+ * is no way to acquire a monitor in one method call and release it in another the way
+ * AppenderLock.lock()/unlock() works, so this appender's critical sections are written as
+ * literal synchronized blocks instead of going through that abstraction at all.
+ */
+final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender implements InternalLogAppender {
+
+	private final Object monitor = new Object();
+
+	// See ThreadLocalBufferLogAppender's identical field for why this suppression is
+	// needed.
+	@SuppressWarnings("nullness:type.argument")
+	private final ThreadLocal<LogEncoder.Buffer> bufferThreadLocal;
+
+	SynchronizedThreadLocalBufferLogAppender(String name, LogOutput output, LogEncoder encoder,
+			Set<LogAppender.AppenderFlag> flags) {
+		super(name, output, encoder, flags);
+		this.bufferThreadLocal = ThreadLocal.withInitial(() -> encoder.buffer(output.bufferHints()));
+	}
+
+	@Override
+	public void append(LogEvent event) {
+		var buffer = bufferThreadLocal.get();
+		buffer.clear();
+		encoder.encode(event, buffer);
+		synchronized (monitor) {
+			output.write(event, buffer);
+			if (immediateFlush) {
+				output.flush();
+			}
+		}
+	}
+
+	@Override
+	public void append(LogEvent[] events, int count) {
+		synchronized (monitor) {
+			output.write(events, count, encoder, bufferThreadLocal.get());
+			if (immediateFlush) {
+				output.flush();
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		synchronized (monitor) {
+			super.close();
+		}
+	}
+
+	@Override
+	public List<LogResponse> act(LogAction action) {
+		synchronized (monitor) {
+			try {
+				return _request(action);
+			}
+			catch (UncheckedIOException ioe) {
+				return List.of(new Response(LogOutput.class, name, Status.ErrorStatus.of(ioe)));
+			}
+		}
+	}
+
+	@Override
+	public DirectLogAppender withFlags(Set<LogAppender.AppenderFlag> flags) {
+		if (flags.isEmpty()) {
+			return this;
+		}
+		if (this.flags.containsAll(flags)) {
+			return this;
+		}
+		flags = EnumSet.copyOf(flags);
+		flags.addAll(this.flags);
+		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
+			return new ReuseBufferLogAppender(name, output, encoder, flags, AppenderLock.of(flags));
+		}
+		if (flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags);
+		}
+		if (flags.contains(LogAppender.AppenderFlag.THREAD_LOCAL_BUFFER)) {
+			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, AppenderLock.of(flags));
+		}
+		return new DefaultLogAppender(name, output, encoder, flags, AppenderLock.of(flags));
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -85,6 +85,24 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 */
 		REUSE_BUFFER,
 		/**
+		 * The appender will give each thread its own reusable buffer (a
+		 * {@link ThreadLocal}) instead of allocating a new buffer per event. Unlike
+		 * {@link #REUSE_BUFFER} the encoding is done <strong>outside</strong> the
+		 * appender's lock (the thread's buffer is only visited by that thread so no
+		 * protection is needed while encoding) with the lock only held for the final
+		 * write to the output, which is the same trade-off {@link #REUSE_BUFFER} makes
+		 * except without serializing the encoding step itself.
+		 * <p>
+		 * This flag is ignored if {@link #REUSE_BUFFER} is also set.
+		 * <p>
+		 * <strong>This is designed for a fixed, modestly sized pool of platform threads
+		 * doing the logging.</strong> With virtual threads the high cardinality and short
+		 * lifetime of the threads means buffers are rarely reused and instead pile up as
+		 * garbage, which is likely worse than just allocating a buffer per event as
+		 * {@link DefaultLogAppender} already does.
+		 */
+		THREAD_LOCAL_BUFFER,
+		/**
 		 * By default the appender will call flush on each item appended or if in async
 		 * batch mode for each batch. This flag disables that behavior so that flushing is
 		 * left up to the output (or an external mechanism) instead.
@@ -555,6 +573,9 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
 			return new ReuseBufferLogAppender(name, output, encoder, flags, lock);
 		}
+		if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
+			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
+		}
 		return new DefaultLogAppender(name, output, encoder, flags, lock);
 	}
 
@@ -784,6 +805,9 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
 			return new ReuseBufferLogAppender(name, output, encoder, flags, lock);
 		}
+		if (flags.contains(LogAppender.AppenderFlag.THREAD_LOCAL_BUFFER)) {
+			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
+		}
 		return new DefaultLogAppender(name, output, encoder, flags, lock);
 	}
 
@@ -889,6 +913,71 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 		try {
 			super.close();
 			buffer.close();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+}
+
+/*
+ * The idea here is like DefaultLogAppender: encode outside the lock. However instead of
+ * allocating a fresh buffer per event (DefaultLogAppender) or sharing (and thus
+ * serializing access to) a single buffer (ReuseBufferLogAppender) each thread gets its
+ * own buffer that only it will ever touch, so encoding never needs to be guarded by the
+ * lock at all - only the final write to the output does.
+ */
+final class ThreadLocalBufferLogAppender extends LockLogAppender implements InternalLogAppender {
+
+	/*
+	 * There is no way to enumerate every thread's buffer to close it on appender close so
+	 * we rely on Buffer implementations not holding onto real resources (today they are
+	 * all just wrapped in-memory builders) and let the ThreadLocal itself (and
+	 * consequently the per-thread entries) become collectible once this appender is
+	 * discarded.
+	 */
+	// CheckerFramework's ThreadLocal stub declares T as inherently @Nullable since get()
+	// can return null before initialValue() runs, but withInitial(...) below guarantees
+	// it never does here.
+	@SuppressWarnings("nullness:type.argument")
+	private final ThreadLocal<LogEncoder.Buffer> bufferThreadLocal;
+
+	ThreadLocalBufferLogAppender(String name, LogOutput output, LogEncoder encoder, Set<LogAppender.AppenderFlag> flags,
+			AppenderLock lock) {
+		super(name, output, encoder, flags, lock);
+		this.bufferThreadLocal = ThreadLocal.withInitial(() -> encoder.buffer(output.bufferHints()));
+	}
+
+	@Override
+	public final void append(LogEvent event) {
+		var buffer = bufferThreadLocal.get();
+		buffer.clear();
+		encoder.encode(event, buffer);
+		if (!lock.tryLock()) {
+			return;
+		}
+		try {
+			output.write(event, buffer);
+			if (immediateFlush) {
+				output.flush();
+			}
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void append(LogEvent[] events, int count) {
+		if (!lock.tryLock()) {
+			return;
+		}
+		try {
+			output.write(events, count, encoder, bufferThreadLocal.get());
+			if (immediateFlush) {
+				output.flush();
+			}
 		}
 		finally {
 			lock.unlock();

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -115,6 +115,9 @@ class AppenderAsModeFlagPermutationTest {
 		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
 			expectedAppenderClass = ReuseBufferLogAppender.class;
 		}
+		else if (flags.contains(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
+			expectedAppenderClass = SynchronizedThreadLocalBufferLogAppender.class;
+		}
 		else if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			expectedAppenderClass = ThreadLocalBufferLogAppender.class;
 		}

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -111,8 +111,16 @@ class AppenderAsModeFlagPermutationTest {
 		assertEquals(expectedFlushes, outputA.flushCount, "outputA flush count");
 		assertEquals(expectedFlushes, outputB.flushCount, "outputB flush count");
 
-		Class<?> expectedAppenderClass = flags.contains(AppenderFlag.REUSE_BUFFER) ? ReuseBufferLogAppender.class
-				: DefaultLogAppender.class;
+		Class<?> expectedAppenderClass;
+		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
+			expectedAppenderClass = ReuseBufferLogAppender.class;
+		}
+		else if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
+			expectedAppenderClass = ThreadLocalBufferLogAppender.class;
+		}
+		else {
+			expectedAppenderClass = DefaultLogAppender.class;
+		}
 		for (var direct : directAppenders(mode, publisher)) {
 			assertInstanceOf(expectedAppenderClass, direct);
 		}

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -124,6 +124,26 @@ class LogAppenderFlagTest {
 	}
 
 	@Test
+	void immediateFlushFlagsRespectedWithSynchronizedThreadLocalBuffer() {
+		var output = new CountingListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER,
+				AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, testAppender);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("single")));
+		testAppender.append(new LogEvent[] { TestEventBuilder.of().build(b -> b.message("batch")) }, 1);
+		assertEquals(0, output.flushCount);
+	}
+
+	@Test
+	void synchronizedThreadLocalBufferFlagReusesBufferPerThread() {
+		var output = new ListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("one")));
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("two")));
+		assertEquals(List.of("one", "two"), output.events().stream().map(e -> e.getKey().message()).toList());
+	}
+
+	@Test
 	void appenderLevelFlagsMergeOntoExistingAppenderWithoutReuseBuffer() {
 		LogConfig config = LogConfig.builder().build();
 		var output = new CountingListLogOutput();

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -104,6 +104,26 @@ class LogAppenderFlagTest {
 	}
 
 	@Test
+	void immediateFlushFlagsRespectedWithThreadLocalBuffer() {
+		var output = new CountingListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.THREAD_LOCAL_BUFFER,
+				AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
+		assertInstanceOf(ThreadLocalBufferLogAppender.class, testAppender);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("single")));
+		testAppender.append(new LogEvent[] { TestEventBuilder.of().build(b -> b.message("batch")) }, 1);
+		assertEquals(0, output.flushCount);
+	}
+
+	@Test
+	void threadLocalBufferFlagReusesBufferPerThread() {
+		var output = new ListLogOutput();
+		var testAppender = appender("test", output, AppenderFlag.THREAD_LOCAL_BUFFER);
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("one")));
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("two")));
+		assertEquals(List.of("one", "two"), output.events().stream().map(e -> e.getKey().message()).toList());
+	}
+
+	@Test
 	void appenderLevelFlagsMergeOntoExistingAppenderWithoutReuseBuffer() {
 		LogConfig config = LogConfig.builder().build();
 		var output = new CountingListLogOutput();

--- a/core/src/test/java/io/jstach/rainbowgum/RainbowGumPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RainbowGumPropertyTest.java
@@ -87,6 +87,24 @@ class RainbowGumPropertyTest {
 				assertInstanceOf(ReuseBufferLogAppender.class, publisher.appender());
 			}
 
+		},
+		THREAD_LOCAL_BUFFER_APPENDER("""
+				logging.appenders=list
+				logging.appender.list.output=list
+				logging.level=ERROR
+				logging.appender.list.flags=thread_local_buffer
+				""", """
+				00:00:00.001 [main] ERROR com.pattern.test.Test - hello
+				""") {
+
+			@Override
+			void assertOther(RainbowGum gum) {
+				SingleSyncRootRouter rootRouter = (SingleSyncRootRouter) gum.router();
+				var router = rootRouter.router();
+				DefaultSyncLogPublisher publisher = (DefaultSyncLogPublisher) router.publisher();
+				assertInstanceOf(ThreadLocalBufferLogAppender.class, publisher.appender());
+			}
+
 		};
 
 		private final String properties;

--- a/core/src/test/java/io/jstach/rainbowgum/RainbowGumPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RainbowGumPropertyTest.java
@@ -105,6 +105,24 @@ class RainbowGumPropertyTest {
 				assertInstanceOf(ThreadLocalBufferLogAppender.class, publisher.appender());
 			}
 
+		},
+		SYNCHRONIZED_THREAD_LOCAL_BUFFER_APPENDER("""
+				logging.appenders=list
+				logging.appender.list.output=list
+				logging.level=ERROR
+				logging.appender.list.flags=synchronized_thread_local_buffer
+				""", """
+				00:00:00.001 [main] ERROR com.pattern.test.Test - hello
+				""") {
+
+			@Override
+			void assertOther(RainbowGum gum) {
+				SingleSyncRootRouter rootRouter = (SingleSyncRootRouter) gum.router();
+				var router = rootRouter.router();
+				DefaultSyncLogPublisher publisher = (DefaultSyncLogPublisher) router.publisher();
+				assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, publisher.appender());
+			}
+
 		};
 
 		private final String properties;


### PR DESCRIPTION
Gives each thread its own reusable encoder buffer instead of a fresh allocation per event (DefaultLogAppender) or one shared buffer serialized under the lock (REUSE_BUFFER). Encoding happens outside the lock like DefaultLogAppender; only the final write is locked, avoiding REUSE_BUFFER's contention cost while still avoiding per-event buffer allocation. Intended for a fixed pool of platform threads - documented as likely counterproductive under virtual threads given their cardinality/lifetime.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5