### PR TITLE
Make buffer-reusing appenders the default, not just an opt-in flag

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -95,19 +96,24 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 * <p>
 		 * This flag is ignored if {@link #REUSE_BUFFER} is also set.
 		 * <p>
-		 * <strong>This is designed for a fixed, modestly sized pool of platform threads
-		 * doing the logging.</strong> With virtual threads the high cardinality and short
-		 * lifetime of the threads means buffers are rarely reused and instead pile up as
-		 * garbage, which is likely worse than just allocating a buffer per event as
-		 * {@link DefaultLogAppender} already does.
+		 * <strong>Virtual-thread aware:</strong> a call from a virtual thread bypasses
+		 * the {@link ThreadLocal} and uses a fresh buffer for that one event instead (the
+		 * same thing {@link DefaultLogAppender} always does) - a per-thread buffer only
+		 * pays off across many events on the same thread, which a short-lived virtual
+		 * thread handling a single request typically is not.
+		 * <p>
+		 * This is one of the two flags (see also
+		 * {@link #SYNCHRONIZED_THREAD_LOCAL_BUFFER}) an appender may end up using
+		 * <strong>even when no flag is explicitly set</strong> - see
+		 * {@code DirectLogAppender#defaultAppender} for the default selection.
 		 */
 		THREAD_LOCAL_BUFFER,
 		/**
 		 * Like {@link #THREAD_LOCAL_BUFFER} (a reused per-thread buffer, encoding done
-		 * outside any lock) except the final write to the output is protected by a plain
-		 * {@code synchronized} block (the JVM's intrinsic monitor) instead of the
-		 * {@link ReentrantLock}-based {@code AppenderLock} every other flag combination
-		 * uses.
+		 * outside any lock, virtual-thread aware) except the final write to the output is
+		 * protected by a plain {@code synchronized} block (the JVM's intrinsic monitor)
+		 * instead of the {@link ReentrantLock}-based {@code AppenderLock} every other
+		 * flag combination uses.
 		 * <p>
 		 * The Java language has no way to acquire a monitor in one method call and
 		 * release it in another the way {@code AppenderLock.lock()}/{@code unlock()}
@@ -118,12 +124,21 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 * {@code AppenderLock}'s {@code ReentrantLock} for same-thread reentrancy
 		 * detection - are ignored if this flag is set.
 		 * <p>
-		 * Experimental: motivated by Log4j2's own garbage-free appenders using
-		 * {@code synchronized} rather than a {@code java.util.concurrent} lock around
-		 * their buffer-transfer step, and prior microbenchmarking suggesting the JVM's
-		 * intrinsic monitor can outperform {@link ReentrantLock} here. Takes precedence
-		 * over {@link #THREAD_LOCAL_BUFFER} (redundant if both are set) but not
+		 * Motivated by Log4j2's own garbage-free appenders using {@code synchronized}
+		 * rather than a {@code java.util.concurrent} lock around their buffer-transfer
+		 * step, and confirmed by real-workload benchmarking to outperform
+		 * {@link ReentrantLock} here on modern JDKs. Takes precedence over
+		 * {@link #THREAD_LOCAL_BUFFER} (redundant if both are set) but not
 		 * {@link #REUSE_BUFFER}.
+		 * <p>
+		 * <strong>Explicitly setting this flag always honors it</strong>, even on a JDK
+		 * where {@code synchronized} still pins the carrier platform thread when called
+		 * from a virtual thread (before JDK
+		 * {@value AppenderLock#SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION}'s
+		 * <a href="https://openjdk.org/jeps/491">JEP 491</a>) - it is only the
+		 * <strong>default selection</strong> (no buffer-strategy flag set at all) that
+		 * checks the running JDK's version and falls back to {@link #THREAD_LOCAL_BUFFER}
+		 * below that version; see {@code DirectLogAppender#defaultAppender}.
 		 */
 		SYNCHRONIZED_THREAD_LOCAL_BUFFER,
 		/**
@@ -464,6 +479,19 @@ abstract class AppenderLock {
 	protected final ReentrantLock realLock;
 	static Function<Set<LogAppender.AppenderFlag>, AppenderLock> lockFactoryFunction = AppenderLock::_of;
 
+	/*
+	 * Testable seam for the JDK-version-gated default appender selection in
+	 * DirectLogAppender.defaultAppender(...) - overridden in tests to exercise both
+	 * branches without needing two different JDKs.
+	 */
+	static IntSupplier jdkFeatureVersionSupplier = () -> Runtime.version().feature();
+
+	/*
+	 * synchronized no longer pins the carrier platform thread when called from a virtual
+	 * thread as of this JDK feature version - JEP 491, finalized in JDK 24.
+	 */
+	static final int SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION = 24;
+
 	private static AppenderLock _of(Set<LogAppender.AppenderFlag> flags) {
 		var lock = new ReentrantLock();
 		if (flags.contains(LogAppender.AppenderFlag.REENTRY_LOG)) {
@@ -603,7 +631,31 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
 		}
-		return new DefaultLogAppender(name, output, encoder, flags, lock);
+		return defaultAppender(name, output, encoder, flags, lock);
+	}
+
+	/**
+	 * Picks the appender used when no {@link AppenderFlag} explicitly requests a
+	 * buffer/lock strategy. {@link AppenderFlag#REENTRY_DROP} or
+	 * {@link AppenderFlag#REENTRY_LOG} alone force the {@link ReentrantLock}-based
+	 * {@link DefaultLogAppender}, since neither {@code ThreadLocalBuffer} appender
+	 * supports reentry detection. Otherwise this defaults to the same trade-off a caller
+	 * gets from explicitly setting {@link AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER}
+	 * on {@link AppenderLock#SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION}+ (where
+	 * {@code synchronized} no longer pins virtual threads - JEP 491) or
+	 * {@link AppenderFlag#THREAD_LOCAL_BUFFER} on older JDKs - measured faster than the
+	 * fresh-buffer-per-event {@link DefaultLogAppender} in real-workload benchmarking, so
+	 * it is the better default rather than only an opt-in.
+	 */
+	static DirectLogAppender defaultAppender(String name, LogOutput output, LogEncoder encoder,
+			Set<LogAppender.AppenderFlag> flags, AppenderLock lock) {
+		if (flags.contains(AppenderFlag.REENTRY_DROP) || flags.contains(AppenderFlag.REENTRY_LOG)) {
+			return new DefaultLogAppender(name, output, encoder, flags, lock);
+		}
+		if (AppenderLock.jdkFeatureVersionSupplier.getAsInt() >= AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION) {
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags);
+		}
+		return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
 	}
 
 	// @Override
@@ -838,7 +890,7 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 		if (flags.contains(LogAppender.AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, lock);
 		}
-		return new DefaultLogAppender(name, output, encoder, flags, lock);
+		return DirectLogAppender.defaultAppender(name, output, encoder, flags, lock);
 	}
 
 }
@@ -981,9 +1033,26 @@ final class ThreadLocalBufferLogAppender extends LockLogAppender implements Inte
 
 	@Override
 	public final void append(LogEvent event) {
+		if (Thread.currentThread().isVirtual()) {
+			/*
+			 * A per-thread buffer only pays off across many events on the same thread - a
+			 * short-lived virtual thread handling a single request typically logs a
+			 * handful of times and terminates, so fall back to a fresh buffer per event
+			 * like DefaultLogAppender instead of populating the ThreadLocal.
+			 */
+			try (var buffer = encoder.buffer(output.bufferHints())) {
+				encoder.encode(event, buffer);
+				writeLocked(event, buffer);
+			}
+			return;
+		}
 		var buffer = bufferThreadLocal.get();
 		buffer.clear();
 		encoder.encode(event, buffer);
+		writeLocked(event, buffer);
+	}
+
+	private void writeLocked(LogEvent event, LogEncoder.Buffer buffer) {
 		if (!lock.tryLock()) {
 			return;
 		}
@@ -1041,9 +1110,25 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 
 	@Override
 	public void append(LogEvent event) {
+		if (Thread.currentThread().isVirtual()) {
+			/*
+			 * See ThreadLocalBufferLogAppender's identical branch: a per-thread buffer
+			 * only pays off across many events on the same thread, which a short-lived
+			 * virtual thread handling a single request typically is not.
+			 */
+			try (var buffer = encoder.buffer(output.bufferHints())) {
+				encoder.encode(event, buffer);
+				writeSynchronized(event, buffer);
+			}
+			return;
+		}
 		var buffer = bufferThreadLocal.get();
 		buffer.clear();
 		encoder.encode(event, buffer);
+		writeSynchronized(event, buffer);
+	}
+
+	private void writeSynchronized(LogEvent event, LogEncoder.Buffer buffer) {
 		synchronized (monitor) {
 			output.write(event, buffer);
 			if (immediateFlush) {
@@ -1100,7 +1185,7 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 		if (flags.contains(LogAppender.AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			return new ThreadLocalBufferLogAppender(name, output, encoder, flags, AppenderLock.of(flags));
 		}
-		return new DefaultLogAppender(name, output, encoder, flags, AppenderLock.of(flags));
+		return DirectLogAppender.defaultAppender(name, output, encoder, flags, AppenderLock.of(flags));
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -35,6 +37,20 @@ import io.jstach.rainbowgum.output.ListLogOutput;
  * details.
  */
 class AppenderAsModeFlagPermutationTest {
+
+	final java.util.function.IntSupplier originalJdkFeatureVersionSupplier = AppenderLock.jdkFeatureVersionSupplier;
+
+	@BeforeEach
+	void before() {
+		// Deterministic regardless of which JDK actually runs the build - see
+		// testPermutation's expectedAppenderClass computation below.
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
+	}
+
+	@AfterEach
+	void after() {
+		AppenderLock.jdkFeatureVersionSupplier = originalJdkFeatureVersionSupplier;
+	}
 
 	enum AsMode {
 
@@ -121,8 +137,17 @@ class AppenderAsModeFlagPermutationTest {
 		else if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			expectedAppenderClass = ThreadLocalBufferLogAppender.class;
 		}
-		else {
+		else if (flags.contains(AppenderFlag.REENTRY_DROP) || flags.contains(AppenderFlag.REENTRY_LOG)) {
+			// No buffer-strategy flag: falls to the default appender selection, which
+			// defers to DefaultLogAppender when reentry detection was explicitly
+			// requested, since neither ThreadLocalBuffer appender supports it.
 			expectedAppenderClass = DefaultLogAppender.class;
+		}
+		else {
+			// No buffer-strategy or reentry flag: the default appender selection - forced
+			// to the modern-JDK branch above, so
+			// SynchronizedThreadLocalBufferLogAppender.
+			expectedAppenderClass = SynchronizedThreadLocalBufferLogAppender.class;
 		}
 		for (var direct : directAppenders(mode, publisher)) {
 			assertInstanceOf(expectedAppenderClass, direct);

--- a/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
@@ -1,0 +1,66 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.IntSupplier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+/**
+ * Exercises {@code DirectLogAppender#defaultAppender} directly - the JDK-version-gated
+ * choice made when no {@link AppenderFlag} explicitly requests a buffer/lock strategy.
+ * {@link AppenderAsModeFlagPermutationTest} covers the same dispatch as part of its full
+ * flag-combination sweep, but forces a fixed JDK version throughout, so it never
+ * exercises the pre-{@value AppenderLock#SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION} branch.
+ * This class covers both branches, plus the REENTRY_DROP/REENTRY_LOG override,
+ * explicitly.
+ */
+class DefaultAppenderSelectionTest {
+
+	final IntSupplier originalJdkFeatureVersionSupplier = AppenderLock.jdkFeatureVersionSupplier;
+
+	@AfterEach
+	void after() {
+		AppenderLock.jdkFeatureVersionSupplier = originalJdkFeatureVersionSupplier;
+	}
+
+	@Test
+	void modernJdkNoFlagsSelectsSynchronizedThreadLocalBuffer() {
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
+		var appender = appender(Set.of());
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, appender);
+	}
+
+	@Test
+	void olderJdkNoFlagsSelectsThreadLocalBuffer() {
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION - 1;
+		var appender = appender(Set.of());
+		assertInstanceOf(ThreadLocalBufferLogAppender.class, appender);
+	}
+
+	@Test
+	void modernJdkReentryDropWithNoOtherFlagStillSelectsDefaultLogAppender() {
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
+		var appender = appender(EnumSet.of(AppenderFlag.REENTRY_DROP));
+		assertInstanceOf(DefaultLogAppender.class, appender);
+	}
+
+	@Test
+	void modernJdkReentryLogWithNoOtherFlagStillSelectsDefaultLogAppender() {
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
+		var appender = appender(EnumSet.of(AppenderFlag.REENTRY_LOG));
+		assertInstanceOf(DefaultLogAppender.class, appender);
+	}
+
+	private static LogAppender appender(Set<AppenderFlag> flags) {
+		var encoder = LogEncoder.of(LogFormatter.builder().message().build());
+		return DirectLogAppender.of("test", new ListLogOutput(), encoder, flags);
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -27,14 +27,20 @@ class LogAppenderFlagTest {
 
 	PrintStream metaLogStream = new PrintStream(metaLogBytes);
 
+	final java.util.function.IntSupplier originalJdkFeatureVersionSupplier = AppenderLock.jdkFeatureVersionSupplier;
+
 	@BeforeEach
 	void before() {
 		MetaLog.output = () -> metaLogStream;
+		// Deterministic regardless of which JDK actually runs the build - see
+		// appenderLevelFlagsMergeOntoExistingAppenderWithoutReuseBuffer below.
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
 	}
 
 	@AfterEach
 	void after() {
 		MetaLog.output = () -> System.err;
+		AppenderLock.jdkFeatureVersionSupplier = originalJdkFeatureVersionSupplier;
 	}
 
 	private static LogAppender appender(String name, ListLogOutput output, AppenderFlag... flags) {
@@ -152,7 +158,10 @@ class LogAppenderFlagTest {
 		var appenders = new LogAppender.Appenders("test-route", config, providers);
 		var result = appenders.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)).asSingle();
 		result.start(config);
-		assertInstanceOf(DefaultLogAppender.class, result);
+		// No buffer-strategy flag set - resolves to the default appender selection,
+		// which on the (forced-deterministic) modern JDK above is
+		// SynchronizedThreadLocalBufferLogAppender, not DefaultLogAppender.
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, result);
 		result.append(TestEventBuilder.of().build(b -> b.message("hello")));
 		assertEquals(0, output.flushCount);
 	}

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderTest.java
@@ -17,6 +17,8 @@ class LogAppenderTest {
 
 	final Function<Set<LogAppender.AppenderFlag>, AppenderLock> originalLockFactoryFunction = AppenderLock.lockFactoryFunction;
 
+	final java.util.function.IntSupplier originalJdkFeatureVersionSupplier = AppenderLock.jdkFeatureVersionSupplier;
+
 	@AfterEach
 	void after() {
 		/*
@@ -25,12 +27,22 @@ class LogAppenderTest {
 		 * that runs afterward in the same JVM.
 		 */
 		AppenderLock.lockFactoryFunction = originalLockFactoryFunction;
+		AppenderLock.jdkFeatureVersionSupplier = originalJdkFeatureVersionSupplier;
 	}
 
 	@Test
 	void test() {
 		var out = Objects.requireNonNull(System.out);
 		ConcurrentLinkedQueue<String> messages = new ConcurrentLinkedQueue<>();
+		/*
+		 * No AppenderFlag is set below, so this exercises the default appender selection.
+		 * Force a pre-JDK-24 version so it resolves to the AppenderLock-based
+		 * ThreadLocalBufferLogAppender (which actually calls lock.tryLock()) rather than
+		 * SynchronizedThreadLocalBufferLogAppender (which does not use AppenderLock at
+		 * all, so the custom reentry-drop lock installed below would never be consulted
+		 * and the reentrant append() call two lines down would recurse forever).
+		 */
+		AppenderLock.jdkFeatureVersionSupplier = () -> 21;
 		AppenderLock.lockFactoryFunction = flags -> new AppenderLock(new ReentrantLock()) {
 			@Override
 			boolean tryLock() {


### PR DESCRIPTION
Goal: out-of-the-box RainbowGum should be as fast or faster than the other Spring Boot logging frameworks. Benchmarking after folding the byte-buffer encoder into core showed the plain no-flags default had become a real regression (-5.2%/-6.3%, GC events nearly doubled) since both file and console outputs now get a fresh 8KB buffer allocated per event with nowhere to reuse it. SYNCHRONIZED_THREAD_LOCAL_BUFFER (or THREAD_LOCAL_BUFFER on older JDKs) applied to both appenders recovered to +7-8% - closing the entire gap requires that to be the default.

DirectLogAppender.defaultAppender(...) now picks the appender used when no buffer-strategy flag is explicitly set: DefaultLogAppender only if REENTRY_DROP/REENTRY_LOG is set (neither ThreadLocalBuffer appender supports reentry detection), otherwise
SynchronizedThreadLocalBufferLogAppender on JDK 24+ (where synchronized no longer pins virtual threads - JEP 491) or ThreadLocalBufferLogAppender below that, sniffed once via AppenderLock.jdkFeatureVersionSupplier (a testable seam, matching the existing lockFactoryFunction pattern). Wired into all three appender-construction call sites.

Also made both ThreadLocalBuffer appenders virtual-thread aware: a call from a virtual thread now bypasses the ThreadLocal and uses a fresh buffer for that one event (matching DefaultLogAppender) instead of populating the ThreadLocal, since a per-thread buffer only pays off across many events on the same thread - not what a short-lived virtual thread handling one request typically provides. Checked per-call via Thread.isVirtual() rather than sniffed once, since there is no reliable JVM-level "is this app using virtual threads" signal and workloads can mix platform/virtual threads on the same appender.

Fixed three existing tests that broke because they assumed DefaultLogAppender for a no-buffer-flag appender: two just needed their expected class updated; LogAppenderTest needed the JDK sniff seam forced to a pre-24 value too, since its custom-AppenderLock reentry-drop injection (via the lockFactoryFunction test seam, not the REENTRY_DROP flag) only gets consulted by AppenderLock-based appenders and was silently bypassed by the new default, causing a real StackOverflowError from unprotected reentrant logging. Added DefaultAppenderSelectionTest covering both JDK branches and the REENTRY override explicitly, since the flag-permutation test only exercises one fixed JDK branch.

Full reactor build and all three analyzer profiles (nullaway, checkerframework, errorprone) pass clean.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5