### PR TITLE
Give SynchronizedThreadLocalBufferLogAppender reentry protection

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -119,10 +119,11 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 * release it in another the way {@code AppenderLock.lock()}/{@code unlock()}
 		 * works, so this is not a pluggable lock strategy on top of the existing
 		 * appenders - it is a separate appender implementation with the critical section
-		 * written as a literal {@code synchronized} block. Consequently
-		 * {@link #REENTRY_DROP} and {@link #REENTRY_LOG} - which rely on
-		 * {@code AppenderLock}'s {@code ReentrantLock} for same-thread reentrancy
-		 * detection - are ignored if this flag is set.
+		 * written as a literal {@code synchronized} block. {@link #REENTRY_DROP} and
+		 * {@link #REENTRY_LOG} are still honored though -
+		 * {@link Thread#holdsLock(Object)} is the {@code synchronized} equivalent of
+		 * {@code ReentrantLock}'s {@code isHeldByCurrentThread()}, so reentrancy is
+		 * detected the same way without needing {@code AppenderLock}.
 		 * <p>
 		 * Motivated by Log4j2's own garbage-free appenders using {@code synchronized}
 		 * rather than a {@code java.util.concurrent} lock around their buffer-transfer
@@ -636,22 +637,21 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 
 	/**
 	 * Picks the appender used when no {@link AppenderFlag} explicitly requests a
-	 * buffer/lock strategy. {@link AppenderFlag#REENTRY_DROP} or
-	 * {@link AppenderFlag#REENTRY_LOG} alone force the {@link ReentrantLock}-based
-	 * {@link DefaultLogAppender}, since neither {@code ThreadLocalBuffer} appender
-	 * supports reentry detection. Otherwise this defaults to the same trade-off a caller
-	 * gets from explicitly setting {@link AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER}
-	 * on {@link AppenderLock#SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION}+ (where
+	 * buffer/lock strategy: the same trade-off a caller gets from explicitly setting
+	 * {@link AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER} on
+	 * {@link AppenderLock#SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION}+ (where
 	 * {@code synchronized} no longer pins virtual threads - JEP 491) or
 	 * {@link AppenderFlag#THREAD_LOCAL_BUFFER} on older JDKs - measured faster than the
 	 * fresh-buffer-per-event {@link DefaultLogAppender} in real-workload benchmarking, so
-	 * it is the better default rather than only an opt-in.
+	 * it is the better default rather than only an opt-in. Both appenders support
+	 * {@link AppenderFlag#REENTRY_DROP}/{@link AppenderFlag#REENTRY_LOG} (the
+	 * {@code synchronized} one via {@link Thread#holdsLock(Object)} rather than
+	 * {@link AppenderLock}), so {@link DefaultLogAppender} is never selected here -
+	 * {@code AppenderLock.of(flags)} still resolving those two flags correctly into
+	 * {@code lock} only matters for {@link AppenderFlag#THREAD_LOCAL_BUFFER}'s branch.
 	 */
 	static DirectLogAppender defaultAppender(String name, LogOutput output, LogEncoder encoder,
 			Set<LogAppender.AppenderFlag> flags, AppenderLock lock) {
-		if (flags.contains(AppenderFlag.REENTRY_DROP) || flags.contains(AppenderFlag.REENTRY_LOG)) {
-			return new DefaultLogAppender(name, output, encoder, flags, lock);
-		}
 		if (AppenderLock.jdkFeatureVersionSupplier.getAsInt() >= AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION) {
 			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags);
 		}
@@ -1129,6 +1129,9 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 	}
 
 	private void writeSynchronized(LogEvent event, LogEncoder.Buffer buffer) {
+		if (shouldDropForReentry()) {
+			return;
+		}
 		synchronized (monitor) {
 			output.write(event, buffer);
 			if (immediateFlush) {
@@ -1139,12 +1142,37 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 
 	@Override
 	public void append(LogEvent[] events, int count) {
+		if (shouldDropForReentry()) {
+			return;
+		}
 		synchronized (monitor) {
 			output.write(events, count, encoder, bufferThreadLocal.get());
 			if (immediateFlush) {
 				output.flush();
 			}
 		}
+	}
+
+	/**
+	 * {@link Thread#holdsLock(Object)} is the {@code synchronized}-block equivalent of
+	 * {@link ReentrantLock#isHeldByCurrentThread()}, which is how
+	 * {@code DropReentryAppenderLock}/{@code LogReentryAppenderLock} detect reentrancy -
+	 * so this mirrors that logic without needing {@link AppenderLock} at all. With
+	 * neither {@link AppenderFlag#REENTRY_DROP} nor {@link AppenderFlag#REENTRY_LOG} set
+	 * this always returns {@code false}, and a reentrant call simply re-enters the
+	 * monitor (Java monitors are reentrant), matching the default
+	 * {@code RentryAppenderLock} behavior.
+	 */
+	private boolean shouldDropForReentry() {
+		if (!Thread.holdsLock(monitor)) {
+			return false;
+		}
+		if (flags.contains(LogAppender.AppenderFlag.REENTRY_LOG)) {
+			Exception exception = new Exception("reentrant appender");
+			MetaLog.error(LogAppender.class, exception);
+			return true;
+		}
+		return flags.contains(LogAppender.AppenderFlag.REENTRY_DROP);
 	}
 
 	@Override

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -137,16 +137,11 @@ class AppenderAsModeFlagPermutationTest {
 		else if (flags.contains(AppenderFlag.THREAD_LOCAL_BUFFER)) {
 			expectedAppenderClass = ThreadLocalBufferLogAppender.class;
 		}
-		else if (flags.contains(AppenderFlag.REENTRY_DROP) || flags.contains(AppenderFlag.REENTRY_LOG)) {
-			// No buffer-strategy flag: falls to the default appender selection, which
-			// defers to DefaultLogAppender when reentry detection was explicitly
-			// requested, since neither ThreadLocalBuffer appender supports it.
-			expectedAppenderClass = DefaultLogAppender.class;
-		}
 		else {
-			// No buffer-strategy or reentry flag: the default appender selection - forced
-			// to the modern-JDK branch above, so
-			// SynchronizedThreadLocalBufferLogAppender.
+			// No buffer-strategy flag (REENTRY_DROP/REENTRY_LOG alone included - both
+			// ThreadLocalBuffer appenders support reentry detection, so they no longer
+			// force DefaultLogAppender): the default appender selection - forced to the
+			// modern-JDK branch above, so SynchronizedThreadLocalBufferLogAppender.
 			expectedAppenderClass = SynchronizedThreadLocalBufferLogAppender.class;
 		}
 		for (var direct : directAppenders(mode, publisher)) {

--- a/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
@@ -1,12 +1,19 @@
 package io.jstach.rainbowgum;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.IntSupplier;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.jstach.rainbowgum.LogAppender.AppenderFlag;
@@ -18,16 +25,28 @@ import io.jstach.rainbowgum.output.ListLogOutput;
  * {@link AppenderAsModeFlagPermutationTest} covers the same dispatch as part of its full
  * flag-combination sweep, but forces a fixed JDK version throughout, so it never
  * exercises the pre-{@value AppenderLock#SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION} branch.
- * This class covers both branches, plus the REENTRY_DROP/REENTRY_LOG override,
- * explicitly.
+ * This class covers both branches explicitly, plus that REENTRY_DROP/REENTRY_LOG actually
+ * work on both - {@code SynchronizedThreadLocalBufferLogAppender} detects reentrancy via
+ * {@link Thread#holdsLock(Object)} rather than {@code AppenderLock}, so it needs its own
+ * behavioral coverage, not just a class-type assertion.
  */
 class DefaultAppenderSelectionTest {
 
 	final IntSupplier originalJdkFeatureVersionSupplier = AppenderLock.jdkFeatureVersionSupplier;
 
+	ByteArrayOutputStream metaLogBytes = new ByteArrayOutputStream();
+
+	PrintStream metaLogStream = new PrintStream(metaLogBytes);
+
+	@BeforeEach
+	void before() {
+		MetaLog.output = () -> metaLogStream;
+	}
+
 	@AfterEach
 	void after() {
 		AppenderLock.jdkFeatureVersionSupplier = originalJdkFeatureVersionSupplier;
+		MetaLog.output = () -> System.err;
 	}
 
 	@Test
@@ -45,22 +64,55 @@ class DefaultAppenderSelectionTest {
 	}
 
 	@Test
-	void modernJdkReentryDropWithNoOtherFlagStillSelectsDefaultLogAppender() {
+	void modernJdkReentryDropWithNoOtherFlagSelectsSynchronizedThreadLocalBuffer() {
 		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
 		var appender = appender(EnumSet.of(AppenderFlag.REENTRY_DROP));
-		assertInstanceOf(DefaultLogAppender.class, appender);
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, appender);
 	}
 
 	@Test
-	void modernJdkReentryLogWithNoOtherFlagStillSelectsDefaultLogAppender() {
+	void modernJdkReentryLogWithNoOtherFlagSelectsSynchronizedThreadLocalBuffer() {
 		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
 		var appender = appender(EnumSet.of(AppenderFlag.REENTRY_LOG));
-		assertInstanceOf(DefaultLogAppender.class, appender);
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, appender);
+	}
+
+	@Test
+	void synchronizedThreadLocalBufferReentryDropFlagDropsReentrantAppend() {
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
+		var output = new ListLogOutput();
+		var testAppender = appender(EnumSet.of(AppenderFlag.REENTRY_DROP), output);
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, testAppender);
+		output.setConsumer((e, s) -> {
+			// A naughty output that logs during its own write - should be dropped.
+			testAppender.append(TestEventBuilder.of().build(b -> b.message("reentrant")));
+		});
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("original")));
+		assertEquals(List.of("original"), output.events().stream().map(e -> e.getKey().message()).toList());
+	}
+
+	@Test
+	void synchronizedThreadLocalBufferReentryLogFlagDropsReentrantAppendAndLogsDiagnostic() {
+		AppenderLock.jdkFeatureVersionSupplier = () -> AppenderLock.SYNCHRONIZED_DEFAULT_MIN_JDK_VERSION;
+		var output = new ListLogOutput();
+		var testAppender = appender(EnumSet.of(AppenderFlag.REENTRY_LOG), output);
+		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, testAppender);
+		output.setConsumer((e, s) -> {
+			testAppender.append(TestEventBuilder.of().build(b -> b.message("reentrant")));
+		});
+		testAppender.append(TestEventBuilder.of().build(b -> b.message("original")));
+		assertEquals(List.of("original"), output.events().stream().map(e -> e.getKey().message()).toList());
+		String diagnostic = metaLogBytes.toString(StandardCharsets.UTF_8);
+		assertTrue(diagnostic.contains("reentrant appender"), () -> "expected reentry diagnostic, got: " + diagnostic);
 	}
 
 	private static LogAppender appender(Set<AppenderFlag> flags) {
+		return appender(flags, new ListLogOutput());
+	}
+
+	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output) {
 		var encoder = LogEncoder.of(LogFormatter.builder().message().build());
-		return DirectLogAppender.of("test", new ListLogOutput(), encoder, flags);
+		return DirectLogAppender.of("test", output, encoder, flags);
 	}
 
 }


### PR DESCRIPTION
Thread.holdsLock(Object) is the synchronized-block equivalent of ReentrantLock.isHeldByCurrentThread(), which is how DropReentryAppenderLock/LogReentryAppenderLock detect reentrancy - so this mirrors that logic directly, without needing AppenderLock at all. Checked before entering the synchronized block (not inside it, since Java monitors are reentrant by design and we need to distinguish "this thread already holds it" before deciding to drop rather than just re-entering). With neither REENTRY_DROP nor REENTRY_LOG set this is a no-op and reentrant calls behave exactly as before.

This removes the earlier limitation ("REENTRY_DROP and REENTRY_LOG are ignored if this flag is set") and, more importantly, removes the special case in DirectLogAppender#defaultAppender that forced DefaultLogAppender whenever REENTRY_DROP/REENTRY_LOG was set with no buffer-strategy flag - that branch existed only because the synchronized appender couldn't support those flags. Now both default branches (SynchronizedThreadLocalBufferLogAppender on JDK 24+, ThreadLocalBufferLogAppender below that) support reentry detection, so DefaultLogAppender is no longer reachable through the flags-based appender-selection API at all.

Updated DefaultAppenderSelectionTest's REENTRY_DROP/REENTRY_LOG tests (previously asserted DefaultLogAppender) and added direct behavioral coverage (drop + diagnostic-log verification) for the synchronized appender, plus simplified AppenderAsModeFlagPermutationTest's expected-class computation now that REENTRY flags no longer need special-casing there either.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5