### PR TITLE
Bump build-tool dependency versions (combines 7 Dependabot PRs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     <jdk.release.version>26.0.2</jdk.release.version>
 
     <ecj.version>3.46.0</ecj.version>
-    <plexus-compiler-eclipse.version>2.15.0</plexus-compiler-eclipse.version>
+    <plexus-compiler-eclipse.version>2.17.0</plexus-compiler-eclipse.version>
     <error-prone.version>2.50.0</error-prone.version>
-    <nullaway.version>0.13.8</nullaway.version>
+    <nullaway.version>0.14.0</nullaway.version>
     <checkerframework.version>4.2.2</checkerframework.version>
 
 
@@ -286,7 +286,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.5.0</version>
           <configuration>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>
@@ -373,7 +373,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-help-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.5.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -383,7 +383,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <phase>validate</phase>
@@ -416,12 +416,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>org.moditect</groupId>


### PR DESCRIPTION
Combines the Maven-plugin and NullAway Dependabot PRs into one commit rather than merging each separately - excludes the runtime dependency bumps (avaje-config, jansi) and spring-javaformat-maven-plugin (a version bump there could change formatting rules across the whole codebase and warrants its own dedicated pass, not a drive-by bundle).

- com.uber.nullaway:nullaway 0.13.8 -> 0.14.0
- org.codehaus.plexus:plexus-compiler-eclipse 2.15.0 -> 2.17.0
- maven-resources-plugin 3.3.1 -> 3.5.0
- maven-help-plugin 3.5.0 -> 3.5.2
- buildnumber-maven-plugin 3.2.1 -> 3.3.0
- maven-release-plugin 3.1.1 -> 3.3.1
- exec-maven-plugin 3.5.1 -> 3.6.3

Full reactor build and all three analyzer profiles (nullaway, checkerframework, errorprone) pass clean with the bumped versions.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5