### PR TITLE
Bump build-tool dependency versions (combines 5 Dependabot PRs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.0</version>
+          <version>3.15.0</version>
           <configuration>
             <release>${java.version}</release>
             <encoding>${project.build.sourceEncoding}</encoding>
@@ -323,7 +323,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.1</version>
           <configuration>
             <archive>
               <manifest>
@@ -401,7 +401,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-plugin</artifactId>
-          <version>2.1.0</version>
+          <version>2.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -441,7 +441,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.13</version>
+          <version>0.8.15</version>
         </plugin>
         <plugin>
             <groupId>org.codehaus.mojo</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -29,7 +29,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jlink-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <extensions>true</extensions>
         </plugin>
       </plugins>

--- a/test/rainbowgum-test-jlink/pom.xml
+++ b/test/rainbowgum-test-jlink/pom.xml
@@ -17,7 +17,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jlink-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
Combines the Maven-plugin Dependabot PRs into one commit rather than merging each separately - excludes runtime dependency bumps (logback-classic, avaje-config, spring-core) and spring-javaformat- maven-plugin (per Adam, a version bump there could shift formatting rules across the codebase and warrants its own dedicated pass).

Also deliberately excludes the spring-boot.version-4.1.1 PR: besides being a framework version rather than build tooling, it incorrectly bumps rainbowgum-test-spring-boot3/pom.xml from 3.3.2 to 4.1.1 - that module is explicitly pinned to Spring Boot 3.x (see the comment above the property: "rainbowgum-spring-boot3 and rainbowgum-spring- boot4 each pin their own Spring Boot major version and must never share a dependencyManagement import"). Dependabot appears to have tracked the property name globally without respecting that pin. Should not be merged as-is.

- maven-compiler-plugin 3.14.0 -> 3.15.0
- maven-jar-plugin 3.4.2 -> 3.5.1
- maven-jlink-plugin 3.2.0 -> 3.3.0 (test/pom.xml and test/rainbowgum-test-jlink/pom.xml)
- maven-scm-plugin 2.1.0 -> 2.2.1
- jacoco-maven-plugin 0.8.13 -> 0.8.15

Full reactor build (including the jlink module) and all three analyzer profiles (nullaway, checkerframework, errorprone) pass clean with the bumped versions.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5