### PR TITLE
Give CompositeLogAppender a readable toString for appender introspection

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -2,6 +2,7 @@ package io.jstach.rainbowgum;
 
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -738,6 +739,11 @@ record CompositeLogAppender(DirectLogAppender[] appenders,
 			.map(a -> a.withFlags(flags))
 			.toArray(i -> new DirectLogAppender[i]);
 		return new CompositeLogAppender(array, lock);
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getName() + "[appenders=" + Arrays.toString(appenders) + ", lock=" + lock + "]";
 	}
 
 	private static DirectLogAppender cast(LogAppender appender) {


### PR DESCRIPTION
The record's default toString printed the appenders array as an identity hash instead of its contents. Needed to make a ServiceRegistry.find(LogAppender.class) dump of a route's actual wired-up appenders (used by the webapp benchmark's new config-report endpoint) legible when a route resolves to a composite (e.g. console + file under the same route) rather than a single appender.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5