### PR TITLE
Implement more of Spring Boot's documented logging properties (Boot 4…

### DIFF
--- a/spring/rainbowgum-spring-boot4/pom.xml
+++ b/spring/rainbowgum-spring-boot4/pom.xml
@@ -61,6 +61,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-jdk</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/RainbowGumLoggingSystemFactory.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/RainbowGumLoggingSystemFactory.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.spring.boot4;
 
 import java.lang.System.Logger.Level;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.ServiceLoader;
@@ -20,6 +21,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 
+import io.jstach.rainbowgum.LogAppender;
 import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogOutput.OutputType;
 import io.jstach.rainbowgum.LogProperties;
@@ -53,6 +55,17 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 		 */
 		private static final String ROOT_LEVEL = "logging.level.root";
 
+		/**
+		 * Spring Boot's directory-only file property - only consulted as a fallback when
+		 * {@link LogProperties#FILE_PROPERTY} (logging.file.name) itself is unset,
+		 * matching Spring Boot's own {@code LogFile.get(...)} precedence.
+		 */
+		private static final String FILE_PATH_PROPERTY = "logging.file.path";
+
+		private static final String CONSOLE_ENABLED_PROPERTY = "logging.console.enabled";
+
+		private static final String SPRING_OUTPUT_ANSI_ENABLED_PROPERTY = "spring.output.ansi.enabled";
+
 		@Override
 		public @Nullable String valueOrNull(String key) {
 			if (key.equals("logging.level")) {
@@ -61,13 +74,59 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 					return value;
 				}
 			}
+			else if (key.equals(LogProperties.FILE_PROPERTY)) {
+				String name = environment.getProperty(key);
+				if (name != null && !name.isBlank()) {
+					return name;
+				}
+				String path = environment.getProperty(FILE_PATH_PROPERTY);
+				if (path != null && !path.isBlank()) {
+					// Spring Boot's own default file name when only the directory is
+					// given - see LogFile.get(...).
+					return Path.of(path, "spring.log").toString();
+				}
+				return null;
+			}
+			else if (key.equals(LogProperties.APPENDERS_PROPERTY)) {
+				String value = environment.getProperty(key);
+				if (value != null) {
+					return value;
+				}
+				boolean consoleEnabled = environment.getProperty(CONSOLE_ENABLED_PROPERTY, Boolean.class, true);
+				// Only meaningful to restrict to just "file" if a file destination
+				// actually resolves - otherwise fall through to the normal default
+				// (console) rather than pointing at a nonexistent file appender.
+				if (!consoleEnabled && valueOrNull(LogProperties.FILE_PROPERTY) != null) {
+					return LogAppender.FILE_APPENDER_NAME;
+				}
+				return null;
+			}
+			else if (key.equals(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY)) {
+				String ansiEnabled = environment.getProperty(SPRING_OUTPUT_ANSI_ENABLED_PROPERTY);
+				if (ansiEnabled != null) {
+					String mapped = switch (ansiEnabled.toUpperCase(Locale.ROOT)) {
+						case "NEVER" -> "true";
+						case "ALWAYS" -> "false";
+						// DETECT or unrecognized - let RainbowGum's own auto-detection
+						// run rather than overriding it.
+						default -> null;
+					};
+					if (mapped != null) {
+						return mapped;
+					}
+				}
+			}
 			return environment.getProperty(key);
 		}
 	}
 
 	final static class Patterns {
 
-		static final String NAME_AND_GROUP = "%esb(){APPLICATION_NAME}%esb{APPLICATION_GROUP}";
+		private static final String INCLUDE_APPLICATION_NAME_PROPERTY = "logging.include-application-name";
+
+		private static final String INCLUDE_APPLICATION_GROUP_PROPERTY = "logging.include-application-group";
+
+		final String NAME_AND_GROUP;
 
 		@Nullable
 		String CONSOLE_LOG_PATTERN;
@@ -85,7 +144,7 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 
 		String LOG_EXCEPTION_CONVERSION_WORD = "%wEx";
 
-		Patterns(LogProperties properties) {
+		Patterns(LogProperties properties, Environment environment) {
 			CONSOLE_LOG_PATTERN = properties.valueOrNull("CONSOLE_LOG_PATTERN");
 			FILE_LOG_PATTERN = properties.valueOrNull("FILE_LOG_PATTERN");
 			LOG_DATEFORMAT_PATTERN = properties.value("LOG_DATEFORMAT_PATTERN", LOG_DATEFORMAT_PATTERN);
@@ -94,6 +153,18 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 			LOG_CORRELATION_PATTERN = properties.value("LOG_CORRELATION_PATTERN", LOG_CORRELATION_PATTERN);
 			LOG_EXCEPTION_CONVERSION_WORD = properties.value("LOG_EXCEPTION_CONVERSION_WORD",
 					LOG_EXCEPTION_CONVERSION_WORD);
+			/*
+			 * Spring Boot doesn't bridge these two toggles to system properties (unlike
+			 * APPLICATION_NAME/APPLICATION_GROUP themselves), so they're read straight
+			 * from the Environment rather than through the system-property-backed
+			 * `properties` above.
+			 */
+			boolean includeApplicationName = environment.getProperty(INCLUDE_APPLICATION_NAME_PROPERTY, Boolean.class,
+					true);
+			boolean includeApplicationGroup = environment.getProperty(INCLUDE_APPLICATION_GROUP_PROPERTY, Boolean.class,
+					true);
+			NAME_AND_GROUP = (includeApplicationName ? "%esb(){APPLICATION_NAME}" : "")
+					+ (includeApplicationGroup ? "%esb{APPLICATION_GROUP}" : "");
 		}
 
 		String consolePattern() {
@@ -186,8 +257,9 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 				.serviceLoader(ServiceLoader.load(RainbowGumServiceProvider.class, classLoader))
 				.configurator(new SpringBootPatternKeywordProvider())
 				.build();
+			Environment environment = initializationContext.getEnvironment();
 			LogProperties patternProperties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
-			Patterns patterns = new Patterns(patternProperties);
+			Patterns patterns = new Patterns(patternProperties, environment);
 
 			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern()).build();
 
@@ -195,7 +267,8 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 
 			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, consoleEncoder);
 			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, fileEncoder);
-			rainbowGum = findAndSet(config, classLoader, initializationContext.getEnvironment());
+			StructuredLogging.apply(config, environment);
+			rainbowGum = findAndSet(config, classLoader, environment);
 		}
 
 		@Override

--- a/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/StructuredLogging.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/StructuredLogging.java
@@ -1,0 +1,96 @@
+package io.jstach.rainbowgum.spring.boot4;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.springframework.core.env.Environment;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogOutput.OutputType;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.json.encoder.EcsEncoder;
+import io.jstach.rainbowgum.json.encoder.GelfEncoder;
+import io.jstach.rainbowgum.json.encoder.LogstashEncoder;
+
+/**
+ * Bridges Spring Boot's {@code logging.structured.format.console}/
+ * {@code logging.structured.format.file} (and the per-format
+ * {@code logging.structured.<format>.*} fields) to RainbowGum's own
+ * {@code rainbowgum-json} encoders. The two output properties are independent, matching
+ * Spring Boot's own behavior - e.g. GELF-to-console with no file output at all (a
+ * 12factor/k8s-style deployment) works the same way it would for Logback/Log4j2.
+ * <p>
+ * Only {@code ecs}, {@code gelf}, and {@code logstash} are supported - Spring Boot also
+ * allows a fully-qualified {@code StructuredLogFormatter} class name for a fully custom
+ * format, which has no RainbowGum equivalent and is silently ignored (falls back to
+ * whatever pattern encoder is already installed for that output type).
+ */
+final class StructuredLogging {
+
+	private static final String FORMAT_CONSOLE_PROPERTY = "logging.structured.format.console";
+
+	private static final String FORMAT_FILE_PROPERTY = "logging.structured.format.file";
+
+	private static final String ECS = "ecs";
+
+	private static final String GELF = "gelf";
+
+	private static final String LOGSTASH = "logstash";
+
+	private StructuredLogging() {
+	}
+
+	static void apply(LogConfig config, Environment environment) {
+		apply(config, environment, FORMAT_CONSOLE_PROPERTY, OutputType.CONSOLE_OUT);
+		apply(config, environment, FORMAT_FILE_PROPERTY, OutputType.FILE);
+	}
+
+	private static void apply(LogConfig config, Environment environment, String formatProperty, OutputType outputType) {
+		String format = environment.getProperty(formatProperty);
+		if (format == null) {
+			return;
+		}
+		LogProvider<? extends LogEncoder> encoder = encoderFor(format, environment);
+		if (encoder != null) {
+			config.encoderRegistry().setEncoderForOutputType(outputType, encoder);
+		}
+	}
+
+	private static @Nullable LogProvider<? extends LogEncoder> encoderFor(String format, Environment environment) {
+		return switch (format.toLowerCase(Locale.ROOT)) {
+			case ECS -> EcsEncoder.of(b -> b
+				.serviceName(
+						environment.getProperty("logging.structured.ecs.service.name", applicationName(environment)))
+				.serviceVersion(environment.getProperty("logging.structured.ecs.service.version",
+						applicationVersion(environment)))
+				.serviceEnvironment(environment.getProperty("logging.structured.ecs.service.environment"))
+				.serviceNodeName(environment.getProperty("logging.structured.ecs.service.node-name")));
+			case GELF -> GelfEncoder.of(b -> {
+				String host = environment.getProperty("logging.structured.gelf.host", applicationName(environment));
+				b.host(host != null ? host : "application");
+				String serviceVersion = environment.getProperty("logging.structured.gelf.service.version",
+						applicationVersion(environment));
+				if (serviceVersion != null) {
+					// GELF additional field names can't contain dots - matches the
+					// underscore-joined convention Spring Boot's own GELF formatter
+					// uses for the same field.
+					b.headers(Map.of("service_version", serviceVersion));
+				}
+			});
+			case LOGSTASH -> LogstashEncoder.of(b -> {
+			});
+			default -> null;
+		};
+	}
+
+	private static @Nullable String applicationName(Environment environment) {
+		return environment.getProperty("spring.application.name");
+	}
+
+	private static @Nullable String applicationVersion(Environment environment) {
+		return environment.getProperty("spring.application.version");
+	}
+
+}

--- a/spring/rainbowgum-spring-boot4/src/main/java/module-info.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module io.jstach.rainbowgum.spring.boot4 {
 	requires transitive io.jstach.rainbowgum;
 	requires transitive io.jstach.rainbowgum.spring.boot.spi;
 	requires io.jstach.rainbowgum.pattern;
+	requires io.jstach.rainbowgum.json;
 
 	/*
 	 * Note that we never require transitive of spring stuff

--- a/spring/rainbowgum-spring-boot4/src/test/java/io/jstach/rainbowgum/spring/boot4/PatternsTest.java
+++ b/spring/rainbowgum-spring-boot4/src/test/java/io/jstach/rainbowgum/spring/boot4/PatternsTest.java
@@ -1,0 +1,54 @@
+package io.jstach.rainbowgum.spring.boot4;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.spring.boot4.RainbowGumLoggingSystemFactory.Patterns;
+
+class PatternsTest {
+
+	private static final LogProperties EMPTY = key -> null;
+
+	private static StandardEnvironment environment(Map<String, Object> properties) {
+		var environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+		return environment;
+	}
+
+	@Test
+	void bothIncludedByDefault() {
+		var patterns = new Patterns(EMPTY, environment(Map.of()));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_NAME"));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_GROUP"));
+	}
+
+	@Test
+	void applicationNameExcludedWhenDisabled() {
+		var patterns = new Patterns(EMPTY, environment(Map.of("logging.include-application-name", "false")));
+		assertFalse(patterns.NAME_AND_GROUP.contains("APPLICATION_NAME"));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_GROUP"));
+	}
+
+	@Test
+	void applicationGroupExcludedWhenDisabled() {
+		var patterns = new Patterns(EMPTY, environment(Map.of("logging.include-application-group", "false")));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_NAME"));
+		assertFalse(patterns.NAME_AND_GROUP.contains("APPLICATION_GROUP"));
+	}
+
+	@Test
+	void bothExcludedWhenDisabled() {
+		var patterns = new Patterns(EMPTY, environment(
+				Map.of("logging.include-application-name", "false", "logging.include-application-group", "false")));
+		assertFalse(patterns.consolePattern().contains("APPLICATION_NAME"));
+		assertFalse(patterns.consolePattern().contains("APPLICATION_GROUP"));
+	}
+
+}

--- a/spring/rainbowgum-spring-boot4/src/test/java/io/jstach/rainbowgum/spring/boot4/SpringLogPropertiesTest.java
+++ b/spring/rainbowgum-spring-boot4/src/test/java/io/jstach/rainbowgum/spring/boot4/SpringLogPropertiesTest.java
@@ -1,0 +1,97 @@
+package io.jstach.rainbowgum.spring.boot4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import io.jstach.rainbowgum.LogAppender;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.spring.boot4.RainbowGumLoggingSystemFactory.SpringLogProperties;
+
+class SpringLogPropertiesTest {
+
+	private static SpringLogProperties properties(Map<String, Object> map) {
+		var environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("test", map));
+		return new SpringLogProperties(environment);
+	}
+
+	@Test
+	void fileNameTakesPrecedenceOverFilePath() {
+		var p = properties(Map.of("logging.file.name", "explicit.log", "logging.file.path", "/var/log"));
+		assertEquals("explicit.log", p.valueOrNull(LogProperties.FILE_PROPERTY));
+	}
+
+	@Test
+	void filePathSynthesizesSpringLogFilename() {
+		var p = properties(Map.of("logging.file.path", "/var/log"));
+		assertEquals("/var/log/spring.log", p.valueOrNull(LogProperties.FILE_PROPERTY));
+	}
+
+	@Test
+	void neitherFileNameNorPathMeansNoFile() {
+		var p = properties(Map.of());
+		assertNull(p.valueOrNull(LogProperties.FILE_PROPERTY));
+	}
+
+	@Test
+	void consoleDisabledWithFileConfiguredRestrictsToFileAppender() {
+		var p = properties(Map.of("logging.console.enabled", "false", "logging.file.name", "app.log"));
+		assertEquals(LogAppender.FILE_APPENDER_NAME, p.valueOrNull(LogProperties.APPENDERS_PROPERTY));
+	}
+
+	@Test
+	void consoleDisabledWithNoFileConfiguredDoesNotForceAppenders() {
+		var p = properties(Map.of("logging.console.enabled", "false"));
+		assertNull(p.valueOrNull(LogProperties.APPENDERS_PROPERTY));
+	}
+
+	@Test
+	void consoleEnabledDoesNotOverrideAppenders() {
+		var p = properties(Map.of("logging.console.enabled", "true", "logging.file.name", "app.log"));
+		assertNull(p.valueOrNull(LogProperties.APPENDERS_PROPERTY));
+	}
+
+	@Test
+	void explicitAppendersPropertyIsNeverOverridden() {
+		var p = properties(Map.of("logging.console.enabled", "false", "logging.file.name", "app.log",
+				"logging.appenders", "console"));
+		assertEquals("console", p.valueOrNull(LogProperties.APPENDERS_PROPERTY));
+	}
+
+	@Test
+	void ansiNeverMapsToGlobalDisableTrue() {
+		var p = properties(Map.of("spring.output.ansi.enabled", "NEVER"));
+		assertEquals("true", p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void ansiAlwaysMapsToGlobalDisableFalse() {
+		var p = properties(Map.of("spring.output.ansi.enabled", "ALWAYS"));
+		assertEquals("false", p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void ansiDetectLeavesAutoDetectionAlone() {
+		var p = properties(Map.of("spring.output.ansi.enabled", "DETECT"));
+		assertNull(p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void ansiUnsetFallsBackToDirectPropertyIfSet() {
+		var p = properties(Map.of("logging.global.ansi.disable", "true"));
+		assertEquals("true", p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void loggingLevelFallsBackToRootLevel() {
+		var p = properties(Map.of("logging.level.root", "DEBUG"));
+		assertEquals("DEBUG", p.valueOrNull("logging.level"));
+	}
+
+}

--- a/spring/rainbowgum-spring-boot4/src/test/java/io/jstach/rainbowgum/spring/boot4/StructuredLoggingTest.java
+++ b/spring/rainbowgum-spring-boot4/src/test/java/io/jstach/rainbowgum/spring/boot4/StructuredLoggingTest.java
@@ -1,0 +1,134 @@
+package io.jstach.rainbowgum.spring.boot4;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogOutput.OutputType;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.json.encoder.EcsEncoder;
+import io.jstach.rainbowgum.json.encoder.GelfEncoder;
+import io.jstach.rainbowgum.json.encoder.LogstashEncoder;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+class StructuredLoggingTest {
+
+	private static StandardEnvironment environment(Map<String, Object> properties) {
+		var environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+		return environment;
+	}
+
+	/*
+	 * ListLogOutput's own OutputType is always MEMORY, so encoderForOutputType's
+	 * auto-resolution-by-output-type wouldn't pick up what StructuredLogging.apply
+	 * installed for FILE/CONSOLE_OUT - fetch that encoder explicitly and wire it onto the
+	 * appender directly instead, matching how EcsEncoderTest/GelfEncoderTest exercise
+	 * encoders elsewhere in the codebase.
+	 */
+	private static String encodedMessage(LogConfig config, OutputType outputType) {
+		var output = new ListLogOutput();
+		var encoder = config.encoderRegistry().encoderForOutputType(outputType);
+		try (var g = RainbowGum.builder(config)
+			.route(rb -> rb.appender("test", a -> a.output(output).encoder(encoder)))
+			.build()
+			.start()) {
+			LogEvent e = LogEvent
+				.of(System.Logger.Level.INFO, "io.jstach.logger", "hello", MutableKeyValues.of().freeze(), null)
+				.freeze(Instant.EPOCH);
+			g.log(e);
+		}
+		return output.events().get(0).getValue();
+	}
+
+	@Test
+	void gelfOnConsoleOnlyLeavesFileAlone() {
+		var config = LogConfig.builder().build();
+		var environment = environment(
+				Map.of("logging.structured.format.console", "gelf", "spring.application.name", "my-app"));
+		StructuredLogging.apply(config, environment);
+
+		var consoleEncoder = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		assertInstanceOf(GelfEncoder.class, consoleEncoder);
+
+		var fileEncoder = config.encoderRegistry().encoderForOutputType(OutputType.FILE).provide("f", config);
+		assertEquals(false, fileEncoder instanceof GelfEncoder, "file output type must be untouched");
+	}
+
+	@Test
+	void gelfHostDefaultsToApplicationName() {
+		var config = LogConfig.builder().build();
+		var environment = environment(
+				Map.of("logging.structured.format.file", "gelf", "spring.application.name", "fallback-app"));
+		StructuredLogging.apply(config, environment);
+		String json = encodedMessage(config, OutputType.FILE);
+		assertTrue(json.contains("\"host\":\"fallback-app\""), json);
+	}
+
+	@Test
+	void gelfServiceVersionBecomesUnderscoreHeader() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of("logging.structured.format.file", "gelf", "logging.structured.gelf.host",
+				"h", "logging.structured.gelf.service.version", "1.2.3"));
+		StructuredLogging.apply(config, environment);
+		String json = encodedMessage(config, OutputType.FILE);
+		assertTrue(json.contains("\"_service_version\":\"1.2.3\""), json);
+	}
+
+	@Test
+	void ecsFieldsAllThreadThrough() {
+		var config = LogConfig.builder().build();
+		var environment = environment(
+				Map.of("logging.structured.format.file", "ecs", "logging.structured.ecs.service.name", "svc",
+						"logging.structured.ecs.service.version", "2.0", "logging.structured.ecs.service.environment",
+						"prod", "logging.structured.ecs.service.node-name", "node-1"));
+		StructuredLogging.apply(config, environment);
+		String json = encodedMessage(config, OutputType.FILE);
+		assertTrue(json.contains("\"service.name\":\"svc\""), json);
+		assertTrue(json.contains("\"service.version\":\"2.0\""), json);
+		assertTrue(json.contains("\"service.environment\":\"prod\""), json);
+	}
+
+	@Test
+	void logstashFormatSelectsLogstashEncoder() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of("logging.structured.format.console", "logstash"));
+		StructuredLogging.apply(config, environment);
+		var encoder = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		assertInstanceOf(LogstashEncoder.class, encoder);
+	}
+
+	@Test
+	void unrecognizedFormatIsIgnored() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of("logging.structured.format.console", "some.custom.FormatterClass"));
+		StructuredLogging.apply(config, environment);
+		var encoder = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		assertEquals(false,
+				encoder instanceof GelfEncoder || encoder instanceof EcsEncoder || encoder instanceof LogstashEncoder);
+	}
+
+	@Test
+	void noFormatPropertiesLeavesBothOutputTypesUntouched() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of());
+		StructuredLogging.apply(config, environment);
+		var console = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		var file = config.encoderRegistry().encoderForOutputType(OutputType.FILE).provide("f", config);
+		assertEquals(false,
+				console instanceof GelfEncoder || console instanceof EcsEncoder || console instanceof LogstashEncoder);
+		assertEquals(false,
+				file instanceof GelfEncoder || file instanceof EcsEncoder || file instanceof LogstashEncoder);
+	}
+
+}


### PR DESCRIPTION
… only)

RainbowGum's Spring Boot 4 LoggingSystem only ever honored a handful of Spring Boot's logging.* properties (level/group directly via core, pattern/exception-word/dateformat transitively via the system-property bridge Spring itself applies before calling any LoggingSystem). This adds native support for a focused, high-value slice of the rest, scoped to spring-boot4 only per Adam - logging.file.name itself is core's own long-standing Spring Boot compatibility affordance and already works regardless of Spring Boot, so it's untouched here.

- logging.structured.format.console / .format.file (ecs/gelf/logstash): new StructuredLogging class bridges these and the per-format fields (logging.structured.ecs.service.*, logging.structured.gelf.host/ service.version) to rainbowgum-json's existing EcsEncoder/GelfEncoder/ LogstashEncoder. The two output properties are independent, matching Spring Boot's own behavior - GELF-to-console with no file at all works the same way it would for Logback/Log4j2. This is the module's first dependency on rainbowgum-json. Spring's own StructuredLogFormatter class-name escape hatch and the logging.structured.json.* JsonWriter customization properties have no RainbowGum equivalent and are out of scope - silently ignored/not supported respectively.
- logging.file.path: synthesizes <path>/spring.log when logging.file.name itself is unset, matching Spring Boot's own LogFile.get() precedence.
- logging.console.enabled=false: restricts the route to just the file appender (via logging.appenders) when a file destination actually resolves, otherwise left alone rather than pointing at nothing.
- spring.output.ansi.enabled (NEVER/ALWAYS/DETECT): bridges to RainbowGum's own existing logging.global.ansi.disable property rather than adding a second ansi mechanism; falls through to that property directly if explicitly set and spring.output.ansi.enabled isn't.
- logging.include-application-name / logging.include-application-group: now actually toggle whether the default pattern includes those segments, instead of always including both unconditionally.
- logging.group.* already worked natively (RainbowGum's own GroupLevelResolver uses the identical logging.group.{name} property key Spring Boot documents) - confirmed, no code change needed.

Deliberately not attempted: logging.charset.console/file and logging.threshold.console/file (would need new core capabilities - configurable output charset, per-appender level filtering - not just a spring-boot4-layer property bridge), logging.config (no RainbowGum equivalent - config is property-driven, not a separate file), logging.register-shutdown-hook (unclear mapping to RainbowGum's own lifecycle), and both logback.rollingpolicy.*/log4j2.rollingpolicy.* (N/A - no such dependency).

23 new tests (StructuredLoggingTest, SpringLogPropertiesTest, PatternsTest) plus end-to-end verification via
test/rainbowgum-test-spring-boot4 confirming GELF-to-console with service.version, the file.path fallback, and console.enabled=false all work in a real running app, not just unit tests.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5