### PR TITLE
Support Spring Boot's logging.charset.console/file properties

### DIFF
--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -1,5 +1,6 @@
 package io.jstach.rainbowgum.pattern.format;
 
+import java.nio.charset.Charset;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.function.Function;
@@ -81,15 +82,21 @@ public final class PatternConfigurator implements Configurator {
 
 	@LogConfigurable(name = "PatternEncoderBuilder", prefix = LogProperties.ENCODER_PREFIX)
 	static LogProvider<LogEncoder> provideEncoder(@KeyParameter String name, String pattern,
-			@PassThroughParameter @Nullable PatternCompiler patternCompiler) {
+			@PassThroughParameter @Nullable PatternCompiler patternCompiler,
+			@ConvertParameter("convertCharset") @Nullable Charset charset) {
 		return (n, config) -> {
 			var compiler = patternCompiler;
 			if (compiler == null) {
 				compiler = PatternCompiler.of(b -> {
 				}).provide(name, config);
 			}
-			return LogEncoder.of(compiler.compile(pattern));
+			var formatter = compiler.compile(pattern);
+			return charset == null ? LogEncoder.of(formatter) : LogEncoder.of(formatter, charset);
 		};
+	}
+
+	static @Nullable Charset convertCharset(@Nullable String charset) {
+		return charset == null ? null : Charset.forName(charset);
 	}
 
 	@LogConfigurable(name = "PatternConfigBuilder", prefix = PatternConfig.PATTERN_CONFIG_PREFIX)

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternEncoderCharsetTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternEncoderCharsetTest.java
@@ -1,0 +1,127 @@
+package io.jstach.rainbowgum.pattern.format;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder.BufferHints;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogOutput;
+import io.jstach.rainbowgum.LogOutput.ContentType;
+import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.RainbowGum;
+
+/*
+ * The generated PatternEncoderBuilder.charset(...) property/setter - verified with raw
+ * captured bytes (like LogEncoder.of(LogFormatter, Charset)'s own test in core) rather
+ * than ListLogOutput, which always decodes as UTF-8 for storage and would defeat a test
+ * trying to confirm a *different* charset was actually used.
+ */
+class PatternEncoderCharsetTest {
+
+	// 'é' is 2 bytes in UTF-8 (0xC3 0xA9) but 1 byte in ISO-8859-1 (0xE9).
+	private static final String MESSAGE = "café";
+
+	@Test
+	void charsetPropertyAppliesToEncodedBytes() {
+		var output = new CapturingOutput();
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list
+				logging.appender.list.encoder=pattern
+				logging.encoder.list.pattern=%msg
+				logging.encoder.list.charset=ISO-8859-1
+				""";
+		var config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new PatternConfigurator())
+			.build();
+		config.outputRegistry().register("list", ref -> LogProvider.of(output));
+		try (var g = RainbowGum.builder(config).build().start()) {
+			g.router().eventBuilder("test", System.Logger.Level.INFO).message(MESSAGE).log();
+		}
+		assertArrayEquals(MESSAGE.getBytes(StandardCharsets.ISO_8859_1), output.capturedBytes());
+	}
+
+	@Test
+	void unsetCharsetDefaultsToUtf8() {
+		var output = new CapturingOutput();
+		String properties = """
+				logging.appenders=list
+				logging.appender.list.output=list
+				logging.appender.list.encoder=pattern
+				logging.encoder.list.pattern=%msg
+				""";
+		var config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new PatternConfigurator())
+			.build();
+		config.outputRegistry().register("list", ref -> LogProvider.of(output));
+		try (var g = RainbowGum.builder(config).build().start()) {
+			g.router().eventBuilder("test", System.Logger.Level.INFO).message(MESSAGE).log();
+		}
+		assertArrayEquals(MESSAGE.getBytes(StandardCharsets.UTF_8), output.capturedBytes());
+	}
+
+	@Test
+	void convertCharsetOfNullIsNull() {
+		assertNull(PatternConfigurator.convertCharset(null));
+	}
+
+	static class CapturingOutput implements LogOutput {
+
+		private final List<byte[]> writes = new ArrayList<>();
+
+		byte[] capturedBytes() {
+			return writes.get(writes.size() - 1);
+		}
+
+		@Override
+		public BufferHints bufferHints() {
+			return WriteMethod.BYTES;
+		}
+
+		@Override
+		public URI uri() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public OutputType type() {
+			return OutputType.MEMORY;
+		}
+
+		@Override
+		public void write(LogEvent event, byte[] bytes, int off, int len, ContentType contentType) {
+			writes.add(Arrays.copyOfRange(bytes, off, off + len));
+		}
+
+		@Override
+		public void write(LogEvent event, ByteBuffer buf, ContentType contentType) {
+			byte[] arr = new byte[buf.remaining()];
+			buf.get(arr);
+			writes.add(arr);
+		}
+
+		@Override
+		public void flush() {
+		}
+
+		@Override
+		public void close() {
+		}
+
+	}
+
+}

--- a/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/RainbowGumLoggingSystemFactory.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/RainbowGumLoggingSystemFactory.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.spring.boot4;
 
 import java.lang.System.Logger.Level;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
@@ -242,9 +243,13 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 			LogProperties patternProperties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 			Patterns patterns = new Patterns(patternProperties, environment);
 
-			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern()).build();
+			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern())
+				.charset(environment.getProperty(SpringBootSupportedProperties.CHARSET_CONSOLE, Charset.class))
+				.build();
 
-			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern()).build();
+			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern())
+				.charset(environment.getProperty(SpringBootSupportedProperties.CHARSET_FILE, Charset.class))
+				.build();
 
 			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, consoleEncoder);
 			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, fileEncoder);

--- a/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/SpringBootSupportedProperties.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/io/jstach/rainbowgum/spring/boot4/SpringBootSupportedProperties.java
@@ -57,6 +57,18 @@ public final class SpringBootSupportedProperties {
 	public static final String OUTPUT_ANSI_ENABLED = "spring.output.ansi.enabled";
 
 	/**
+	 * Charset for console output - bridged to the console pattern encoder's own {@code
+	 * charset} builder property.
+	 */
+	public static final String CHARSET_CONSOLE = "logging.charset.console";
+
+	/**
+	 * Charset for file output - bridged to the file pattern encoder's own {@code
+	 * charset} builder property.
+	 */
+	public static final String CHARSET_FILE = "logging.charset.file";
+
+	/**
 	 * Supported transitively - Spring Boot bridges this to the {@code
 	 * CONSOLE_LOG_PATTERN} system property before any {@code LoggingSystem} is
 	 * initialized.

--- a/spring/rainbowgum-spring-boot4/src/main/java/module-info.java
+++ b/spring/rainbowgum-spring-boot4/src/main/java/module-info.java
@@ -107,17 +107,19 @@
  * underscore-prefixed {@code _service_version} additional field, matching Spring Boot's
  * own GELF formatter's naming.</td>
  * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot4.SpringBootSupportedProperties#CHARSET_CONSOLE}, {@value
+ * io.jstach.rainbowgum.spring.boot4.SpringBootSupportedProperties#CHARSET_FILE}</td>
+ * <td>Native - bridged to the pattern encoder's own {@code charset} builder property
+ * (a core {@code rainbowgum-pattern} capability, not Spring-specific); unset falls back
+ * to UTF-8 the same as when Spring Boot is not on the classpath at all.</td>
+ * </tr>
  * </table>
  * <table class="table">
  * <caption><strong>Not supported</strong></caption>
  * <tr>
  * <th>Property</th>
  * <th>Why</th>
- * </tr>
- * <tr>
- * <td>{@code logging.charset.console}, {@code logging.charset.file}</td>
- * <td>Would need a new core capability (configurable output charset - UTF-8 is
- * currently fixed), not just a property bridge at this layer.</td>
  * </tr>
  * <tr>
  * <td>{@code logging.threshold.console}, {@code logging.threshold.file}</td>


### PR DESCRIPTION
Adds a charset builder property to PatternEncoderBuilder (rainbowgum-pattern), using the encoder charset support just added to core, then bridges Spring Boot's logging.charset.console/file to it in rainbowgum-spring-boot4. Unset falls back to UTF-8, same as without Spring Boot.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5