### PR TITLE
Bring Spring Boot 3 property support to parity with Boot 4

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1368,10 +1368,11 @@ its own artifact:
 Their own internal implementation packages ({@code io.jstach.rainbowgum.spring.boot3}/{@code boot4}) are not
 exported and never imported by consumers - Spring Boot discovers them itself through {@code META-INF/spring.factories}
 and the Java service loader - so those packages are duplicated per major version rather than shared, and are not
-necessarily identical in behavior; <strong>{@link io.jstach.rainbowgum.spring.boot4/ } is the one kept up to date
-with which Spring Boot logging properties (<code>logging.*</code>, <code>spring.output.ansi.enabled</code>, etc.) are
-supported</strong> - see that module's own javadoc for the full supported/not-supported property table, kept next to
-the code that implements it rather than duplicated here where it could drift out of sync. The one package you might
+necessarily identical in behavior; each module's own javadoc has the authoritative full supported/not-supported
+property table for which Spring Boot logging properties (<code>logging.*</code>, <code>spring.output.ansi.enabled</code>,
+etc.) it supports, kept next to the code that implements it rather than duplicated here where it could drift out of
+sync -
+{@link io.jstach.rainbowgum.spring.boot4/ } and {@link io.jstach.rainbowgum.spring.boot3/ }. The one package you might
 actually import,
 {@link io.jstach.rainbowgum.spring.boot.spi}, lives in its own genuinely shared module (<code>rainbowgum-spring-spi</code>,
 pulled in transitively by both starters) because it only depends on {@code org.springframework.core.env.Environment},

--- a/spring/rainbowgum-spring-boot3/pom.xml
+++ b/spring/rainbowgum-spring-boot3/pom.xml
@@ -61,6 +61,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-jdk</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/RainbowGumLoggingSystemFactory.java
+++ b/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/RainbowGumLoggingSystemFactory.java
@@ -1,6 +1,8 @@
 package io.jstach.rainbowgum.spring.boot3;
 
 import java.lang.System.Logger.Level;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.ServiceLoader;
@@ -47,18 +49,41 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 	}
 
 	record SpringLogProperties(Environment environment) implements LogProperties {
-		/*
-		 * Rainbow Gum uses logging.level as the root but strangely probably because of
-		 * binding boot uses the below.
-		 */
-		private static final String ROOT_LEVEL = "logging.level.root";
 
 		@Override
 		public @Nullable String valueOrNull(String key) {
-			if (key.equals("logging.level")) {
-				String value = environment.getProperty(ROOT_LEVEL);
+			if (key.equals(SpringBootSupportedProperties.LOGGING_LEVEL)) {
+				String value = environment.getProperty(SpringBootSupportedProperties.LOGGING_LEVEL_ROOT);
 				if (value != null) {
 					return value;
+				}
+			}
+			else if (key.equals(LogProperties.FILE_PROPERTY)) {
+				String name = environment.getProperty(key);
+				if (name != null && !name.isBlank()) {
+					return name;
+				}
+				String path = environment.getProperty(SpringBootSupportedProperties.FILE_PATH);
+				if (path != null && !path.isBlank()) {
+					// Spring Boot's own default file name when only the directory is
+					// given - see LogFile.get(...).
+					return Path.of(path, "spring.log").toString();
+				}
+				return null;
+			}
+			else if (key.equals(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY)) {
+				String ansiEnabled = environment.getProperty(SpringBootSupportedProperties.OUTPUT_ANSI_ENABLED);
+				if (ansiEnabled != null) {
+					String mapped = switch (ansiEnabled.toUpperCase(Locale.ROOT)) {
+						case "NEVER" -> "true";
+						case "ALWAYS" -> "false";
+						// DETECT or unrecognized - let RainbowGum's own auto-detection
+						// run rather than overriding it.
+						default -> null;
+					};
+					if (mapped != null) {
+						return mapped;
+					}
 				}
 			}
 			return environment.getProperty(key);
@@ -67,7 +92,7 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 
 	final static class Patterns {
 
-		static final String NAME_AND_GROUP = "%esb(){APPLICATION_NAME}%esb{APPLICATION_GROUP}";
+		final String NAME_AND_GROUP;
 
 		@Nullable
 		String CONSOLE_LOG_PATTERN;
@@ -85,7 +110,7 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 
 		String LOG_EXCEPTION_CONVERSION_WORD = "%wEx";
 
-		Patterns(LogProperties properties) {
+		Patterns(LogProperties properties, Environment environment) {
 			CONSOLE_LOG_PATTERN = properties.valueOrNull("CONSOLE_LOG_PATTERN");
 			FILE_LOG_PATTERN = properties.valueOrNull("FILE_LOG_PATTERN");
 			LOG_DATEFORMAT_PATTERN = properties.value("LOG_DATEFORMAT_PATTERN", LOG_DATEFORMAT_PATTERN);
@@ -94,6 +119,18 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 			LOG_CORRELATION_PATTERN = properties.value("LOG_CORRELATION_PATTERN", LOG_CORRELATION_PATTERN);
 			LOG_EXCEPTION_CONVERSION_WORD = properties.value("LOG_EXCEPTION_CONVERSION_WORD",
 					LOG_EXCEPTION_CONVERSION_WORD);
+			/*
+			 * Spring Boot doesn't bridge these two toggles to system properties (unlike
+			 * APPLICATION_NAME/APPLICATION_GROUP themselves), so they're read straight
+			 * from the Environment rather than through the system-property-backed
+			 * `properties` above.
+			 */
+			boolean includeApplicationName = environment
+				.getProperty(SpringBootSupportedProperties.INCLUDE_APPLICATION_NAME, Boolean.class, true);
+			boolean includeApplicationGroup = environment
+				.getProperty(SpringBootSupportedProperties.INCLUDE_APPLICATION_GROUP, Boolean.class, true);
+			NAME_AND_GROUP = (includeApplicationName ? "%esb(){APPLICATION_NAME}" : "")
+					+ (includeApplicationGroup ? "%esb{APPLICATION_GROUP}" : "");
 		}
 
 		String consolePattern() {
@@ -186,16 +223,22 @@ public class RainbowGumLoggingSystemFactory implements LoggingSystemFactory {
 				.serviceLoader(ServiceLoader.load(RainbowGumServiceProvider.class, classLoader))
 				.configurator(new SpringBootPatternKeywordProvider())
 				.build();
+			Environment environment = initializationContext.getEnvironment();
 			LogProperties patternProperties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
-			Patterns patterns = new Patterns(patternProperties);
+			Patterns patterns = new Patterns(patternProperties, environment);
 
-			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern()).build();
+			var consoleEncoder = new PatternEncoderBuilder("console").pattern(patterns.consolePattern())
+				.charset(environment.getProperty(SpringBootSupportedProperties.CHARSET_CONSOLE, Charset.class))
+				.build();
 
-			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern()).build();
+			var fileEncoder = new PatternEncoderBuilder("file").pattern(patterns.filePattern())
+				.charset(environment.getProperty(SpringBootSupportedProperties.CHARSET_FILE, Charset.class))
+				.build();
 
 			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, consoleEncoder);
 			config.encoderRegistry().setEncoderForOutputType(OutputType.FILE, fileEncoder);
-			rainbowGum = findAndSet(config, classLoader, initializationContext.getEnvironment());
+			StructuredLogging.apply(config, environment);
+			rainbowGum = findAndSet(config, classLoader, environment);
 		}
 
 		@Override

--- a/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/SpringBootSupportedProperties.java
+++ b/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/SpringBootSupportedProperties.java
@@ -1,0 +1,147 @@
+package io.jstach.rainbowgum.spring.boot3;
+
+/**
+ * Single source of truth for the literal Spring Boot logging property keys this module
+ * reads (directly, or transitively via Spring Boot's own system-property bridging) -
+ * referenced from both the code that reads them and {@code module-info.java}'s own
+ * javadoc via {@code {@value}}, so the two can't drift apart.
+ * <p>
+ * {@link io.jstach.rainbowgum.LogProperties#FILE_PROPERTY} ({@code logging.file.name})
+ * and {@link io.jstach.rainbowgum.LogProperties#GROUP_PROPERTY}
+ * ({@code logging.group.{name}}) are deliberately not duplicated here - they already have
+ * a single canonical home in {@code rainbowgum-core} itself, since both work with or
+ * without Spring Boot on the classpath.
+ * <p>
+ * Unlike {@code io.jstach.rainbowgum.spring.boot4.SpringBootSupportedProperties}, there
+ * is no {@code CONSOLE_ENABLED} constant here - {@code logging.console.enabled} is a
+ * Spring Boot 4-only property, not documented for Spring Boot 3.
+ */
+public final class SpringBootSupportedProperties {
+
+	private SpringBootSupportedProperties() {
+	}
+
+	/**
+	 * Root logger level - Spring Boot binds this rather than {@code logging.level} (see
+	 * {@link #LOGGING_LEVEL}).
+	 */
+	public static final String LOGGING_LEVEL_ROOT = "logging.level.root";
+
+	/**
+	 * The property RainbowGum core itself reads for the root level; remapped from
+	 * {@link #LOGGING_LEVEL_ROOT} since that's what Spring Boot actually binds.
+	 */
+	public static final String LOGGING_LEVEL = "logging.level";
+
+	/**
+	 * Whether the default pattern includes the {@code APPLICATION_NAME} segment.
+	 */
+	public static final String INCLUDE_APPLICATION_NAME = "logging.include-application-name";
+
+	/**
+	 * Whether the default pattern includes the {@code APPLICATION_GROUP} segment.
+	 */
+	public static final String INCLUDE_APPLICATION_GROUP = "logging.include-application-group";
+
+	/**
+	 * Directory-only file property - consulted only as a fallback when {@code
+	 * logging.file.name} itself is unset, synthesizing {@code <path>/spring.log}.
+	 */
+	public static final String FILE_PATH = "logging.file.path";
+
+	/**
+	 * {@code NEVER}/{@code ALWAYS}/{@code DETECT} - bridged to RainbowGum's own {@code
+	 * logging.global.ansi.disable} property.
+	 */
+	public static final String OUTPUT_ANSI_ENABLED = "spring.output.ansi.enabled";
+
+	/**
+	 * Charset for console output - bridged to the console pattern encoder's own {@code
+	 * charset} builder property.
+	 */
+	public static final String CHARSET_CONSOLE = "logging.charset.console";
+
+	/**
+	 * Charset for file output - bridged to the file pattern encoder's own {@code
+	 * charset} builder property.
+	 */
+	public static final String CHARSET_FILE = "logging.charset.file";
+
+	/**
+	 * Supported transitively - Spring Boot bridges this to the {@code
+	 * CONSOLE_LOG_PATTERN} system property before any {@code LoggingSystem} is
+	 * initialized.
+	 */
+	public static final String PATTERN_CONSOLE = "logging.pattern.console";
+
+	/**
+	 * Supported transitively - Spring Boot bridges this to the {@code FILE_LOG_PATTERN}
+	 * system property before any {@code LoggingSystem} is initialized.
+	 */
+	public static final String PATTERN_FILE = "logging.pattern.file";
+
+	/**
+	 * Supported transitively - Spring Boot bridges this to the {@code LOG_LEVEL_PATTERN}
+	 * system property before any {@code LoggingSystem} is initialized.
+	 */
+	public static final String PATTERN_LEVEL = "logging.pattern.level";
+
+	/**
+	 * Supported transitively - Spring Boot bridges this to the {@code
+	 * LOG_DATEFORMAT_PATTERN} system property before any {@code LoggingSystem} is
+	 * initialized.
+	 */
+	public static final String PATTERN_DATEFORMAT = "logging.pattern.dateformat";
+
+	/**
+	 * Supported transitively - Spring Boot bridges this to the {@code
+	 * LOG_EXCEPTION_CONVERSION_WORD} system property before any {@code LoggingSystem} is
+	 * initialized.
+	 */
+	public static final String EXCEPTION_CONVERSION_WORD = "logging.exception-conversion-word";
+
+	/**
+	 * Structured format for console output: {@code ecs}, {@code gelf}, or {@code
+	 * logstash}. Independent of {@link #STRUCTURED_FORMAT_FILE}.
+	 */
+	public static final String STRUCTURED_FORMAT_CONSOLE = "logging.structured.format.console";
+
+	/**
+	 * Structured format for file output: {@code ecs}, {@code gelf}, or {@code
+	 * logstash}. Independent of {@link #STRUCTURED_FORMAT_CONSOLE}.
+	 */
+	public static final String STRUCTURED_FORMAT_FILE = "logging.structured.format.file";
+
+	/**
+	 * ECS {@code service.name} field - defaults to {@code spring.application.name}.
+	 */
+	public static final String STRUCTURED_ECS_SERVICE_NAME = "logging.structured.ecs.service.name";
+
+	/**
+	 * ECS {@code service.version} field - defaults to {@code
+	 * spring.application.version}.
+	 */
+	public static final String STRUCTURED_ECS_SERVICE_VERSION = "logging.structured.ecs.service.version";
+
+	/**
+	 * ECS {@code service.environment} field.
+	 */
+	public static final String STRUCTURED_ECS_SERVICE_ENVIRONMENT = "logging.structured.ecs.service.environment";
+
+	/**
+	 * ECS {@code service.node-name} field.
+	 */
+	public static final String STRUCTURED_ECS_SERVICE_NODE_NAME = "logging.structured.ecs.service.node-name";
+
+	/**
+	 * GELF {@code host} field - defaults to {@code spring.application.name}.
+	 */
+	public static final String STRUCTURED_GELF_HOST = "logging.structured.gelf.host";
+
+	/**
+	 * GELF service version - becomes the underscore-prefixed {@code _service_version}
+	 * additional field, matching Spring Boot's own GELF formatter's naming.
+	 */
+	public static final String STRUCTURED_GELF_SERVICE_VERSION = "logging.structured.gelf.service.version";
+
+}

--- a/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/StructuredLogging.java
+++ b/spring/rainbowgum-spring-boot3/src/main/java/io/jstach/rainbowgum/spring/boot3/StructuredLogging.java
@@ -1,0 +1,95 @@
+package io.jstach.rainbowgum.spring.boot3;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.springframework.core.env.Environment;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogOutput.OutputType;
+import io.jstach.rainbowgum.LogProvider;
+import io.jstach.rainbowgum.json.encoder.EcsEncoder;
+import io.jstach.rainbowgum.json.encoder.GelfEncoder;
+import io.jstach.rainbowgum.json.encoder.LogstashEncoder;
+
+/**
+ * Bridges Spring Boot's {@code logging.structured.format.console}/
+ * {@code logging.structured.format.file} (and the per-format
+ * {@code logging.structured.<format>.*} fields) to RainbowGum's own
+ * {@code rainbowgum-json} encoders. The two output properties are independent, matching
+ * Spring Boot's own behavior - e.g. GELF-to-console with no file output at all (a
+ * 12factor/k8s-style deployment) works the same way it would for Logback/Log4j2.
+ * <p>
+ * Only {@code ecs}, {@code gelf}, and {@code logstash} are supported - Spring Boot also
+ * allows a fully-qualified {@code StructuredLogFormatter} class name for a fully custom
+ * format, which has no RainbowGum equivalent and is silently ignored (falls back to
+ * whatever pattern encoder is already installed for that output type).
+ */
+final class StructuredLogging {
+
+	private static final String ECS = "ecs";
+
+	private static final String GELF = "gelf";
+
+	private static final String LOGSTASH = "logstash";
+
+	private StructuredLogging() {
+	}
+
+	static void apply(LogConfig config, Environment environment) {
+		apply(config, environment, SpringBootSupportedProperties.STRUCTURED_FORMAT_CONSOLE, OutputType.CONSOLE_OUT);
+		apply(config, environment, SpringBootSupportedProperties.STRUCTURED_FORMAT_FILE, OutputType.FILE);
+	}
+
+	private static void apply(LogConfig config, Environment environment, String formatProperty, OutputType outputType) {
+		String format = environment.getProperty(formatProperty);
+		if (format == null) {
+			return;
+		}
+		LogProvider<? extends LogEncoder> encoder = encoderFor(format, environment);
+		if (encoder != null) {
+			config.encoderRegistry().setEncoderForOutputType(outputType, encoder);
+		}
+	}
+
+	private static @Nullable LogProvider<? extends LogEncoder> encoderFor(String format, Environment environment) {
+		return switch (format.toLowerCase(Locale.ROOT)) {
+			case ECS -> EcsEncoder.of(b -> b
+				.serviceName(environment.getProperty(SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_NAME,
+						applicationName(environment)))
+				.serviceVersion(environment.getProperty(SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_VERSION,
+						applicationVersion(environment)))
+				.serviceEnvironment(
+						environment.getProperty(SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_ENVIRONMENT))
+				.serviceNodeName(
+						environment.getProperty(SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_NODE_NAME)));
+			case GELF -> GelfEncoder.of(b -> {
+				String host = environment.getProperty(SpringBootSupportedProperties.STRUCTURED_GELF_HOST,
+						applicationName(environment));
+				b.host(host != null ? host : "application");
+				String serviceVersion = environment.getProperty(
+						SpringBootSupportedProperties.STRUCTURED_GELF_SERVICE_VERSION, applicationVersion(environment));
+				if (serviceVersion != null) {
+					// GELF additional field names can't contain dots - matches the
+					// underscore-joined convention Spring Boot's own GELF formatter
+					// uses for the same field.
+					b.headers(Map.of("service_version", serviceVersion));
+				}
+			});
+			case LOGSTASH -> LogstashEncoder.of(b -> {
+			});
+			default -> null;
+		};
+	}
+
+	private static @Nullable String applicationName(Environment environment) {
+		return environment.getProperty("spring.application.name");
+	}
+
+	private static @Nullable String applicationVersion(Environment environment) {
+		return environment.getProperty("spring.application.version");
+	}
+
+}

--- a/spring/rainbowgum-spring-boot3/src/main/java/module-info.java
+++ b/spring/rainbowgum-spring-boot3/src/main/java/module-info.java
@@ -13,11 +13,156 @@
  * genuinely shared module, {@code io.jstach.rainbowgum.spring.boot.spi}, since it does not
  * depend on Spring Boot at all (just the stable {@code Environment} type from spring-core)
  * and is meant to be implemented by consumers, so it is neither duplicated nor suffixed.
+ * <p>
+ * <b>Spring Boot logging property support</b> - see
+ * <a href="https://docs.spring.io/spring-boot/3.5/reference/features/logging.html">Spring
+ * Boot 3.5's own logging documentation</a> for what each property means. This is a
+ * snapshot of Boot 3 support specifically; the (separately maintained, not necessarily
+ * identical) Boot 4 module is {@code io.jstach.rainbowgum.spring.boot4}. Every property
+ * key below is a {@code {@value}} reference into
+ * {@link io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties} (or, for
+ * the two properties RainbowGum core itself understands independent of Spring Boot,
+ * {@link io.jstach.rainbowgum.LogProperties}) rather than a literal string, so this
+ * table can't silently drift from what the code actually reads.
+ * <table class="table">
+ * <caption><strong>Supported</strong></caption>
+ * <tr>
+ * <th>Property</th>
+ * <th>Notes</th>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#LOGGING_LEVEL_ROOT}, {@code
+ * logging.level.<logger>}, {@value io.jstach.rainbowgum.LogProperties#GROUP_PROPERTY}</td>
+ * <td>Native - the group property works because RainbowGum core's own {@code
+ * GroupLevelResolver} already uses this exact property key, not anything
+ * Spring-specific.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code debug}, {@code trace}</td>
+ * <td>Transitively - Spring's own {@code LoggingApplicationListener} converts these to
+ * {@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#LOGGING_LEVEL_ROOT} before any
+ * {@code LoggingSystem} is initialized.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#PATTERN_CONSOLE}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#PATTERN_FILE}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#PATTERN_LEVEL}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#PATTERN_DATEFORMAT}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#EXCEPTION_CONVERSION_WORD}</td>
+ * <td>Transitively - Spring Boot bridges these to system properties
+ * ({@code CONSOLE_LOG_PATTERN}, etc.) before calling {@code initialize()}; this module's
+ * {@code Patterns} class reads those system properties, the same mechanism a
+ * hand-written {@code logback.xml} would rely on.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#INCLUDE_APPLICATION_NAME}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#INCLUDE_APPLICATION_GROUP}</td>
+ * <td>Native - toggle whether the default pattern includes those segments.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.LogProperties#FILE_PROPERTY}</td>
+ * <td>Native, but in {@code rainbowgum-core} itself (not this module) - works even
+ * without Spring Boot on the classpath at all, kept there for that reason.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#FILE_PATH}</td>
+ * <td>Native - synthesizes {@code <path>/spring.log} when {@code logging.file.name}
+ * itself is unset, matching Spring Boot's own {@code LogFile.get(...)} precedence.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#OUTPUT_ANSI_ENABLED} ({@code
+ * NEVER}/{@code ALWAYS}/{@code DETECT})</td>
+ * <td>Native - bridged to RainbowGum's own existing
+ * {@code logging.global.ansi.disable} property rather than a second ansi mechanism;
+ * {@code DETECT} (or unset) leaves RainbowGum's own auto-detection in charge.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_FORMAT_CONSOLE}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_FORMAT_FILE} ({@code
+ * ecs}/{@code gelf}/{@code logstash} only - not a custom {@code StructuredLogFormatter}
+ * class name)</td>
+ * <td>Native - bridges to {@code rainbowgum-json}'s {@code EcsEncoder}/
+ * {@code GelfEncoder}/{@code LogstashEncoder}. The two properties are independent,
+ * matching Spring Boot's own behavior. Structured logging is a Spring Boot 3.4+ feature -
+ * this module reads the property itself regardless of the exact 3.x patch version, so it
+ * works even on Boot versions where Spring's own auto-configuration predates it.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_ECS_SERVICE_NAME}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_ECS_SERVICE_VERSION}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_ECS_SERVICE_ENVIRONMENT}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_ECS_SERVICE_NODE_NAME}</td>
+ * <td>Native - {@code .name}/{@code .version} default to
+ * {@code spring.application.name}/{@code .version} the same way Spring Boot's own ECS
+ * formatter does.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_GELF_HOST}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#STRUCTURED_GELF_SERVICE_VERSION}</td>
+ * <td>Native - {@code .host} defaults to {@code spring.application.name}. GELF has no
+ * dedicated version field, so {@code .service.version} becomes an
+ * underscore-prefixed {@code _service_version} additional field, matching Spring Boot's
+ * own GELF formatter's naming.</td>
+ * </tr>
+ * <tr>
+ * <td>{@value io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#CHARSET_CONSOLE}, {@value
+ * io.jstach.rainbowgum.spring.boot3.SpringBootSupportedProperties#CHARSET_FILE}</td>
+ * <td>Native - bridged to the pattern encoder's own {@code charset} builder property
+ * (a core {@code rainbowgum-pattern} capability, not Spring-specific); unset falls back
+ * to UTF-8 the same as when Spring Boot is not on the classpath at all.</td>
+ * </tr>
+ * </table>
+ * <table class="table">
+ * <caption><strong>Not supported</strong></caption>
+ * <tr>
+ * <th>Property</th>
+ * <th>Why</th>
+ * </tr>
+ * <tr>
+ * <td>{@code logging.threshold.console}, {@code logging.threshold.file}</td>
+ * <td>Would need a new core capability (per-appender level filtering within a
+ * multi-appender route - level filtering today is per-route, not per-appender).</td>
+ * </tr>
+ * <tr>
+ * <td>{@code logging.structured.json.include}, {@code .exclude}, {@code .rename.*},
+ * {@code .add.*}, {@code .customizer}, {@code .stacktrace.*}</td>
+ * <td>Spring Boot's own {@code JsonWriter}/{@code StackTracePrinter} customization
+ * layer, specific to its {@code StructuredLogFormatter} machinery - no RainbowGum
+ * equivalent to bridge to.</td>
+ * </tr>
+ * <tr>
+ * <td>A fully-qualified {@code StructuredLogFormatter} class name as the
+ * {@code logging.structured.format.*} value (Spring Boot's fully-custom-format escape
+ * hatch)</td>
+ * <td>No RainbowGum equivalent; silently falls back to whatever pattern encoder is
+ * already installed for that output type rather than failing.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code logging.config}</td>
+ * <td>No RainbowGum equivalent - configuration is property-driven, not a separate
+ * config file format like {@code logback.xml}.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code logging.register-shutdown-hook}</td>
+ * <td>Unclear mapping to RainbowGum's own shutdown lifecycle - not attempted.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code logging.logback.rollingpolicy.*}, {@code logging.log4j2.rollingpolicy.*}</td>
+ * <td>N/A - this module has no Logback or Log4j2 dependency, and RainbowGum does not
+ * support file rolling at all (see the roadmap's file-rolling discussion).</td>
+ * </tr>
+ * <tr>
+ * <td>{@code logging.console.enabled}</td>
+ * <td>N/A - not a Spring Boot 3 property (Boot 4 only; see
+ * {@code io.jstach.rainbowgum.spring.boot4.SpringBootSupportedProperties#CONSOLE_ENABLED}).</td>
+ * </tr>
+ * </table>
  */
 module io.jstach.rainbowgum.spring.boot3 {
 	requires transitive io.jstach.rainbowgum;
 	requires transitive io.jstach.rainbowgum.spring.boot.spi;
 	requires io.jstach.rainbowgum.pattern;
+	requires io.jstach.rainbowgum.json;
 
 	/*
 	 * Note that we never require transitive of spring stuff

--- a/spring/rainbowgum-spring-boot3/src/test/java/io/jstach/rainbowgum/spring/boot3/PatternsTest.java
+++ b/spring/rainbowgum-spring-boot3/src/test/java/io/jstach/rainbowgum/spring/boot3/PatternsTest.java
@@ -1,0 +1,56 @@
+package io.jstach.rainbowgum.spring.boot3;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.spring.boot3.RainbowGumLoggingSystemFactory.Patterns;
+
+class PatternsTest {
+
+	private static final LogProperties EMPTY = key -> null;
+
+	private static StandardEnvironment environment(Map<String, Object> properties) {
+		var environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+		return environment;
+	}
+
+	@Test
+	void bothIncludedByDefault() {
+		var patterns = new Patterns(EMPTY, environment(Map.of()));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_NAME"));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_GROUP"));
+	}
+
+	@Test
+	void applicationNameExcludedWhenDisabled() {
+		var patterns = new Patterns(EMPTY,
+				environment(Map.of(SpringBootSupportedProperties.INCLUDE_APPLICATION_NAME, "false")));
+		assertFalse(patterns.NAME_AND_GROUP.contains("APPLICATION_NAME"));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_GROUP"));
+	}
+
+	@Test
+	void applicationGroupExcludedWhenDisabled() {
+		var patterns = new Patterns(EMPTY,
+				environment(Map.of(SpringBootSupportedProperties.INCLUDE_APPLICATION_GROUP, "false")));
+		assertTrue(patterns.NAME_AND_GROUP.contains("APPLICATION_NAME"));
+		assertFalse(patterns.NAME_AND_GROUP.contains("APPLICATION_GROUP"));
+	}
+
+	@Test
+	void bothExcludedWhenDisabled() {
+		var patterns = new Patterns(EMPTY, environment(Map.of(SpringBootSupportedProperties.INCLUDE_APPLICATION_NAME,
+				"false", SpringBootSupportedProperties.INCLUDE_APPLICATION_GROUP, "false")));
+		assertFalse(patterns.consolePattern().contains("APPLICATION_NAME"));
+		assertFalse(patterns.consolePattern().contains("APPLICATION_GROUP"));
+	}
+
+}

--- a/spring/rainbowgum-spring-boot3/src/test/java/io/jstach/rainbowgum/spring/boot3/SpringLogPropertiesTest.java
+++ b/spring/rainbowgum-spring-boot3/src/test/java/io/jstach/rainbowgum/spring/boot3/SpringLogPropertiesTest.java
@@ -1,0 +1,72 @@
+package io.jstach.rainbowgum.spring.boot3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.spring.boot3.RainbowGumLoggingSystemFactory.SpringLogProperties;
+
+class SpringLogPropertiesTest {
+
+	private static SpringLogProperties properties(Map<String, Object> map) {
+		var environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("test", map));
+		return new SpringLogProperties(environment);
+	}
+
+	@Test
+	void fileNameTakesPrecedenceOverFilePath() {
+		var p = properties(Map.of(LogProperties.FILE_PROPERTY, "explicit.log", SpringBootSupportedProperties.FILE_PATH,
+				"/var/log"));
+		assertEquals("explicit.log", p.valueOrNull(LogProperties.FILE_PROPERTY));
+	}
+
+	@Test
+	void filePathSynthesizesSpringLogFilename() {
+		var p = properties(Map.of(SpringBootSupportedProperties.FILE_PATH, "/var/log"));
+		assertEquals("/var/log/spring.log", p.valueOrNull(LogProperties.FILE_PROPERTY));
+	}
+
+	@Test
+	void neitherFileNameNorPathMeansNoFile() {
+		var p = properties(Map.of());
+		assertNull(p.valueOrNull(LogProperties.FILE_PROPERTY));
+	}
+
+	@Test
+	void ansiNeverMapsToGlobalDisableTrue() {
+		var p = properties(Map.of(SpringBootSupportedProperties.OUTPUT_ANSI_ENABLED, "NEVER"));
+		assertEquals("true", p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void ansiAlwaysMapsToGlobalDisableFalse() {
+		var p = properties(Map.of(SpringBootSupportedProperties.OUTPUT_ANSI_ENABLED, "ALWAYS"));
+		assertEquals("false", p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void ansiDetectLeavesAutoDetectionAlone() {
+		var p = properties(Map.of(SpringBootSupportedProperties.OUTPUT_ANSI_ENABLED, "DETECT"));
+		assertNull(p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void ansiUnsetFallsBackToDirectPropertyIfSet() {
+		var p = properties(Map.of(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY, "true"));
+		assertEquals("true", p.valueOrNull(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY));
+	}
+
+	@Test
+	void loggingLevelFallsBackToRootLevel() {
+		var p = properties(Map.of(SpringBootSupportedProperties.LOGGING_LEVEL_ROOT, "DEBUG"));
+		assertEquals("DEBUG", p.valueOrNull(SpringBootSupportedProperties.LOGGING_LEVEL));
+	}
+
+}

--- a/spring/rainbowgum-spring-boot3/src/test/java/io/jstach/rainbowgum/spring/boot3/StructuredLoggingTest.java
+++ b/spring/rainbowgum-spring-boot3/src/test/java/io/jstach/rainbowgum/spring/boot3/StructuredLoggingTest.java
@@ -1,0 +1,137 @@
+package io.jstach.rainbowgum.spring.boot3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import io.jstach.rainbowgum.KeyValues.MutableKeyValues;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogOutput.OutputType;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.json.encoder.EcsEncoder;
+import io.jstach.rainbowgum.json.encoder.GelfEncoder;
+import io.jstach.rainbowgum.json.encoder.LogstashEncoder;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+class StructuredLoggingTest {
+
+	private static StandardEnvironment environment(Map<String, Object> properties) {
+		var environment = new StandardEnvironment();
+		environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+		return environment;
+	}
+
+	/*
+	 * ListLogOutput's own OutputType is always MEMORY, so encoderForOutputType's
+	 * auto-resolution-by-output-type wouldn't pick up what StructuredLogging.apply
+	 * installed for FILE/CONSOLE_OUT - fetch that encoder explicitly and wire it onto the
+	 * appender directly instead, matching how EcsEncoderTest/GelfEncoderTest exercise
+	 * encoders elsewhere in the codebase.
+	 */
+	private static String encodedMessage(LogConfig config, OutputType outputType) {
+		var output = new ListLogOutput();
+		var encoder = config.encoderRegistry().encoderForOutputType(outputType);
+		try (var g = RainbowGum.builder(config)
+			.route(rb -> rb.appender("test", a -> a.output(output).encoder(encoder)))
+			.build()
+			.start()) {
+			LogEvent e = LogEvent
+				.of(System.Logger.Level.INFO, "io.jstach.logger", "hello", MutableKeyValues.of().freeze(), null)
+				.freeze(Instant.EPOCH);
+			g.log(e);
+		}
+		return output.events().get(0).getValue();
+	}
+
+	@Test
+	void gelfOnConsoleOnlyLeavesFileAlone() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of(SpringBootSupportedProperties.STRUCTURED_FORMAT_CONSOLE, "gelf",
+				"spring.application.name", "my-app"));
+		StructuredLogging.apply(config, environment);
+
+		var consoleEncoder = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		assertInstanceOf(GelfEncoder.class, consoleEncoder);
+
+		var fileEncoder = config.encoderRegistry().encoderForOutputType(OutputType.FILE).provide("f", config);
+		assertEquals(false, fileEncoder instanceof GelfEncoder, "file output type must be untouched");
+	}
+
+	@Test
+	void gelfHostDefaultsToApplicationName() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of(SpringBootSupportedProperties.STRUCTURED_FORMAT_FILE, "gelf",
+				"spring.application.name", "fallback-app"));
+		StructuredLogging.apply(config, environment);
+		String json = encodedMessage(config, OutputType.FILE);
+		assertTrue(json.contains("\"host\":\"fallback-app\""), json);
+	}
+
+	@Test
+	void gelfServiceVersionBecomesUnderscoreHeader() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of(SpringBootSupportedProperties.STRUCTURED_FORMAT_FILE, "gelf",
+				SpringBootSupportedProperties.STRUCTURED_GELF_HOST, "h",
+				SpringBootSupportedProperties.STRUCTURED_GELF_SERVICE_VERSION, "1.2.3"));
+		StructuredLogging.apply(config, environment);
+		String json = encodedMessage(config, OutputType.FILE);
+		assertTrue(json.contains("\"_service_version\":\"1.2.3\""), json);
+	}
+
+	@Test
+	void ecsFieldsAllThreadThrough() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of(SpringBootSupportedProperties.STRUCTURED_FORMAT_FILE, "ecs",
+				SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_NAME, "svc",
+				SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_VERSION, "2.0",
+				SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_ENVIRONMENT, "prod",
+				SpringBootSupportedProperties.STRUCTURED_ECS_SERVICE_NODE_NAME, "node-1"));
+		StructuredLogging.apply(config, environment);
+		String json = encodedMessage(config, OutputType.FILE);
+		assertTrue(json.contains("\"service.name\":\"svc\""), json);
+		assertTrue(json.contains("\"service.version\":\"2.0\""), json);
+		assertTrue(json.contains("\"service.environment\":\"prod\""), json);
+	}
+
+	@Test
+	void logstashFormatSelectsLogstashEncoder() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of(SpringBootSupportedProperties.STRUCTURED_FORMAT_CONSOLE, "logstash"));
+		StructuredLogging.apply(config, environment);
+		var encoder = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		assertInstanceOf(LogstashEncoder.class, encoder);
+	}
+
+	@Test
+	void unrecognizedFormatIsIgnored() {
+		var config = LogConfig.builder().build();
+		var environment = environment(
+				Map.of(SpringBootSupportedProperties.STRUCTURED_FORMAT_CONSOLE, "some.custom.FormatterClass"));
+		StructuredLogging.apply(config, environment);
+		var encoder = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		assertEquals(false,
+				encoder instanceof GelfEncoder || encoder instanceof EcsEncoder || encoder instanceof LogstashEncoder);
+	}
+
+	@Test
+	void noFormatPropertiesLeavesBothOutputTypesUntouched() {
+		var config = LogConfig.builder().build();
+		var environment = environment(Map.of());
+		StructuredLogging.apply(config, environment);
+		var console = config.encoderRegistry().encoderForOutputType(OutputType.CONSOLE_OUT).provide("c", config);
+		var file = config.encoderRegistry().encoderForOutputType(OutputType.FILE).provide("f", config);
+		assertEquals(false,
+				console instanceof GelfEncoder || console instanceof EcsEncoder || console instanceof LogstashEncoder);
+		assertEquals(false,
+				file instanceof GelfEncoder || file instanceof EcsEncoder || file instanceof LogstashEncoder);
+	}
+
+}


### PR DESCRIPTION
Ports the Boot 4 module's Spring Boot logging property support (root level, logging.file.path fallback, logging.include-application-name/ group, spring.output.ansi.enabled bridging, structured logging via rainbowgum-json, and console/file charset) into rainbowgum-spring-boot3, duplicating the code rather than sharing it with boot4 (same policy the modules already document for themselves). logging.console.enabled is intentionally not ported - it's a Boot 4-only property, not documented for Boot 3.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5