### PR TITLE
Draft v0.10.0 GitHub release notes

### DIFF
--- a/doc/v0-10-0.md
+++ b/doc/v0-10-0.md
@@ -1,0 +1,115 @@
+# Rainbow Gum 0.10.0
+
+This release's headline is **Spring Boot**: Boot 3 and Boot 4 support are now separate,
+independently-versioned modules, and the Boot 4 module in particular understands a lot
+more of Spring Boot's own logging properties out of the box - Boot 3 has since been
+brought up to the same level. Alongside that, the default appender configuration changed
+to favor virtual threads and buffer reuse, which shows up as a real throughput win in
+our own benchmarks (more below).
+
+## Spring Boot: split modules, real property support
+
+Rainbow Gum's Spring Boot integration is no longer one module trying to straddle two
+incompatible major versions. It's now:
+
+- `io.jstach.rainbowgum:rainbowgum-spring-boot4` / `rainbowgum-spring-boot4-starter` -
+  for Spring Boot 4 / Spring Framework 7 **(recommended for new projects)**.
+- `io.jstach.rainbowgum:rainbowgum-spring-boot3` / `rainbowgum-spring-boot3-starter` -
+  for Spring Boot 3.
+
+Each is its own artifact with its own release cadence, so a Spring Boot major-version
+bump on their end doesn't force one on ours, or vice versa.
+
+More importantly, both modules now natively understand a real chunk of [Spring Boot's
+documented logging properties](https://docs.spring.io/spring-boot/reference/features/logging.html) -
+no custom `LoggingSystem` boilerplate or workaround classes required in your app:
+
+- `logging.level.root` / `logging.level.<logger>`, `logging.group.*`, `debug`/`trace`
+- `logging.file.name` and `logging.file.path` (directory-only fallback, Spring's own
+  `<path>/spring.log` convention)
+- `logging.include-application-name` / `logging.include-application-group`
+- `logging.pattern.console` / `.file` / `.level` / `.dateformat`,
+  `logging.exception-conversion-word`
+- `spring.output.ansi.enabled` (`NEVER`/`ALWAYS`/`DETECT`)
+- `logging.charset.console` / `logging.charset.file` - encoders can now be configured
+  with an arbitrary charset, not just UTF-8 (see below)
+- `logging.structured.format.console` / `.file` - `ecs`, `gelf`, and `logstash`,
+  independently configurable per output, bridging to the new JSON encoders below
+- The full set of `logging.structured.ecs.*` / `logging.structured.gelf.*` fields
+- Boot 4 only: `logging.console.enabled` (not a Boot 3 property)
+
+Each module's own javadoc carries the authoritative, always-current supported/
+not-supported property table (see `io.jstach.rainbowgum.spring.boot4` /
+`io.jstach.rainbowgum.spring.boot3`) rather than a copy here that can drift out of sync.
+
+## Performance: better defaults for virtual threads
+
+The default appender buffering strategy changed from a plain `synchronized` block to a
+`ReentrantLock`-guarded reusable buffer (`LOCK_THREAD_LOCAL_BUFFER`), and buffer reuse
+itself is now the out-of-the-box default rather than an opt-in flag. The practical
+effect: significantly less contention under virtual threads, where a `synchronized`
+block pins the carrier thread - `ReentrantLock` doesn't have that problem.
+
+We re-ran a Spring Boot webapp benchmark (Logback vs Log4j2 vs Rainbow Gum, real HTTP
+load, virtual and platform threads, plain and GELF/structured logging) to check this
+wasn't just a synthetic win:
+
+| scenario | Logback | Log4j2 | Rainbow Gum |
+|---|---:|---:|---:|
+| virtual threads | 25,554 req/s | 18,990 req/s | **26,324 req/s** |
+| virtual threads + GELF | 25,797 req/s | 17,734 req/s | **27,450 req/s** |
+| container/12-factor style (console-only, GELF) | 15,002 req/s | 19,639 req/s | **34,172 req/s** |
+| container/12-factor + virtual threads | 21,587 req/s | 15,445 req/s | **25,572 req/s** |
+
+The container/12-factor scenario (structured logging straight to stdout, no file output
+- the way most people actually run Spring Boot in Kubernetes today) is Rainbow Gum's
+best result of the bunch, roughly **2x** both Logback and Log4j2. It's also the closest
+thing to "out of the box, zero extra config" of the scenarios tested, since it's exactly
+what the new native structured-logging support above produces with nothing but a
+property.
+
+(For completeness: on plain platform threads with no structured logging, Log4j2 still
+leads; that specific gap isn't closed yet.)
+
+Other, smaller performance work in this release: garbage-free `ByteBuffer` encoding
+folded into the default formatter-backed encoder, and cached/precision-fixed timestamp
+formatting instead of reformatting on every log call.
+
+## New: structured JSON logging encoders
+
+New `rainbowgum-json` module encoders, usable standalone or via the Spring Boot
+structured-logging properties above:
+
+- **ECS** (Elastic Common Schema)
+- **GELF** (Graylog Extended Log Format)
+- **Logstash**-style JSON
+
+## Pattern formatter additions
+
+- `%wEx`/`%wex` - Spring Boot's whitespace-prefixed throwable format
+- `%xEx` - extended throwable rendering with packaging/version data (Logback-compatible)
+- `%ex{depth}` - configurable stack frame depth and exclusion patterns
+- `%r` / `%relative` - elapsed milliseconds since process start
+- `%lsn` - a local, in-process monotonic sequence number
+- `%X`/`%mdc` output now matches Logback's MDC formatting exactly, for drop-in
+  compatibility with existing Logback patterns
+
+## Native ANSI color detection
+
+Color pattern keywords now work out of the box with **no extra dependency** - Rainbow
+Gum detects a real ANSI-capable terminal itself (`System.console()` plus `NO_COLOR`/
+`TERM`) instead of relying on the JAnsi library to strip escape sequences. The separate
+`rainbowgum-jansi` module is still available but is now effectively legacy.
+
+## Module changes
+
+- JUL (`java.util.logging`) bridging is now its own module, `rainbowgum-jul`, split out
+  of `rainbowgum-jdk`.
+- `rainbowgum-rabbitmq` has been removed.
+- Appender flag renames (if you set these explicitly): `THREAD_LOCAL_BUFFER` →
+  `LOCK_THREAD_LOCAL_BUFFER`, `IMMEDIATE_FLUSH` → `DISABLE_IMMEDIATE_FLUSH` (immediate
+  flush is now on by default, so the flag inverted along with the rename).
+
+## Full changelog
+
+[v0.9.0...v0.10.0](https://github.com/jstachio/rainbowgum/compare/v0.9.0...v0.10.0)


### PR DESCRIPTION
Focused on the two things actually worth telling users about for a release this size: the Spring Boot 3/4 module split with real property support, and the virtual-thread/buffer-reuse default change backed by a webapp benchmark rerun. Deliberately leaves out build-infra and pure bugfix commits per Adam's direction - those don't belong in user-facing release notes for a release this size.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5