### PR TITLE
Exploration: let a thread-local-buffer appender discard an oversized …

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -119,7 +119,7 @@ public interface LogEncoder {
 
 		private @Nullable ContentType contentType;
 
-		private int maxSize = -1;
+		private int maxBufferSize = -1;
 
 		private int initialBufferSize = DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY;
 
@@ -161,17 +161,22 @@ public interface LogEncoder {
 		}
 
 		/**
-		 * Configures a maximum buffer size - see {@link Buffer#isOversized()}. This, like
-		 * charset, is a property of the encoder/buffer, not of whatever appender ends up
-		 * reusing the buffer - an appender that reuses a buffer across events (e.g. a
-		 * {@code ThreadLocal}-cached one) simply asks the buffer whether it has become
-		 * oversized and discards/replaces it if so; it has no threshold of its own.
-		 * @param maxSize a negative value disables {@link Buffer#isOversized()} entirely
-		 * (the default).
+		 * Configures a maximum buffer size - see {@link Buffer#isOversized()}. This is a
+		 * <strong>soft ceiling, not a hard cap</strong>: a single event can still grow
+		 * the buffer past this size while it is being encoded (nothing here truncates or
+		 * rejects an oversized event), it just means the buffer's backing storage gets
+		 * shrunk back down afterward instead of being kept at its grown size indefinitely
+		 * - a quota that gets reclaimed after the fact, not enforced during the write.
+		 * This, like charset, is a property of the encoder/buffer itself, not of whatever
+		 * ends up reusing the buffer (e.g. an appender's {@code ThreadLocal}-cached one)
+		 * - the buffer decides for itself, inside its own {@link Buffer#clear()}, whether
+		 * to shrink.
+		 * @param maxBufferSize a negative value disables {@link Buffer#isOversized()}
+		 * entirely (the default).
 		 * @return this.
 		 */
-		public Builder maxSize(int maxSize) {
-			this.maxSize = maxSize;
+		public Builder maxBufferSize(int maxBufferSize) {
+			this.maxBufferSize = maxBufferSize;
 			return this;
 		}
 
@@ -209,7 +214,7 @@ public interface LogEncoder {
 			if (ct == null) {
 				ct = ContentType.of(StandardContentType.TEXT_PLAIN.contentType(), c);
 			}
-			return new FormatterEncoder(formatter, c, ct, maxSize, initialBufferSize);
+			return new FormatterEncoder(formatter, c, ct, maxBufferSize, initialBufferSize);
 		}
 
 	}
@@ -298,8 +303,11 @@ public interface LogEncoder {
 		 * capacity the last event actually used) that its backing storage is worth
 		 * shrinking back down rather than kept at its grown size indefinitely - reused
 		 * buffers only grow on their own, they never shrink back down without deliberate
-		 * help. Built-in implementations consult this themselves inside {@link #clear()}
-		 * to decide whether to shrink their own backing storage in place (e.g.
+		 * help. This is a soft ceiling checked between events, not a hard cap enforced
+		 * during one: nothing here stops a single event from growing the buffer past
+		 * whatever threshold it was configured with while that event is being encoded.
+		 * Built-in implementations consult this themselves inside {@link #clear()} to
+		 * decide whether to shrink their own backing storage in place (e.g.
 		 * {@link StringBuilder#trimToSize()}, or reallocating a smaller
 		 * {@link java.nio.ByteBuffer}) - most callers do not need to call this directly;
 		 * it remains here mainly for tests/observability and for a custom {@link Buffer}
@@ -339,7 +347,7 @@ public interface LogEncoder {
 			 */
 			public final StringBuilder stringBuilder;
 
-			private final int maxSize;
+			private final int maxBufferSize;
 
 			/**
 			 * Creates a StringBuilder based buffer that never reports
@@ -353,20 +361,20 @@ public interface LogEncoder {
 
 			/**
 			 * Creates a StringBuilder based buffer that reports {@link #isOversized()}
-			 * once {@code sb}'s capacity exceeds {@code maxSize}.
+			 * once {@code sb}'s capacity exceeds {@code maxBufferSize}.
 			 * @param sb string builder.
-			 * @param maxSize a negative value disables {@link #isOversized()} entirely
-			 * (always {@code false}).
+			 * @param maxBufferSize a negative value disables {@link #isOversized()}
+			 * entirely (always {@code false}).
 			 * @return buffer.
 			 */
-			public static StringBuilderBuffer of(StringBuilder sb, int maxSize) {
-				return new StringBuilderBuffer(sb, maxSize);
+			public static StringBuilderBuffer of(StringBuilder sb, int maxBufferSize) {
+				return new StringBuilderBuffer(sb, maxBufferSize);
 			}
 
-			private StringBuilderBuffer(StringBuilder stringBuilder, int maxSize) {
+			private StringBuilderBuffer(StringBuilder stringBuilder, int maxBufferSize) {
 				super();
 				this.stringBuilder = stringBuilder;
-				this.maxSize = maxSize;
+				this.maxBufferSize = maxBufferSize;
 			}
 
 			@Override
@@ -388,7 +396,7 @@ public interface LogEncoder {
 
 			@Override
 			public boolean isOversized() {
-				return maxSize >= 0 && stringBuilder.capacity() > maxSize;
+				return maxBufferSize >= 0 && stringBuilder.capacity() > maxBufferSize;
 			}
 
 		}
@@ -445,7 +453,7 @@ public interface LogEncoder {
 
 			private final LogOutput.ContentType contentType;
 
-			private final int maxSize;
+			private final int maxBufferSize;
 
 			private final int initialByteCapacity;
 
@@ -512,24 +520,24 @@ public interface LogEncoder {
 			 * @param contentType content type reported to {@link LogOutput#write}. Its
 			 * {@link LogOutput.ContentType#charsetOrNull() charset}, if specified, should
 			 * normally match {@code charset}.
-			 * @param maxSize a negative value disables {@link #isOversized()} entirely
-			 * (always {@code false}). Since {@code initialByteCapacity} (commonly
-			 * {@value #DEFAULT_INITIAL_BYTE_CAPACITY}) is allocated up front and counted
-			 * by {@link #isOversized()} regardless of how much of it any event has
-			 * actually used, a {@code maxSize} at or below {@code initialByteCapacity}
-			 * makes {@link #isOversized()} unconditionally {@code true} from the very
-			 * first event - {@code maxSize} should normally be set well above whatever
-			 * initial capacity is in play.
+			 * @param maxBufferSize a negative value disables {@link #isOversized()}
+			 * entirely (always {@code false}). Since {@code initialByteCapacity}
+			 * (commonly {@value #DEFAULT_INITIAL_BYTE_CAPACITY}) is allocated up front
+			 * and counted by {@link #isOversized()} regardless of how much of it any
+			 * event has actually used, a {@code maxBufferSize} at or below
+			 * {@code initialByteCapacity} makes {@link #isOversized()} unconditionally
+			 * {@code true} from the very first event - {@code maxBufferSize} should
+			 * normally be set well above whatever initial capacity is in play.
 			 */
 			public DirectByteBufferBuffer(LogOutput.WriteMethod writeMethod, int initialByteCapacity, Charset charset,
-					LogOutput.ContentType contentType, int maxSize) {
+					LogOutput.ContentType contentType, int maxBufferSize) {
 				this.writeMethod = writeMethod;
 				this.byteBuffer = ByteBuffer.allocate(initialByteCapacity);
 				this.charsetEncoder = charset.newEncoder()
 					.onMalformedInput(CodingErrorAction.REPLACE)
 					.onUnmappableCharacter(CodingErrorAction.REPLACE);
 				this.contentType = contentType;
-				this.maxSize = maxSize;
+				this.maxBufferSize = maxBufferSize;
 				this.initialByteCapacity = initialByteCapacity;
 			}
 
@@ -599,7 +607,7 @@ public interface LogEncoder {
 
 			@Override
 			public boolean isOversized() {
-				return maxSize >= 0 && (stringBuilder.capacity() + byteBuffer.capacity()) > maxSize;
+				return maxBufferSize >= 0 && (stringBuilder.capacity() + byteBuffer.capacity()) > maxBufferSize;
 			}
 
 		}
@@ -693,26 +701,26 @@ final class FormatterEncoder implements LogEncoder {
 
 	private final ContentType contentType;
 
-	private final int maxSize;
+	private final int maxBufferSize;
 
 	private final int initialBufferSize;
 
-	FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType, int maxSize,
+	FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType, int maxBufferSize,
 			int initialBufferSize) {
 		super();
 		this.formatter = formatter;
 		this.charset = charset;
 		this.contentType = contentType;
-		this.maxSize = maxSize;
+		this.maxBufferSize = maxBufferSize;
 		this.initialBufferSize = initialBufferSize;
 	}
 
 	@Override
 	public Buffer buffer(BufferHints hints) {
 		return switch (hints.writeMethod()) {
-			case STRING -> StringBuilderBuffer.of(new StringBuilder(initialBufferSize), maxSize);
+			case STRING -> StringBuilderBuffer.of(new StringBuilder(initialBufferSize), maxBufferSize);
 			case BYTES, BYTE_BUFFER ->
-				new DirectByteBufferBuffer(hints.writeMethod(), initialBufferSize, charset, contentType, maxSize);
+				new DirectByteBufferBuffer(hints.writeMethod(), initialBufferSize, charset, contentType, maxBufferSize);
 		};
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -9,6 +9,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
 
 import io.jstach.rainbowgum.LogEncoder.Buffer.DirectByteBufferBuffer;
 import io.jstach.rainbowgum.LogEncoder.Buffer.StringBuilderBuffer;
@@ -16,6 +19,7 @@ import io.jstach.rainbowgum.LogOutput.ContentType;
 import io.jstach.rainbowgum.LogOutput.ContentType.StandardContentType;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
 import io.jstach.rainbowgum.format.AbstractStandardEventFormatter;
+import io.jstach.rainbowgum.format.StandardEventFormatter;
 
 /**
  * Encodes a {@link LogEvent} into a buffer of its choosing. While the {@link Buffer} does
@@ -74,81 +78,140 @@ public interface LogEncoder {
 
 	/**
 	 * Creates an encoder from a formatter that encodes with
-	 * {@link StandardCharsets#UTF_8}.
+	 * {@link StandardCharsets#UTF_8}. For anything more than the default charset/content
+	 * type/max buffer size use {@link #builder(LogFormatter)}.
 	 * @param formatter formatter.
 	 * @return encoder.
 	 */
 	public static LogEncoder of(LogFormatter formatter) {
-		return of(formatter, StandardCharsets.UTF_8);
+		return builder(formatter).build();
 	}
 
 	/**
-	 * Creates an encoder from a formatter that encodes with the given charset and reports
-	 * {@link StandardContentType#TEXT_PLAIN} with that charset to the output.
-	 * {@link Buffer#isOversized()} is disabled - see
-	 * {@link #of(LogFormatter, Charset, int)} to configure it.
+	 * Creates a builder for an encoder backed by the given formatter.
 	 * @param formatter formatter.
-	 * @param charset charset to encode with. Only affects outputs whose
-	 * {@link BufferHints#writeMethod()} is {@link WriteMethod#BYTES} or
-	 * {@link WriteMethod#BYTE_BUFFER} - the {@link WriteMethod#STRING} path hands a plain
-	 * {@link String} to {@link LogOutput#write(LogEvent, String)}, whose own default
-	 * implementation is fixed to {@link StandardCharsets#UTF_8} regardless of this
-	 * parameter, but no built-in output actually uses that write method.
-	 * @return encoder.
+	 * @return builder.
 	 */
-	public static LogEncoder of(LogFormatter formatter, Charset charset) {
-		return of(formatter, charset, -1);
+	public static Builder builder(LogFormatter formatter) {
+		return new Builder(formatter);
 	}
 
 	/**
-	 * Like {@link #of(LogFormatter, Charset)} but also configures a maximum buffer size -
-	 * see {@link Buffer#isOversized()}. This, like charset, is a property of the
-	 * encoder/buffer, not of whatever appender ends up reusing the buffer - an appender
-	 * that reuses a buffer across events (e.g. a {@code ThreadLocal}-cached one) simply
-	 * asks the buffer whether it has become oversized and discards/replaces it if so; it
-	 * has no threshold of its own.
-	 * @param formatter formatter.
-	 * @param charset charset to encode with. See {@link #of(LogFormatter, Charset)}.
-	 * @param maxSize a negative value disables {@link Buffer#isOversized()} entirely (the
-	 * same behavior as {@link #of(LogFormatter, Charset)}).
-	 * @return encoder.
+	 * Creates a builder for an encoder backed by the default TTLL
+	 * ({@link io.jstach.rainbowgum.format.StandardEventFormatter}) formatter.
+	 * @return builder.
 	 */
-	public static LogEncoder of(LogFormatter formatter, Charset charset, int maxSize) {
-		return of(formatter, charset, ContentType.of(StandardContentType.TEXT_PLAIN.contentType(), charset), maxSize);
+	public static Builder builder() {
+		return new Builder(StandardEventFormatter.builder().build());
 	}
 
 	/**
-	 * Creates an encoder from a formatter that reports the given content type to the
-	 * output, encoding with {@link ContentType#charsetOrNull() its charset} if specified,
-	 * otherwise {@link StandardCharsets#UTF_8}. Use this instead of
-	 * {@link #of(LogFormatter, Charset)} when the formatter produces something other than
-	 * plain text (e.g. a custom {@link ContentType.DefaultContentType}).
-	 * {@link Buffer#isOversized()} is disabled - see
-	 * {@link #of(LogFormatter, ContentType, int)} to configure it.
-	 * @param formatter formatter.
-	 * @param contentType content type reported to the output. See
-	 * {@link #of(LogFormatter, Charset)} for the effect of its charset.
-	 * @return encoder.
+	 * Builds a {@link LogEncoder} out of a {@link LogFormatter}.
+	 *
+	 * @apiNote created with {@link LogEncoder#builder(LogFormatter)} or
+	 * {@link LogEncoder#builder()}.
 	 */
-	public static LogEncoder of(LogFormatter formatter, ContentType contentType) {
-		return of(formatter, contentType, -1);
-	}
+	public static final class Builder {
 
-	/**
-	 * Like {@link #of(LogFormatter, ContentType)} but also configures a maximum buffer
-	 * size - see {@link #of(LogFormatter, Charset, int)}.
-	 * @param formatter formatter.
-	 * @param contentType content type reported to the output.
-	 * @param maxSize a negative value disables {@link Buffer#isOversized()} entirely.
-	 * @return encoder.
-	 */
-	public static LogEncoder of(LogFormatter formatter, ContentType contentType, int maxSize) {
-		var charset = contentType.charsetOrNull();
-		return of(formatter, charset == null ? StandardCharsets.UTF_8 : charset, contentType, maxSize);
-	}
+		private final LogFormatter formatter;
 
-	private static LogEncoder of(LogFormatter formatter, Charset charset, ContentType contentType, int maxSize) {
-		return new FormatterEncoder(formatter, charset, contentType, maxSize);
+		private @Nullable Charset charset;
+
+		private @Nullable ContentType contentType;
+
+		private int maxSize = -1;
+
+		private int initialBufferSize = DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY;
+
+		private Builder(LogFormatter formatter) {
+			this.formatter = Objects.requireNonNull(formatter);
+		}
+
+		/**
+		 * Charset to encode with. Only affects outputs whose
+		 * {@link BufferHints#writeMethod()} is {@link WriteMethod#BYTES} or
+		 * {@link WriteMethod#BYTE_BUFFER} - the {@link WriteMethod#STRING} path hands a
+		 * plain {@link String} to {@link LogOutput#write(LogEvent, String)}, whose own
+		 * default implementation is fixed to {@link StandardCharsets#UTF_8} regardless of
+		 * this setting, but no built-in output actually uses that write method. Defaults
+		 * to {@link StandardCharsets#UTF_8}, or to {@link #contentType(ContentType)}'s
+		 * own charset if that was set and this was not. If both are set this charset is
+		 * what is actually used to encode; {@link #contentType(ContentType)} still
+		 * controls what is reported to the output.
+		 * @param charset charset to encode with.
+		 * @return this.
+		 */
+		public Builder charset(Charset charset) {
+			this.charset = Objects.requireNonNull(charset);
+			return this;
+		}
+
+		/**
+		 * Content type reported to the output. Use this when the formatter produces
+		 * something other than plain text (e.g. a custom
+		 * {@link ContentType.DefaultContentType}). Defaults to
+		 * {@link StandardContentType#TEXT_PLAIN} with whatever charset is in effect (see
+		 * {@link #charset(Charset)}).
+		 * @param contentType content type reported to the output.
+		 * @return this.
+		 */
+		public Builder contentType(ContentType contentType) {
+			this.contentType = Objects.requireNonNull(contentType);
+			return this;
+		}
+
+		/**
+		 * Configures a maximum buffer size - see {@link Buffer#isOversized()}. This, like
+		 * charset, is a property of the encoder/buffer, not of whatever appender ends up
+		 * reusing the buffer - an appender that reuses a buffer across events (e.g. a
+		 * {@code ThreadLocal}-cached one) simply asks the buffer whether it has become
+		 * oversized and discards/replaces it if so; it has no threshold of its own.
+		 * @param maxSize a negative value disables {@link Buffer#isOversized()} entirely
+		 * (the default).
+		 * @return this.
+		 */
+		public Builder maxSize(int maxSize) {
+			this.maxSize = maxSize;
+			return this;
+		}
+
+		/**
+		 * The capacity a fresh buffer is allocated with before any event has been encoded
+		 * into it. Defaults to
+		 * {@link DirectByteBufferBuffer#DEFAULT_INITIAL_BYTE_CAPACITY}.
+		 * @param initialBufferSize initial buffer capacity, must be positive.
+		 * @return this.
+		 * @throws IllegalArgumentException if not positive.
+		 */
+		public Builder initialBufferSize(int initialBufferSize) {
+			if (initialBufferSize <= 0) {
+				throw new IllegalArgumentException("initialBufferSize must be positive: " + initialBufferSize);
+			}
+			this.initialBufferSize = initialBufferSize;
+			return this;
+		}
+
+		/**
+		 * Builds the encoder.
+		 * @return encoder.
+		 */
+		public LogEncoder build() {
+			Charset c = charset;
+			ContentType ct = contentType;
+			if (ct != null) {
+				if (c == null) {
+					c = ct.charsetOrNull();
+				}
+			}
+			if (c == null) {
+				c = StandardCharsets.UTF_8;
+			}
+			if (ct == null) {
+				ct = ContentType.of(StandardContentType.TEXT_PLAIN.contentType(), c);
+			}
+			return new FormatterEncoder(formatter, c, ct, maxSize, initialBufferSize);
+		}
+
 	}
 
 	/**
@@ -245,9 +308,9 @@ public interface LogEncoder {
 		 * What "large enough" means, and whether it means anything at all, is entirely up
 		 * to the buffer/encoder - the same way charset is an encoder concern rather than
 		 * something an appender configures (see
-		 * {@link LogEncoder#of(LogFormatter, java.nio.charset.Charset)}). The default
-		 * implementation returns {@code false} - a buffer implementation that does not
-		 * override this, or an encoder that never configured a threshold, never shrinks.
+		 * {@link LogEncoder#builder(LogFormatter)}). The default implementation returns
+		 * {@code false} - a buffer implementation that does not override this, or an
+		 * encoder that never configured a threshold, never shrinks.
 		 * @return {@code true} if this buffer's backing storage has grown past whatever
 		 * threshold it was configured with.
 		 */
@@ -632,20 +695,24 @@ final class FormatterEncoder implements LogEncoder {
 
 	private final int maxSize;
 
-	public FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType, int maxSize) {
+	private final int initialBufferSize;
+
+	FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType, int maxSize,
+			int initialBufferSize) {
 		super();
 		this.formatter = formatter;
 		this.charset = charset;
 		this.contentType = contentType;
 		this.maxSize = maxSize;
+		this.initialBufferSize = initialBufferSize;
 	}
 
 	@Override
 	public Buffer buffer(BufferHints hints) {
 		return switch (hints.writeMethod()) {
-			case STRING -> StringBuilderBuffer.of(new StringBuilder(), maxSize);
-			case BYTES, BYTE_BUFFER -> new DirectByteBufferBuffer(hints.writeMethod(),
-					DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY, charset, contentType, maxSize);
+			case STRING -> StringBuilderBuffer.of(new StringBuilder(initialBufferSize), maxSize);
+			case BYTES, BYTE_BUFFER ->
+				new DirectByteBufferBuffer(hints.writeMethod(), initialBufferSize, charset, contentType, maxSize);
 		};
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -85,6 +85,8 @@ public interface LogEncoder {
 	/**
 	 * Creates an encoder from a formatter that encodes with the given charset and reports
 	 * {@link StandardContentType#TEXT_PLAIN} with that charset to the output.
+	 * {@link Buffer#isOversized()} is disabled - see
+	 * {@link #of(LogFormatter, Charset, int)} to configure it.
 	 * @param formatter formatter.
 	 * @param charset charset to encode with. Only affects outputs whose
 	 * {@link BufferHints#writeMethod()} is {@link WriteMethod#BYTES} or
@@ -95,7 +97,24 @@ public interface LogEncoder {
 	 * @return encoder.
 	 */
 	public static LogEncoder of(LogFormatter formatter, Charset charset) {
-		return of(formatter, charset, ContentType.of(StandardContentType.TEXT_PLAIN.contentType(), charset));
+		return of(formatter, charset, -1);
+	}
+
+	/**
+	 * Like {@link #of(LogFormatter, Charset)} but also configures a maximum buffer size -
+	 * see {@link Buffer#isOversized()}. This, like charset, is a property of the
+	 * encoder/buffer, not of whatever appender ends up reusing the buffer - an appender
+	 * that reuses a buffer across events (e.g. a {@code ThreadLocal}-cached one) simply
+	 * asks the buffer whether it has become oversized and discards/replaces it if so; it
+	 * has no threshold of its own.
+	 * @param formatter formatter.
+	 * @param charset charset to encode with. See {@link #of(LogFormatter, Charset)}.
+	 * @param maxSize a negative value disables {@link Buffer#isOversized()} entirely (the
+	 * same behavior as {@link #of(LogFormatter, Charset)}).
+	 * @return encoder.
+	 */
+	public static LogEncoder of(LogFormatter formatter, Charset charset, int maxSize) {
+		return of(formatter, charset, ContentType.of(StandardContentType.TEXT_PLAIN.contentType(), charset), maxSize);
 	}
 
 	/**
@@ -104,18 +123,32 @@ public interface LogEncoder {
 	 * otherwise {@link StandardCharsets#UTF_8}. Use this instead of
 	 * {@link #of(LogFormatter, Charset)} when the formatter produces something other than
 	 * plain text (e.g. a custom {@link ContentType.DefaultContentType}).
+	 * {@link Buffer#isOversized()} is disabled - see
+	 * {@link #of(LogFormatter, ContentType, int)} to configure it.
 	 * @param formatter formatter.
 	 * @param contentType content type reported to the output. See
 	 * {@link #of(LogFormatter, Charset)} for the effect of its charset.
 	 * @return encoder.
 	 */
 	public static LogEncoder of(LogFormatter formatter, ContentType contentType) {
-		var charset = contentType.charsetOrNull();
-		return of(formatter, charset == null ? StandardCharsets.UTF_8 : charset, contentType);
+		return of(formatter, contentType, -1);
 	}
 
-	private static LogEncoder of(LogFormatter formatter, Charset charset, ContentType contentType) {
-		return new FormatterEncoder(formatter, charset, contentType);
+	/**
+	 * Like {@link #of(LogFormatter, ContentType)} but also configures a maximum buffer
+	 * size - see {@link #of(LogFormatter, Charset, int)}.
+	 * @param formatter formatter.
+	 * @param contentType content type reported to the output.
+	 * @param maxSize a negative value disables {@link Buffer#isOversized()} entirely.
+	 * @return encoder.
+	 */
+	public static LogEncoder of(LogFormatter formatter, ContentType contentType, int maxSize) {
+		var charset = contentType.charsetOrNull();
+		return of(formatter, charset == null ? StandardCharsets.UTF_8 : charset, contentType, maxSize);
+	}
+
+	private static LogEncoder of(LogFormatter formatter, Charset charset, ContentType contentType, int maxSize) {
+		return new FormatterEncoder(formatter, charset, contentType, maxSize);
 	}
 
 	/**
@@ -189,8 +222,38 @@ public interface LogEncoder {
 		 * <p>
 		 * An appender may not call clear before being passed to the encoder so the
 		 * encoder should do its own clearing.
+		 * <p>
+		 * Built-in implementations also shrink their own backing storage back down here
+		 * if {@link #isOversized()} - see that method - so a single unusually large event
+		 * does not permanently bloat a buffer that gets reused for many more events after
+		 * it.
 		 */
 		public void clear();
+
+		/**
+		 * Whether this buffer has grown large enough (its capacity, not how much of that
+		 * capacity the last event actually used) that its backing storage is worth
+		 * shrinking back down rather than kept at its grown size indefinitely - reused
+		 * buffers only grow on their own, they never shrink back down without deliberate
+		 * help. Built-in implementations consult this themselves inside {@link #clear()}
+		 * to decide whether to shrink their own backing storage in place (e.g.
+		 * {@link StringBuilder#trimToSize()}, or reallocating a smaller
+		 * {@link java.nio.ByteBuffer}) - most callers do not need to call this directly;
+		 * it remains here mainly for tests/observability and for a custom {@link Buffer}
+		 * implementation that wants the same self-shrinking behavior.
+		 * <p>
+		 * What "large enough" means, and whether it means anything at all, is entirely up
+		 * to the buffer/encoder - the same way charset is an encoder concern rather than
+		 * something an appender configures (see
+		 * {@link LogEncoder#of(LogFormatter, java.nio.charset.Charset)}). The default
+		 * implementation returns {@code false} - a buffer implementation that does not
+		 * override this, or an encoder that never configured a threshold, never shrinks.
+		 * @return {@code true} if this buffer's backing storage has grown past whatever
+		 * threshold it was configured with.
+		 */
+		default boolean isOversized() {
+			return false;
+		}
 
 		/**
 		 * Convenience that will call clear.
@@ -213,18 +276,34 @@ public interface LogEncoder {
 			 */
 			public final StringBuilder stringBuilder;
 
+			private final int maxSize;
+
 			/**
-			 * Creates a StringBuilder based buffer.
+			 * Creates a StringBuilder based buffer that never reports
+			 * {@link #isOversized()}.
 			 * @param sb string builder.
 			 * @return buffer.
 			 */
 			public static StringBuilderBuffer of(StringBuilder sb) {
-				return new StringBuilderBuffer(sb);
+				return of(sb, -1);
 			}
 
-			private StringBuilderBuffer(StringBuilder stringBuilder) {
+			/**
+			 * Creates a StringBuilder based buffer that reports {@link #isOversized()}
+			 * once {@code sb}'s capacity exceeds {@code maxSize}.
+			 * @param sb string builder.
+			 * @param maxSize a negative value disables {@link #isOversized()} entirely
+			 * (always {@code false}).
+			 * @return buffer.
+			 */
+			public static StringBuilderBuffer of(StringBuilder sb, int maxSize) {
+				return new StringBuilderBuffer(sb, maxSize);
+			}
+
+			private StringBuilderBuffer(StringBuilder stringBuilder, int maxSize) {
 				super();
 				this.stringBuilder = stringBuilder;
+				this.maxSize = maxSize;
 			}
 
 			@Override
@@ -235,6 +314,18 @@ public interface LogEncoder {
 			@Override
 			public void clear() {
 				stringBuilder.setLength(0);
+				// setLength(0) never touches capacity, so isOversized() here still
+				// reflects growth from whatever was just written - trimToSize()
+				// mutates the StringBuilder in place, no reassignment needed (works
+				// fine through the public final field above).
+				if (isOversized()) {
+					stringBuilder.trimToSize();
+				}
+			}
+
+			@Override
+			public boolean isOversized() {
+				return maxSize >= 0 && stringBuilder.capacity() > maxSize;
 			}
 
 		}
@@ -291,6 +382,10 @@ public interface LogEncoder {
 
 			private final LogOutput.ContentType contentType;
 
+			private final int maxSize;
+
+			private final int initialByteCapacity;
+
 			private ByteBuffer byteBuffer;
 
 			/**
@@ -322,7 +417,8 @@ public interface LogEncoder {
 
 			/**
 			 * Creates a buffer with the given write method, initial byte capacity,
-			 * charset and content type to report to the output.
+			 * charset and content type to report to the output. {@link #isOversized()} is
+			 * disabled (always {@code false}).
 			 * @param writeMethod which {@link LogOutput#write} overload {@link #drain}
 			 * should call - {@link LogOutput.WriteMethod#BYTES} or
 			 * {@link LogOutput.WriteMethod#BYTE_BUFFER}.
@@ -336,12 +432,42 @@ public interface LogEncoder {
 			 */
 			public DirectByteBufferBuffer(LogOutput.WriteMethod writeMethod, int initialByteCapacity, Charset charset,
 					LogOutput.ContentType contentType) {
+				this(writeMethod, initialByteCapacity, charset, contentType, -1);
+			}
+
+			/**
+			 * Creates a buffer with the given write method, initial byte capacity,
+			 * charset, content type to report to the output, and maximum combined size
+			 * (see {@link #isOversized()}).
+			 * @param writeMethod which {@link LogOutput#write} overload {@link #drain}
+			 * should call - {@link LogOutput.WriteMethod#BYTES} or
+			 * {@link LogOutput.WriteMethod#BYTE_BUFFER}.
+			 * @param initialByteCapacity initial capacity of the byte buffer. It will
+			 * grow (doubling, or to whatever a single event needs if larger) as needed
+			 * and the grown capacity is kept for subsequent events.
+			 * @param charset charset to encode with.
+			 * @param contentType content type reported to {@link LogOutput#write}. Its
+			 * {@link LogOutput.ContentType#charsetOrNull() charset}, if specified, should
+			 * normally match {@code charset}.
+			 * @param maxSize a negative value disables {@link #isOversized()} entirely
+			 * (always {@code false}). Since {@code initialByteCapacity} (commonly
+			 * {@value #DEFAULT_INITIAL_BYTE_CAPACITY}) is allocated up front and counted
+			 * by {@link #isOversized()} regardless of how much of it any event has
+			 * actually used, a {@code maxSize} at or below {@code initialByteCapacity}
+			 * makes {@link #isOversized()} unconditionally {@code true} from the very
+			 * first event - {@code maxSize} should normally be set well above whatever
+			 * initial capacity is in play.
+			 */
+			public DirectByteBufferBuffer(LogOutput.WriteMethod writeMethod, int initialByteCapacity, Charset charset,
+					LogOutput.ContentType contentType, int maxSize) {
 				this.writeMethod = writeMethod;
 				this.byteBuffer = ByteBuffer.allocate(initialByteCapacity);
 				this.charsetEncoder = charset.newEncoder()
 					.onMalformedInput(CodingErrorAction.REPLACE)
 					.onUnmappableCharacter(CodingErrorAction.REPLACE);
 				this.contentType = contentType;
+				this.maxSize = maxSize;
+				this.initialByteCapacity = initialByteCapacity;
 			}
 
 			/**
@@ -397,6 +523,20 @@ public interface LogEncoder {
 			@Override
 			public void clear() {
 				stringBuilder.setLength(0);
+				// Checked before byteBuffer is touched below, so this still reflects
+				// growth from whatever was just drained. stringBuilder.trimToSize()
+				// mutates in place; byteBuffer isn't final (it's already reassigned
+				// during growth in encodeToByteBuffer()) so reallocating it back down
+				// here needs no new field-mutability changes either.
+				if (isOversized()) {
+					stringBuilder.trimToSize();
+					byteBuffer = ByteBuffer.allocate(initialByteCapacity);
+				}
+			}
+
+			@Override
+			public boolean isOversized() {
+				return maxSize >= 0 && (stringBuilder.capacity() + byteBuffer.capacity()) > maxSize;
 			}
 
 		}
@@ -490,19 +630,22 @@ final class FormatterEncoder implements LogEncoder {
 
 	private final ContentType contentType;
 
-	public FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType) {
+	private final int maxSize;
+
+	public FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType, int maxSize) {
 		super();
 		this.formatter = formatter;
 		this.charset = charset;
 		this.contentType = contentType;
+		this.maxSize = maxSize;
 	}
 
 	@Override
 	public Buffer buffer(BufferHints hints) {
 		return switch (hints.writeMethod()) {
-			case STRING -> StringBuilderBuffer.of(new StringBuilder());
+			case STRING -> StringBuilderBuffer.of(new StringBuilder(), maxSize);
 			case BYTES, BYTE_BUFFER -> new DirectByteBufferBuffer(hints.writeMethod(),
-					DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY, charset, contentType);
+					DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY, charset, contentType, maxSize);
 		};
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogFormatter.java
@@ -479,12 +479,14 @@ public sealed interface LogFormatter {
 		}
 
 		/**
-		 * Creates the formatter and converts it to an encoder.
-		 * @return encoder.
+		 * Creates the formatter and starts an encoder builder from it - call
+		 * {@link LogEncoder.Builder#build()} to finish, optionally configuring charset,
+		 * content type, max buffer size, or initial buffer size first.
+		 * @return encoder builder.
 		 * @apiNote for ergonomics
 		 */
-		public LogEncoder encoder() {
-			return LogEncoder.of(build());
+		public LogEncoder.Builder encoder() {
+			return LogEncoder.builder(build());
 		}
 
 	}

--- a/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
@@ -147,9 +147,9 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 		 * {@link StandardContentType#TEXT_PLAIN} because UTF-8 is standard enough on
 		 * modern Java (e.g. {@code String#getBytes()}'s no-charset overload) to treat as
 		 * the assumed default rather than "unspecified" - an encoder actually configured
-		 * with a different charset (see
-		 * {@link LogEncoder#of(LogFormatter, java.nio.charset.Charset)}) reports a
-		 * {@link DefaultContentType} instead, not {@link StandardContentType#TEXT_PLAIN}.
+		 * with a different charset (see {@link LogEncoder#builder(LogFormatter)}) reports
+		 * a {@link DefaultContentType} instead, not
+		 * {@link StandardContentType#TEXT_PLAIN}.
 		 * @return charset or <code>null</code> if not fixed/known.
 		 */
 		@Nullable

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -84,8 +84,14 @@ class AppenderAsModeFlagPermutationTest {
 		var outputA = new CountingListLogOutput();
 		var outputB = new CountingListLogOutput();
 		List<LogProvider<LogAppender>> providers = List.of(
-				LogAppender.builder("a").encoder(LogFormatter.builder().message().encoder()).output(outputA).build(),
-				LogAppender.builder("b").encoder(LogFormatter.builder().message().encoder()).output(outputB).build());
+				LogAppender.builder("a")
+					.encoder(LogFormatter.builder().message().encoder().build())
+					.output(outputA)
+					.build(),
+				LogAppender.builder("b")
+					.encoder(LogFormatter.builder().message().encoder().build())
+					.output(outputB)
+					.build());
 		var appenders = new Appenders("test-route", config, providers).flags(flags);
 
 		LogPublisher publisher = switch (mode) {
@@ -159,8 +165,10 @@ class AppenderAsModeFlagPermutationTest {
 		var outputB = new ListLogOutput();
 		LogConfig config = LogConfig.builder().build();
 		try (var gum = RainbowGum.builder(config).route(r -> {
-			r.appender("a", a -> a.output(outputA).encoder(LogFormatter.builder().message().newline().encoder()));
-			r.appender("b", a -> a.output(outputB).encoder(LogFormatter.builder().message().newline().encoder()));
+			r.appender("a",
+					a -> a.output(outputA).encoder(LogFormatter.builder().message().newline().encoder().build()));
+			r.appender("b",
+					a -> a.output(outputB).encoder(LogFormatter.builder().message().newline().encoder().build()));
 			r.publisher((name, cfg, appenders) -> new FanoutSyncLogPublisher(appenders.asList()));
 		}).build().start()) {
 			gum.router().eventBuilder("test", System.Logger.Level.INFO).message("fanned out").log();

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
@@ -91,12 +91,12 @@ class AppenderAsModeReentryTest {
 		 */
 		List<LogProvider<LogAppender>> providers = List.of(
 				LogAppender.builder("a")
-					.encoder(LogFormatter.builder().message().encoder())
+					.encoder(LogFormatter.builder().message().encoder().build())
 					.output(outputA)
 					.flag(reentryFlag)
 					.build(),
 				LogAppender.builder("b")
-					.encoder(LogFormatter.builder().message().encoder())
+					.encoder(LogFormatter.builder().message().encoder().build())
 					.output(outputB)
 					.flag(reentryFlag)
 					.build());

--- a/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
@@ -42,7 +42,7 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void stringBuilderBufferShrinksAfterOversizedClear() {
-		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 100);
+		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(100).build();
 		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
 
 		encoder.encode(event("x".repeat(2000)), buffer);
@@ -57,7 +57,7 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void stringBuilderBufferUnderThresholdIsLeftAlone() {
-		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 100_000);
+		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(100_000).build();
 		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
 
 		encoder.encode(event("small"), buffer);
@@ -78,7 +78,7 @@ class BufferSelfShrinkTest {
 	 */
 	@Test
 	void directByteBufferBufferShrinksBothStoresAfterOversizedClear() {
-		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 10_000);
+		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(10_000).build();
 		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
 		var output = new CapturingOutput();
 
@@ -104,7 +104,7 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void directByteBufferBufferUnderThresholdIsLeftAlone() {
-		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 100_000);
+		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(100_000).build();
 		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
 		var output = new CapturingOutput();
 
@@ -137,7 +137,7 @@ class BufferSelfShrinkTest {
 	 */
 	@Test
 	void batchAppendPathAlsoShrinksOversizedBufferBetweenEventsInTheSameBatch() {
-		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 10_000);
+		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(10_000).build();
 		var output = new CapturingOutput();
 		var appender = new LockThreadLocalBufferLogAppender("test", output, encoder, EnumSet.noneOf(AppenderFlag.class),
 				new ReentrantLock());

--- a/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
@@ -1,0 +1,196 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogEncoder.Buffer.DirectByteBufferBuffer;
+import io.jstach.rainbowgum.LogEncoder.Buffer.StringBuilderBuffer;
+import io.jstach.rainbowgum.LogOutput.ContentType;
+import io.jstach.rainbowgum.LogOutput.WriteMethod;
+
+/*
+ * Buffer#clear() self-shrinking (see LogEncoder.Buffer#isOversized()). The earlier
+ * appender-level replacement mechanism from this exploration (an appender discarding an
+ * oversized ThreadLocal-cached Buffer and asking the encoder for a fresh one) was deleted
+ * in favor of this: clear() itself - called once per event by every appender's write path,
+ * including the default batch write(LogEvent[], int, LogEncoder, Buffer) loop in
+ * LogOutput.java - shrinks a buffer's own backing storage back down once it has grown
+ * past its configured maxSize, with no appender/encoder coordination needed at all.
+ * <p>
+ * These tests assert actual capacity() values before/after clear(), not just that
+ * isOversized() flips back to false, to prove the backing storage genuinely shrank rather
+ * than just re-deriving the same predicate under test.
+ */
+class BufferSelfShrinkTest {
+
+	private static final LogFormatter FORMATTER = LogFormatter.builder().message().build();
+
+	private static LogEvent event(String message) {
+		return LogEvent.of(System.Logger.Level.INFO, "test", message, KeyValues.of(), null);
+	}
+
+	@Test
+	void stringBuilderBufferShrinksAfterOversizedClear() {
+		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 100);
+		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
+
+		encoder.encode(event("x".repeat(2000)), buffer);
+		int grownCapacity = buffer.stringBuilder.capacity();
+		assertTrue(grownCapacity > 100, "sanity check: the big message must have actually grown the buffer");
+
+		buffer.clear();
+
+		assertTrue(buffer.stringBuilder.capacity() < grownCapacity,
+				"clear() must shrink the backing StringBuilder back down once oversized");
+	}
+
+	@Test
+	void stringBuilderBufferUnderThresholdIsLeftAlone() {
+		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 100_000);
+		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
+
+		encoder.encode(event("small"), buffer);
+		int capacityBeforeClear = buffer.stringBuilder.capacity();
+
+		buffer.clear();
+
+		assertEquals(capacityBeforeClear, buffer.stringBuilder.capacity(),
+				"a buffer well under the threshold must not be reallocated on every clear()");
+	}
+
+	/*
+	 * maxSize is deliberately set above
+	 * DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY (8192) here - a maxSize at or
+	 * below that makes the buffer unconditionally oversized from construction alone
+	 * (documented on the buffer's own constructor), which would demonstrate that caveat
+	 * instead of genuine event-driven growth.
+	 */
+	@Test
+	void directByteBufferBufferShrinksBothStoresAfterOversizedClear() {
+		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 10_000);
+		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
+		var output = new CapturingOutput();
+
+		encoder.encode(event("x".repeat(20_000)), buffer);
+		int grownStringCapacity = buffer.stringBuilder.capacity();
+		buffer.drain(output, event("unused"));
+		int grownByteCapacity = output.lastCapacity;
+		assertTrue(grownStringCapacity + grownByteCapacity > 10_000,
+				"sanity check: the big message must have actually grown both stores past the threshold");
+
+		buffer.clear();
+
+		assertTrue(buffer.stringBuilder.capacity() < grownStringCapacity,
+				"clear() must shrink the backing StringBuilder back down once oversized");
+
+		// Encode a small event so encodeToByteBuffer() doesn't need to regrow the
+		// now-shrunk ByteBuffer, then drain again to observe its new capacity.
+		encoder.encode(event("small"), buffer);
+		buffer.drain(output, event("unused"));
+		assertTrue(output.lastCapacity < grownByteCapacity,
+				"clear() must also reallocate the backing ByteBuffer back down once oversized");
+	}
+
+	@Test
+	void directByteBufferBufferUnderThresholdIsLeftAlone() {
+		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 100_000);
+		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
+		var output = new CapturingOutput();
+
+		encoder.encode(event("small"), buffer);
+		int stringCapacityBeforeClear = buffer.stringBuilder.capacity();
+		buffer.drain(output, event("unused"));
+		int byteCapacityBeforeClear = output.lastCapacity;
+
+		buffer.clear();
+		encoder.encode(event("small"), buffer);
+		buffer.drain(output, event("unused"));
+
+		assertEquals(stringCapacityBeforeClear, buffer.stringBuilder.capacity(),
+				"a buffer well under the threshold must not have its StringBuilder reallocated");
+		assertEquals(byteCapacityBeforeClear, output.lastCapacity,
+				"a buffer well under the threshold must not have its ByteBuffer reallocated");
+	}
+
+	/*
+	 * Confirms gap #3 from the previous round of this exploration (batch
+	 * append(LogEvent[], int) not covered by the appender-level replacement mechanism) is
+	 * closed as a side effect of moving the shrink into clear() itself: the default
+	 * LogOutput#write(LogEvent[], int, LogEncoder, Buffer) loop both real thread-local-
+	 * buffer appenders use for their batch path already calls buffer.clear() once per
+	 * event, so a big event early in one batch shrinks the shared buffer back down before
+	 * the very next event in that same batch, with no separate wiring needed for the
+	 * batch path at all - exercised here through a real
+	 * LockThreadLocalBufferLogAppender.append(LogEvent[], int) call, not just the default
+	 * method in isolation.
+	 */
+	@Test
+	void batchAppendPathAlsoShrinksOversizedBufferBetweenEventsInTheSameBatch() {
+		LogEncoder encoder = LogEncoder.of(FORMATTER, StandardCharsets.UTF_8, 10_000);
+		var output = new CapturingOutput();
+		var appender = new LockThreadLocalBufferLogAppender("test", output, encoder, EnumSet.noneOf(AppenderFlag.class),
+				new ReentrantLock());
+
+		appender.append(new LogEvent[] { event("x".repeat(20_000)), event("small") }, 2);
+
+		assertTrue(output.capacities.get(0) > 10_000,
+				"sanity check: the first (big) event in the batch must have grown the shared buffer");
+		assertTrue(output.capacities.get(1) < output.capacities.get(0),
+				"the second event in the same batch must already see the buffer shrunk back down, proving the "
+						+ "batch path is covered without any appender-level wiring");
+	}
+
+	static class CapturingOutput implements LogOutput {
+
+		int lastCapacity = -1;
+
+		final List<Integer> capacities = new ArrayList<>();
+
+		@Override
+		public LogEncoder.BufferHints bufferHints() {
+			return WriteMethod.BYTE_BUFFER;
+		}
+
+		@Override
+		public URI uri() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public OutputType type() {
+			return OutputType.MEMORY;
+		}
+
+		@Override
+		public void write(LogEvent event, ByteBuffer buf, ContentType contentType) {
+			lastCapacity = buf.capacity();
+			capacities.add(lastCapacity);
+		}
+
+		@Override
+		public void write(LogEvent event, byte[] bytes, int off, int len, ContentType contentType) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void flush() {
+		}
+
+		@Override
+		public void close() {
+		}
+
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
@@ -26,7 +26,7 @@ import io.jstach.rainbowgum.LogOutput.WriteMethod;
  * in favor of this: clear() itself - called once per event by every appender's write path,
  * including the default batch write(LogEvent[], int, LogEncoder, Buffer) loop in
  * LogOutput.java - shrinks a buffer's own backing storage back down once it has grown
- * past its configured maxSize, with no appender/encoder coordination needed at all.
+ * past its configured maxBufferSize, with no appender/encoder coordination needed at all.
  * <p>
  * These tests assert actual capacity() values before/after clear(), not just that
  * isOversized() flips back to false, to prove the backing storage genuinely shrank rather
@@ -42,7 +42,7 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void stringBuilderBufferShrinksAfterOversizedClear() {
-		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(100).build();
+		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxBufferSize(100).build();
 		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
 
 		encoder.encode(event("x".repeat(2000)), buffer);
@@ -57,7 +57,10 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void stringBuilderBufferUnderThresholdIsLeftAlone() {
-		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(100_000).build();
+		LogEncoder encoder = LogEncoder.builder(FORMATTER)
+			.charset(StandardCharsets.UTF_8)
+			.maxBufferSize(100_000)
+			.build();
 		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
 
 		encoder.encode(event("small"), buffer);
@@ -70,15 +73,18 @@ class BufferSelfShrinkTest {
 	}
 
 	/*
-	 * maxSize is deliberately set above
-	 * DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY (8192) here - a maxSize at or
-	 * below that makes the buffer unconditionally oversized from construction alone
+	 * maxBufferSize is deliberately set above
+	 * DirectByteBufferBuffer.DEFAULT_INITIAL_BYTE_CAPACITY (8192) here - a maxBufferSize
+	 * at or below that makes the buffer unconditionally oversized from construction alone
 	 * (documented on the buffer's own constructor), which would demonstrate that caveat
 	 * instead of genuine event-driven growth.
 	 */
 	@Test
 	void directByteBufferBufferShrinksBothStoresAfterOversizedClear() {
-		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(10_000).build();
+		LogEncoder encoder = LogEncoder.builder(FORMATTER)
+			.charset(StandardCharsets.UTF_8)
+			.maxBufferSize(10_000)
+			.build();
 		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
 		var output = new CapturingOutput();
 
@@ -104,7 +110,10 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void directByteBufferBufferUnderThresholdIsLeftAlone() {
-		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(100_000).build();
+		LogEncoder encoder = LogEncoder.builder(FORMATTER)
+			.charset(StandardCharsets.UTF_8)
+			.maxBufferSize(100_000)
+			.build();
 		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
 		var output = new CapturingOutput();
 
@@ -137,7 +146,10 @@ class BufferSelfShrinkTest {
 	 */
 	@Test
 	void batchAppendPathAlsoShrinksOversizedBufferBetweenEventsInTheSameBatch() {
-		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxSize(10_000).build();
+		LogEncoder encoder = LogEncoder.builder(FORMATTER)
+			.charset(StandardCharsets.UTF_8)
+			.maxBufferSize(10_000)
+			.build();
 		var output = new CapturingOutput();
 		var appender = new LockThreadLocalBufferLogAppender("test", output, encoder, EnumSet.noneOf(AppenderFlag.class),
 				new ReentrantLock());

--- a/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
@@ -502,10 +502,10 @@ class LevelResolverTest {
 		var secondOutput = new ListLogOutput();
 		var gum = RainbowGum.builder(config).route(r -> {
 			r.appender("default",
-					a -> a.output(defaultOutput).encoder(LogFormatter.builder().message().newline().encoder()));
+					a -> a.output(defaultOutput).encoder(LogFormatter.builder().message().newline().encoder().build()));
 		}).route("second", r -> {
 			r.appender("second",
-					a -> a.output(secondOutput).encoder(LogFormatter.builder().message().newline().encoder()));
+					a -> a.output(secondOutput).encoder(LogFormatter.builder().message().newline().encoder().build()));
 		}).build();
 		try (var g = gum) {
 			g.router().eventBuilder("com.stuff", Level.INFO).message("hello").log();

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -38,7 +38,9 @@ class LogAppenderFlagTest {
 	}
 
 	private static LogAppender appender(String name, ListLogOutput output, AppenderFlag... flags) {
-		var builder = LogAppender.builder(name).encoder(LogFormatter.builder().message().encoder()).output(output);
+		var builder = LogAppender.builder(name)
+			.encoder(LogFormatter.builder().message().encoder().build())
+			.output(output);
 		for (var flag : flags) {
 			builder.flag(flag);
 		}
@@ -147,8 +149,10 @@ class LogAppenderFlagTest {
 	void appenderLevelFlagsMergeOntoExistingAppenderWithoutReuseBuffer() {
 		LogConfig config = LogConfig.builder().build();
 		var output = new CountingListLogOutput();
-		List<LogProvider<LogAppender>> providers = List
-			.of(LogAppender.builder("test").encoder(LogFormatter.builder().message().encoder()).output(output).build());
+		List<LogProvider<LogAppender>> providers = List.of(LogAppender.builder("test")
+			.encoder(LogFormatter.builder().message().encoder().build())
+			.output(output)
+			.build());
 		var appenders = new LogAppender.Appenders("test-route", config, providers);
 		var result = appenders.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)).asSingle();
 		result.start(config);
@@ -164,7 +168,7 @@ class LogAppenderFlagTest {
 		LogConfig config = LogConfig.builder().build();
 		var output = new CountingListLogOutput();
 		List<LogProvider<LogAppender>> providers = List.of(LogAppender.builder("test")
-			.encoder(LogFormatter.builder().message().encoder())
+			.encoder(LogFormatter.builder().message().encoder().build())
 			.output(output)
 			.flag(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)
 			.build());
@@ -181,8 +185,14 @@ class LogAppenderFlagTest {
 		var outputA = new CountingListLogOutput();
 		var outputB = new CountingListLogOutput();
 		List<LogProvider<LogAppender>> providers = List.of(
-				LogAppender.builder("a").encoder(LogFormatter.builder().message().encoder()).output(outputA).build(),
-				LogAppender.builder("b").encoder(LogFormatter.builder().message().encoder()).output(outputB).build());
+				LogAppender.builder("a")
+					.encoder(LogFormatter.builder().message().encoder().build())
+					.output(outputA)
+					.build(),
+				LogAppender.builder("b")
+					.encoder(LogFormatter.builder().message().encoder().build())
+					.output(outputB)
+					.build());
 		var appenders = new LogAppender.Appenders("test-route", config, providers)
 			.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH));
 		var result = appenders.asSingle();

--- a/core/src/test/java/io/jstach/rainbowgum/LogEncoderCharsetTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEncoderCharsetTest.java
@@ -16,9 +16,10 @@ import io.jstach.rainbowgum.LogOutput.ContentType.DefaultContentType;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
 
 /*
- * LogEncoder.of(LogFormatter, Charset) - verified with raw captured bytes rather than
- * ListLogOutput (whose own write(byte[]...) overload always decodes as UTF-8 for
- * storage, which would defeat a test trying to confirm a *different* charset was used).
+ * LogEncoder.builder(LogFormatter).charset(...)/.contentType(...) - verified with raw
+ * captured bytes rather than ListLogOutput (whose own write(byte[]...) overload always
+ * decodes as UTF-8 for storage, which would defeat a test trying to confirm a
+ * *different* charset was used).
  */
 class LogEncoderCharsetTest {
 
@@ -65,7 +66,8 @@ class LogEncoderCharsetTest {
 		var contentType = new DefaultContentType("text/csv", StandardCharsets.ISO_8859_1);
 		var config = LogConfig.builder().build();
 		var gum = RainbowGum.builder(config)
-			.route(r -> r.appender("list", a -> a.output(output).encoder(LogEncoder.of(FORMATTER, contentType))))
+			.route(r -> r.appender("list",
+					a -> a.output(output).encoder(LogEncoder.builder(FORMATTER).contentType(contentType).build())))
 			.build();
 		try (var g = gum.start()) {
 			g.log(event());
@@ -80,7 +82,8 @@ class LogEncoderCharsetTest {
 		var contentType = new DefaultContentType("text/csv", null);
 		var config = LogConfig.builder().build();
 		var gum = RainbowGum.builder(config)
-			.route(r -> r.appender("list", a -> a.output(output).encoder(LogEncoder.of(FORMATTER, contentType))))
+			.route(r -> r.appender("list",
+					a -> a.output(output).encoder(LogEncoder.builder(FORMATTER).contentType(contentType).build())))
 			.build();
 		try (var g = gum.start()) {
 			g.log(event());
@@ -102,7 +105,8 @@ class LogEncoderCharsetTest {
 	private static void encodeInto(CapturingOutput output, java.nio.charset.Charset charset) {
 		var config = LogConfig.builder().build();
 		var gum = RainbowGum.builder(config)
-			.route(r -> r.appender("list", a -> a.output(output).encoder(LogEncoder.of(FORMATTER, charset))))
+			.route(r -> r.appender("list",
+					a -> a.output(output).encoder(LogEncoder.builder(FORMATTER).charset(charset).build())))
 			.build();
 		try (var g = gum.start()) {
 			g.log(event());

--- a/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
@@ -69,13 +69,13 @@ class LogEncoderRegistryTest {
 
 				@Override
 				public LogProvider<LogEncoder> provide(LogProviderRef ref) {
-					return (n, c) -> LogFormatter.builder().text("CUSTOM ").message().newline().encoder();
+					return (n, c) -> LogFormatter.builder().text("CUSTOM ").message().newline().encoder().build();
 				}
 			};
 			config.encoderRegistry().register("custom", provider);
 			config.encoderRegistry()
 				.setEncoderForOutputType(OutputType.MEMORY,
-						(name, c) -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder());
+						(name, c) -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder().build());
 			return true;
 		}
 

--- a/core/src/test/java/io/jstach/rainbowgum/publisher/BlockingQueueAsyncLogPublisherTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/publisher/BlockingQueueAsyncLogPublisherTest.java
@@ -50,14 +50,14 @@ class BlockingQueueAsyncLogPublisherTest {
 		var gum = RainbowGum.builder().route(b -> {
 			b.appender("console", a -> {
 				a.output(LogOutput.ofStandardOut());
-				a.encoder(LogFormatter.builder().message().newline().encoder());
+				a.encoder(LogFormatter.builder().message().newline().encoder().build());
 			});
 			/*
 			 * This has to be the second one so that it happens after the console output.
 			 */
 			b.appender("list", a -> {
 				a.output(output);
-				a.encoder(LogFormatter.builder().message().newline().encoder());
+				a.encoder(LogFormatter.builder().message().newline().encoder().build());
 			});
 			b.publisher(PublisherFactory.ofAsync(100));
 		}).build();

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/JsonBuffer.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/JsonBuffer.java
@@ -15,13 +15,29 @@ import io.jstach.rainbowgum.LogOutput;
  */
 public final class JsonBuffer implements Buffer {
 
-	private final RawJsonWriter jsonWriter = new RawJsonWriter(1024 * 8);
+	/**
+	 * Default initial capacity of the raw JSON byte buffer, matching what this class has
+	 * always used - big enough that most events never need to grow it.
+	 */
+	public static final int DEFAULT_INITIAL_JSON_CAPACITY = 1024 * 8;
 
-	private final StringBuilder formattedMessageBuilder = new StringBuilder();
+	/**
+	 * Default initial capacity of {@link #getFormattedMessageBuilder()}. Bigger than
+	 * {@link StringBuilder}'s own default of 16 since most log messages exceed that
+	 * immediately, but still small relative to {@link #DEFAULT_INITIAL_JSON_CAPACITY}
+	 * since this buffer is just the formatted message, not the whole encoded event.
+	 */
+	public static final int DEFAULT_INITIAL_MESSAGE_CAPACITY = 128;
+
+	private final RawJsonWriter jsonWriter = new RawJsonWriter(DEFAULT_INITIAL_JSON_CAPACITY);
+
+	private final StringBuilder formattedMessageBuilder = new StringBuilder(DEFAULT_INITIAL_MESSAGE_CAPACITY);
 
 	private final boolean prettyPrint;
 
 	private final ExtendedFieldPrefix extendedFieldPrefix;
+
+	private final int maxBufferSize;
 
 	/**
 	 * A flag to indicate this field is extended which means it will be prefixed with
@@ -38,11 +54,16 @@ public final class JsonBuffer implements Buffer {
 	 * Create a JSON buffer.
 	 * @param prettyPrint whether or not to pretty print the JSON.
 	 * @param extendedFieldPrefix prefix for extended fields.
+	 * @param maxBufferSize a negative value disables {@link #isOversized()} entirely.
+	 * Applied, for simplicity, as a single combined threshold across both the raw JSON
+	 * byte buffer and {@link #getFormattedMessageBuilder()} rather than tracked
+	 * separately per buffer.
 	 */
-	public JsonBuffer(boolean prettyPrint, ExtendedFieldPrefix extendedFieldPrefix) {
+	public JsonBuffer(boolean prettyPrint, ExtendedFieldPrefix extendedFieldPrefix, int maxBufferSize) {
 		super();
 		this.prettyPrint = prettyPrint;
 		this.extendedFieldPrefix = extendedFieldPrefix;
+		this.maxBufferSize = maxBufferSize;
 	}
 
 	@Override
@@ -55,6 +76,15 @@ public final class JsonBuffer implements Buffer {
 	public void clear() {
 		jsonWriter.reset();
 		formattedMessageBuilder.setLength(0);
+		if (isOversized()) {
+			jsonWriter.shrinkTo(DEFAULT_INITIAL_JSON_CAPACITY);
+			formattedMessageBuilder.trimToSize();
+		}
+	}
+
+	@Override
+	public boolean isOversized() {
+		return maxBufferSize >= 0 && (jsonWriter.capacity() + formattedMessageBuilder.capacity()) > maxBufferSize;
 	}
 
 	/**

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/RawJsonWriter.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/RawJsonWriter.java
@@ -430,4 +430,23 @@ class RawJsonWriter {
 		position = 0;
 	}
 
+	/**
+	 * Current capacity of the backing byte array - not how much of it the last event
+	 * actually used (see {@link #size()} for that).
+	 * @return backing array length.
+	 */
+	final int capacity() {
+		return buffer.length;
+	}
+
+	/**
+	 * Reallocates the backing byte array to the given capacity, discarding its current
+	 * contents. Only meaningful right after {@link #reset()} - this does not preserve
+	 * {@code position} or copy any existing bytes.
+	 * @param capacity new backing array length.
+	 */
+	final void shrinkTo(int capacity) {
+		buffer = new byte[capacity];
+	}
+
 }

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/EcsEncoder.java
@@ -65,10 +65,13 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 
 	private final boolean prettyprint;
 
+	private final int maxBufferSize;
+
 	private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_INSTANT;
 
 	EcsEncoder(@Nullable String serviceName, @Nullable String serviceVersion, @Nullable String serviceEnvironment,
-			@Nullable String serviceNodeName, @Nullable String eventDataset, boolean structured, boolean prettyprint) {
+			@Nullable String serviceNodeName, @Nullable String eventDataset, boolean structured, boolean prettyprint,
+			int maxBufferSize) {
 		super();
 		this.serviceName = serviceName;
 		this.serviceVersion = serviceVersion;
@@ -77,6 +80,7 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 		this.eventDataset = eventDataset;
 		this.structured = structured;
 		this.prettyprint = prettyprint;
+		this.maxBufferSize = maxBufferSize;
 	}
 
 	/**
@@ -113,21 +117,27 @@ public final class EcsEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 	 * @param structured <code>true</code> nests fields as JSON objects (Spring Boot's ECS
 	 * shape) instead of flattened dotted field names, default is false.
 	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
+	 * @param maxBufferSize maximum buffer size - a soft ceiling checked between events,
+	 * not a hard cap enforced on any single event (see
+	 * {@link LogEncoder.Buffer#isOversized()}). A negative value (the default) disables
+	 * this entirely.
 	 * @return encoder.
 	 */
 	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
 	static EcsEncoder of(@LogConfigurable.KeyParameter String name, @Nullable String serviceName,
 			@Nullable String serviceVersion, @Nullable String serviceEnvironment, @Nullable String serviceNodeName,
-			@Nullable String eventDataset, @Nullable Boolean structured, @Nullable Boolean prettyPrint) {
+			@Nullable String eventDataset, @Nullable Boolean structured, @Nullable Boolean prettyPrint,
+			@Nullable Integer maxBufferSize) {
 		prettyPrint = prettyPrint == null ? false : prettyPrint;
 		structured = structured == null ? false : structured;
+		int _maxBufferSize = maxBufferSize == null ? -1 : maxBufferSize;
 		return new EcsEncoder(serviceName, serviceVersion, serviceEnvironment, serviceNodeName, eventDataset,
-				structured, prettyPrint);
+				structured, prettyPrint, _maxBufferSize);
 	}
 
 	@Override
 	protected JsonBuffer doBuffer(BufferHints hints) {
-		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.AT);
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.AT, maxBufferSize);
 	}
 
 	@Override

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/GelfEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/GelfEncoder.java
@@ -44,18 +44,21 @@ public final class GelfEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 
 	/**
 	 * Default number of fractional second digits the <code>_time</code> field is rendered
-	 * with, see {@link #of(String, String, Map, Boolean, Integer)}.
+	 * with, see {@link #of(String, String, Map, Boolean, Integer, Integer)}.
 	 */
 	public static final int DEFAULT_TIME_FRACTIONAL_DIGITS = 3;
 
 	private final TimestampFormatter timeFormatter;
 
-	GelfEncoder(String host, KeyValues headers, boolean prettyprint, int timeFractionalDigits) {
+	private final int maxBufferSize;
+
+	GelfEncoder(String host, KeyValues headers, boolean prettyprint, int timeFractionalDigits, int maxBufferSize) {
 		super();
 		this.host = host;
 		this.headers = headers;
 		this.prettyprint = prettyprint;
 		this.timeFormatter = timeFormatter(timeFractionalDigits);
+		this.maxBufferSize = maxBufferSize;
 	}
 
 	/*
@@ -108,24 +111,29 @@ public final class GelfEncoder extends LogEncoder.AbstractEncoder<JsonBuffer> {
 	 * nanosecond resolution) but cannot be cached the way millisecond-or-coarser
 	 * precision can, since it can legitimately differ between two events in the same
 	 * millisecond.
+	 * @param maxBufferSize maximum buffer size - a soft ceiling checked between events,
+	 * not a hard cap enforced on any single event (see
+	 * {@link LogEncoder.Buffer#isOversized()}). A negative value (the default) disables
+	 * this entirely.
 	 * @return encoder.
 	 */
 	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
 	static GelfEncoder of(@LogConfigurable.KeyParameter String name, String host, //
 			@Nullable Map<String, String> headers, //
-			@Nullable Boolean prettyPrint, @Nullable Integer timeFractionalDigits) {
+			@Nullable Boolean prettyPrint, @Nullable Integer timeFractionalDigits, @Nullable Integer maxBufferSize) {
 		prettyPrint = prettyPrint == null ? false : prettyPrint;
 		host = Objects.requireNonNull(host);
 		var _headers = KeyValues.of(headers == null ? Map.of() : headers);
 		int _timeFractionalDigits = timeFractionalDigits == null ? DEFAULT_TIME_FRACTIONAL_DIGITS
 				: timeFractionalDigits;
+		int _maxBufferSize = maxBufferSize == null ? -1 : maxBufferSize;
 
-		return new GelfEncoder(host, _headers, prettyPrint, _timeFractionalDigits);
+		return new GelfEncoder(host, _headers, prettyPrint, _timeFractionalDigits, _maxBufferSize);
 	}
 
 	@Override
 	protected JsonBuffer doBuffer(BufferHints hints) {
-		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.UNDERSCORE);
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.UNDERSCORE, maxBufferSize);
 	}
 
 	@Override

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoder.java
@@ -45,9 +45,12 @@ public final class LogbackJsonEncoder extends LogEncoder.AbstractEncoder<JsonBuf
 
 	private final boolean prettyprint;
 
-	LogbackJsonEncoder(boolean prettyprint) {
+	private final int maxBufferSize;
+
+	LogbackJsonEncoder(boolean prettyprint, int maxBufferSize) {
 		super();
 		this.prettyprint = prettyprint;
+		this.maxBufferSize = maxBufferSize;
 	}
 
 	/**
@@ -68,17 +71,23 @@ public final class LogbackJsonEncoder extends LogEncoder.AbstractEncoder<JsonBuf
 	 * Creates a Logback JSON encoder.
 	 * @param name property name prefix.
 	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
+	 * @param maxBufferSize maximum buffer size - a soft ceiling checked between events,
+	 * not a hard cap enforced on any single event (see
+	 * {@link LogEncoder.Buffer#isOversized()}). A negative value (the default) disables
+	 * this entirely.
 	 * @return encoder.
 	 */
 	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
-	static LogbackJsonEncoder of(@LogConfigurable.KeyParameter String name, @Nullable Boolean prettyPrint) {
+	static LogbackJsonEncoder of(@LogConfigurable.KeyParameter String name, @Nullable Boolean prettyPrint,
+			@Nullable Integer maxBufferSize) {
 		prettyPrint = prettyPrint == null ? false : prettyPrint;
-		return new LogbackJsonEncoder(prettyPrint);
+		int _maxBufferSize = maxBufferSize == null ? -1 : maxBufferSize;
+		return new LogbackJsonEncoder(prettyPrint, _maxBufferSize);
 	}
 
 	@Override
 	protected JsonBuffer doBuffer(BufferHints hints) {
-		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.UNDERSCORE);
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.UNDERSCORE, maxBufferSize);
 	}
 
 	@Override

--- a/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogstashEncoder.java
+++ b/rainbowgum-json/src/main/java/io/jstach/rainbowgum/json/encoder/LogstashEncoder.java
@@ -50,11 +50,14 @@ public final class LogstashEncoder extends LogEncoder.AbstractEncoder<JsonBuffer
 
 	private final DateTimeFormatter timeFormatter;
 
-	LogstashEncoder(ZoneId zoneId, boolean prettyprint) {
+	private final int maxBufferSize;
+
+	LogstashEncoder(ZoneId zoneId, boolean prettyprint, int maxBufferSize) {
 		super();
 		this.zoneId = zoneId;
 		this.prettyprint = prettyprint;
 		this.timeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId);
+		this.maxBufferSize = maxBufferSize;
 	}
 
 	/**
@@ -85,14 +88,20 @@ public final class LogstashEncoder extends LogEncoder.AbstractEncoder<JsonBuffer
 	 * @param zoneId zone used for <code>@timestamp</code>, defaults to the system default
 	 * zone.
 	 * @param prettyPrint <code>true</code> will pretty print the JSON, default is false.
+	 * @param maxBufferSize maximum buffer size - a soft ceiling checked between events,
+	 * not a hard cap enforced on any single event (see
+	 * {@link LogEncoder.Buffer#isOversized()}). A negative value (the default) disables
+	 * this entirely.
 	 * @return encoder.
 	 */
 	@LogConfigurable(prefix = LogProperties.ENCODER_PREFIX)
 	static LogstashEncoder of(@LogConfigurable.KeyParameter String name,
-			@ConvertParameter("convertZoneId") @Nullable ZoneId zoneId, @Nullable Boolean prettyPrint) {
+			@ConvertParameter("convertZoneId") @Nullable ZoneId zoneId, @Nullable Boolean prettyPrint,
+			@Nullable Integer maxBufferSize) {
 		prettyPrint = prettyPrint == null ? false : prettyPrint;
 		zoneId = zoneId == null ? ZoneId.systemDefault() : zoneId;
-		return new LogstashEncoder(zoneId, prettyPrint);
+		int _maxBufferSize = maxBufferSize == null ? -1 : maxBufferSize;
+		return new LogstashEncoder(zoneId, prettyPrint, _maxBufferSize);
 	}
 
 	static ZoneId convertZoneId(@Nullable String zoneId) {
@@ -101,7 +110,7 @@ public final class LogstashEncoder extends LogEncoder.AbstractEncoder<JsonBuffer
 
 	@Override
 	protected JsonBuffer doBuffer(BufferHints hints) {
-		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.AT);
+		return new JsonBuffer(this.prettyprint, ExtendedFieldPrefix.AT, maxBufferSize);
 	}
 
 	@Override

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/JsonBufferSelfShrinkTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/JsonBufferSelfShrinkTest.java
@@ -1,0 +1,79 @@
+package io.jstach.rainbowgum.json;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.json.JsonBuffer.ExtendedFieldPrefix;
+
+/*
+ * Buffer#clear() self-shrinking for JsonBuffer, the JSON module's own Buffer
+ * implementation - mirrors core's BufferSelfShrinkTest, but for JsonBuffer's two backing
+ * stores (RawJsonWriter's byte array, and getFormattedMessageBuilder()'s StringBuilder)
+ * which, per Adam, share ONE combined maxBufferSize threshold for simplicity rather than
+ * being tracked separately.
+ * <p>
+ * JsonBuffer's raw JSON writer pre-allocates JsonBuffer.DEFAULT_INITIAL_JSON_CAPACITY
+ * (8192) bytes unconditionally at construction, plus DEFAULT_INITIAL_MESSAGE_CAPACITY
+ * (128) chars for the message builder - a combined baseline around 8320 present before a
+ * single byte is ever written, the same caveat DirectByteBufferBuffer documents in core.
+ * Thresholds here are picked comfortably above that baseline so growth is what tips a
+ * buffer over, not the fixed initial allocation alone.
+ */
+class JsonBufferSelfShrinkTest {
+
+	private static JsonBuffer buffer(int maxBufferSize) {
+		return new JsonBuffer(false, ExtendedFieldPrefix.UNDERSCORE, maxBufferSize);
+	}
+
+	@Test
+	void growingRawJsonWriterPastThresholdReportsOversized() {
+		var buffer = buffer(20_000);
+		buffer.write("key", "x".repeat(20_000), 0);
+		assertTrue(buffer.isOversized());
+	}
+
+	@Test
+	void growingFormattedMessageBuilderPastThresholdReportsOversized() {
+		var buffer = buffer(20_000);
+		buffer.getFormattedMessageBuilder().append("x".repeat(30_000));
+		assertTrue(buffer.isOversized());
+	}
+
+	@Test
+	void underThresholdIsNotOversized() {
+		var buffer = buffer(100_000);
+		buffer.write("key", "short", 0);
+		assertFalse(buffer.isOversized());
+	}
+
+	@Test
+	void unsetThresholdNeverReportsOversized() {
+		var buffer = buffer(-1);
+		buffer.write("key", "x".repeat(20_000), 0);
+		buffer.getFormattedMessageBuilder().append("x".repeat(30_000));
+		assertFalse(buffer.isOversized());
+	}
+
+	@Test
+	void clearShrinksBothStoresOnceOversized() {
+		var buffer = buffer(20_000);
+		buffer.write("key", "x".repeat(20_000), 0);
+		buffer.getFormattedMessageBuilder().append("x".repeat(30_000));
+		assertTrue(buffer.isOversized(), "sanity check: must actually be oversized before clear()");
+
+		buffer.clear();
+
+		assertFalse(buffer.isOversized(), "clear() must shrink both backing stores back under threshold");
+	}
+
+	@Test
+	void clearLeavesUnderThresholdBufferAlone() {
+		var buffer = buffer(100_000);
+		buffer.write("key", "short", 0);
+		buffer.clear();
+		assertFalse(buffer.isOversized());
+	}
+
+}

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/RawJsonWriterTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/RawJsonWriterTest.java
@@ -51,6 +51,32 @@ class RawJsonWriterTest {
 	}
 
 	@Test
+	void testCapacityMatchesInitialConstruction() {
+		var w = new RawJsonWriter(16);
+		assertEquals(16, w.capacity());
+	}
+
+	@Test
+	void testCapacityGrowsWithContent() {
+		var w = new RawJsonWriter(4);
+		w.writeString("a string long enough to force at least one enlargeOrFlush call");
+		assertTrue(w.capacity() > 4, "capacity must have grown past the tiny initial allocation");
+	}
+
+	@Test
+	void testShrinkToReplacesBackingArrayCapacity() {
+		var w = new RawJsonWriter(4);
+		w.writeString("a string long enough to force at least one enlargeOrFlush call");
+		w.reset();
+		w.shrinkTo(8);
+		assertEquals(8, w.capacity());
+		// the shrunk writer must still be fully usable afterward.
+		w.writeByte(RawJsonWriter.OBJECT_START);
+		w.writeByte(RawJsonWriter.OBJECT_END);
+		assertEquals("{}", toUtf8(w));
+	}
+
+	@Test
 	void testWriteStringFastPathNoEscaping() {
 		var w = new RawJsonWriter(16);
 		w.writeString("hello world");

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/EcsEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/EcsEncoderTest.java
@@ -26,6 +26,23 @@ import io.jstach.rainbowgum.output.ListLogOutput;
 
 class EcsEncoderTest {
 
+	/*
+	 * Confirms maxBufferSize threads all the way from EcsEncoderBuilder through to the
+	 * JsonBuffer's own isOversized() answer.
+	 */
+	@Test
+	void testMaxBufferSizeThreadsThroughToBuffer() {
+		EcsEncoderBuilder b = new EcsEncoderBuilder("ecs");
+		b.maxBufferSize(20_000);
+		EcsEncoder encoder = b.build();
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		LogEvent e = LogEvent.of(Level.INFO, "ecs", "x".repeat(30_000), KeyValues.of(), null);
+		encoder.encode(e, buffer);
+
+		assertTrue(buffer.isOversized());
+	}
+
 	@Test
 	void testBuilder() {
 		EcsEncoderBuilder b = new EcsEncoderBuilder("ecs");

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
@@ -131,6 +131,25 @@ class GelfEncoderTest {
 	}
 
 	/*
+	 * Confirms maxBufferSize threads all the way from GelfEncoderBuilder through to the
+	 * JsonBuffer's own isOversized() answer, the same way prettyPrint/host thread through
+	 * to actual encoding behavior elsewhere in this file.
+	 */
+	@Test
+	void testMaxBufferSizeThreadsThroughToBuffer() {
+		GelfEncoderBuilder b = new GelfEncoderBuilder("gelf");
+		b.host("localhost");
+		b.maxBufferSize(20_000);
+		GelfEncoder encoder = b.build();
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		LogEvent e = LogEvent.of(Level.INFO, "gelf", "x".repeat(30_000), KeyValues.of(), null);
+		encoder.encode(e, buffer);
+
+		assertTrue(buffer.isOversized());
+	}
+
+	/*
 	 * host is a required property with no default value, so GelfEncoderBuilder's field
 	 * starts out null - if build() is called directly (bypassing fromProperties())
 	 * without ever calling .host(...), Property.require() throws. Every other test in

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogbackJsonEncoderTest.java
@@ -22,6 +22,21 @@ import io.jstach.rainbowgum.output.ListLogOutput;
 class LogbackJsonEncoderTest {
 
 	/*
+	 * Confirms maxBufferSize threads all the way from LogbackJsonEncoderBuilder through
+	 * to the JsonBuffer's own isOversized() answer.
+	 */
+	@Test
+	void testMaxBufferSizeThreadsThroughToBuffer() {
+		var encoder = new LogbackJsonEncoderBuilder("logback").maxBufferSize(20_000).build();
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		LogEvent e = LogEvent.of(Level.INFO, "logback", "x".repeat(30_000), KeyValues.of(), null);
+		encoder.encode(e, buffer);
+
+		assertTrue(buffer.isOversized());
+	}
+
+	/*
 	 * Every other test in this file builds LogbackJsonEncoder directly (either via
 	 * LogbackJsonEncoderBuilder or LogbackJsonEncoder.of(...)), bypassing
 	 * LogbackJsonEncoderConfigurator (the ServiceLoader-registered URI-scheme resolution

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/LogstashEncoderTest.java
@@ -23,6 +23,21 @@ import io.jstach.rainbowgum.output.ListLogOutput;
 
 class LogstashEncoderTest {
 
+	/*
+	 * Confirms maxBufferSize threads all the way from LogstashEncoderBuilder through to
+	 * the JsonBuffer's own isOversized() answer.
+	 */
+	@Test
+	void testMaxBufferSizeThreadsThroughToBuffer() {
+		var encoder = new LogstashEncoderBuilder("logstash").maxBufferSize(20_000).build();
+
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		LogEvent e = LogEvent.of(Level.INFO, "logstash", "x".repeat(30_000), KeyValues.of(), null);
+		encoder.encode(e, buffer);
+
+		assertTrue(buffer.isOversized());
+	}
+
 	@Test
 	void testSimpleMessage() {
 		var encoder = new LogstashEncoderBuilder("logstash").zoneId(java.time.ZoneOffset.UTC).build();

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -1,7 +1,6 @@
 package io.jstach.rainbowgum.pattern.format;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.function.Function;
@@ -92,9 +91,14 @@ public final class PatternConfigurator implements Configurator {
 				}).provide(name, config);
 			}
 			var formatter = compiler.compile(pattern);
-			var charset_ = charset == null ? StandardCharsets.UTF_8 : charset;
-			var maxSize_ = maxSize == null ? -1 : maxSize;
-			return LogEncoder.of(formatter, charset_, maxSize_);
+			var builder = LogEncoder.builder(formatter);
+			if (charset != null) {
+				builder.charset(charset);
+			}
+			if (maxSize != null) {
+				builder.maxSize(maxSize);
+			}
+			return builder.build();
 		};
 	}
 

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -83,7 +83,7 @@ public final class PatternConfigurator implements Configurator {
 	@LogConfigurable(name = "PatternEncoderBuilder", prefix = LogProperties.ENCODER_PREFIX)
 	static LogProvider<LogEncoder> provideEncoder(@KeyParameter String name, String pattern,
 			@PassThroughParameter @Nullable PatternCompiler patternCompiler,
-			@ConvertParameter("convertCharset") @Nullable Charset charset, @Nullable Integer maxSize) {
+			@ConvertParameter("convertCharset") @Nullable Charset charset, @Nullable Integer maxBufferSize) {
 		return (n, config) -> {
 			var compiler = patternCompiler;
 			if (compiler == null) {
@@ -95,8 +95,8 @@ public final class PatternConfigurator implements Configurator {
 			if (charset != null) {
 				builder.charset(charset);
 			}
-			if (maxSize != null) {
-				builder.maxSize(maxSize);
+			if (maxBufferSize != null) {
+				builder.maxBufferSize(maxBufferSize);
 			}
 			return builder.build();
 		};

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.pattern.format;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.function.Function;
@@ -83,7 +84,7 @@ public final class PatternConfigurator implements Configurator {
 	@LogConfigurable(name = "PatternEncoderBuilder", prefix = LogProperties.ENCODER_PREFIX)
 	static LogProvider<LogEncoder> provideEncoder(@KeyParameter String name, String pattern,
 			@PassThroughParameter @Nullable PatternCompiler patternCompiler,
-			@ConvertParameter("convertCharset") @Nullable Charset charset) {
+			@ConvertParameter("convertCharset") @Nullable Charset charset, @Nullable Integer maxSize) {
 		return (n, config) -> {
 			var compiler = patternCompiler;
 			if (compiler == null) {
@@ -91,7 +92,9 @@ public final class PatternConfigurator implements Configurator {
 				}).provide(name, config);
 			}
 			var formatter = compiler.compile(pattern);
-			return charset == null ? LogEncoder.of(formatter) : LogEncoder.of(formatter, charset);
+			var charset_ = charset == null ? StandardCharsets.UTF_8 : charset;
+			var maxSize_ = maxSize == null ? -1 : maxSize;
+			return LogEncoder.of(formatter, charset_, maxSize_);
 		};
 	}
 

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternEncoderMaxBufferSizeTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternEncoderMaxBufferSizeTest.java
@@ -14,21 +14,21 @@ import io.jstach.rainbowgum.LogOutput.WriteMethod;
 import io.jstach.rainbowgum.LogProperties;
 
 /*
- * The generated PatternEncoderBuilder.maxSize(...) property/setter - proves
- * logging.encoder.{name}.maxSize actually threads through to the LogEncoder.Buffer
+ * The generated PatternEncoderBuilder.maxBufferSize(...) property/setter - proves
+ * logging.encoder.{name}.maxBufferSize actually threads through to the LogEncoder.Buffer
  * handed out and its isOversized() answer, the same way charset threads through to
  * encoding (see PatternEncoderCharsetTest). This is the encoder-side half of
- * AppenderBufferSizeLimitTest (core) - the appender never sees maxSize itself, only the
+ * BufferSelfShrinkTest (core) - the appender never sees maxBufferSize itself, only the
  * boolean isOversized() the buffer computes from it.
  * <p>
  * Uses {@link WriteMethod#STRING} (a plain {@link LogEncoder.Buffer.StringBuilderBuffer}
  * starting from a tiny default-capacity {@link StringBuilder}) rather than
  * {@link WriteMethod#BYTES}/{@link WriteMethod#BYTE_BUFFER}
  * ({@link LogEncoder.Buffer.DirectByteBufferBuffer}, which pre-allocates an 8192-byte
- * buffer up front) so small, easy-to-read {@code maxSize} values in these tests aren't
+ * buffer up front) so small, easy-to-read {@code maxBufferSize} values in these tests aren't
  * swamped by that pre-allocation.
  */
-class PatternEncoderMaxSizeTest {
+class PatternEncoderMaxBufferSizeTest {
 
 	private static LogEncoder.Buffer bufferAfterEncoding(String properties, String message) {
 		var config = LogConfig.builder().properties(LogProperties.builder().fromProperties(properties).build()).build();
@@ -43,19 +43,20 @@ class PatternEncoderMaxSizeTest {
 	}
 
 	@Test
-	void messagePastMaxSizeReportsOversizedBuffer() {
-		var buffer = bufferAfterEncoding("logging.encoder.list.maxSize=5\n", "a message well past five characters");
+	void messagePastMaxBufferSizeReportsOversizedBuffer() {
+		var buffer = bufferAfterEncoding("logging.encoder.list.maxBufferSize=5\n",
+				"a message well past five characters");
 		assertTrue(buffer.isOversized());
 	}
 
 	@Test
-	void messageUnderMaxSizeDoesNotReportOversized() {
-		var buffer = bufferAfterEncoding("logging.encoder.list.maxSize=1000\n", "short");
+	void messageUnderMaxBufferSizeDoesNotReportOversized() {
+		var buffer = bufferAfterEncoding("logging.encoder.list.maxBufferSize=1000\n", "short");
 		assertFalse(buffer.isOversized());
 	}
 
 	@Test
-	void unsetMaxSizeNeverReportsOversized() {
+	void unsetMaxBufferSizeNeverReportsOversized() {
 		var buffer = bufferAfterEncoding("",
 				"a message well past five characters, over and over again to grow it a lot more just in case");
 		assertFalse(buffer.isOversized());
@@ -63,18 +64,18 @@ class PatternEncoderMaxSizeTest {
 
 	/*
 	 * Confirms one of the previously-flagged gaps in the appender-side exploration
-	 * (core's AppenderBufferSizeLimitTest) no longer applies now that maxSize moved to
-	 * the encoder: the built-in "console" appender's default encoder - resolved via
+	 * (core's BufferSelfShrinkTest) no longer applies now that maxBufferSize moved to the
+	 * encoder: the built-in "console" appender's default encoder - resolved via
 	 * PatternConfigurator's own CONSOLE_OUT registration below, not through an explicit
 	 * logging.appender.console.encoder property - is built with
 	 * PatternEncoderBuilder(name).fromProperties(...) using the SAME name ("console") a
-	 * real appender would pass, so logging.encoder.console.maxSize is picked up exactly
-	 * the same way logging.encoder.console.charset already was, with no separate wiring
-	 * needed.
+	 * real appender would pass, so logging.encoder.console.maxBufferSize is picked up
+	 * exactly the same way logging.encoder.console.charset already was, with no separate
+	 * wiring needed.
 	 */
 	@Test
-	void consoleDefaultEncoderPicksUpMaxSizeTheSameWayAsAnyOtherEncoder() {
-		String properties = "logging.encoder.console.maxSize=5\n";
+	void consoleDefaultEncoderPicksUpMaxBufferSizeTheSameWayAsAnyOtherEncoder() {
+		String properties = "logging.encoder.console.maxBufferSize=5\n";
 		var config = LogConfig.builder()
 			.properties(LogProperties.builder().fromProperties(properties).build())
 			.configurator(new PatternConfigurator())

--- a/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternEncoderMaxSizeTest.java
+++ b/rainbowgum-pattern/src/test/java/io/jstach/rainbowgum/pattern/format/PatternEncoderMaxSizeTest.java
@@ -1,0 +1,95 @@
+package io.jstach.rainbowgum.pattern.format;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEncoder;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogOutput.OutputType;
+import io.jstach.rainbowgum.LogOutput.WriteMethod;
+import io.jstach.rainbowgum.LogProperties;
+
+/*
+ * The generated PatternEncoderBuilder.maxSize(...) property/setter - proves
+ * logging.encoder.{name}.maxSize actually threads through to the LogEncoder.Buffer
+ * handed out and its isOversized() answer, the same way charset threads through to
+ * encoding (see PatternEncoderCharsetTest). This is the encoder-side half of
+ * AppenderBufferSizeLimitTest (core) - the appender never sees maxSize itself, only the
+ * boolean isOversized() the buffer computes from it.
+ * <p>
+ * Uses {@link WriteMethod#STRING} (a plain {@link LogEncoder.Buffer.StringBuilderBuffer}
+ * starting from a tiny default-capacity {@link StringBuilder}) rather than
+ * {@link WriteMethod#BYTES}/{@link WriteMethod#BYTE_BUFFER}
+ * ({@link LogEncoder.Buffer.DirectByteBufferBuffer}, which pre-allocates an 8192-byte
+ * buffer up front) so small, easy-to-read {@code maxSize} values in these tests aren't
+ * swamped by that pre-allocation.
+ */
+class PatternEncoderMaxSizeTest {
+
+	private static LogEncoder.Buffer bufferAfterEncoding(String properties, String message) {
+		var config = LogConfig.builder().properties(LogProperties.builder().fromProperties(properties).build()).build();
+		var b = new PatternEncoderBuilder("list");
+		b.pattern("%msg");
+		b.fromProperties(config.properties());
+		LogEncoder encoder = b.build().provide("list", config);
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		var event = LogEvent.of(System.Logger.Level.INFO, "test", message, KeyValues.of(), null);
+		encoder.encode(event, buffer);
+		return buffer;
+	}
+
+	@Test
+	void messagePastMaxSizeReportsOversizedBuffer() {
+		var buffer = bufferAfterEncoding("logging.encoder.list.maxSize=5\n", "a message well past five characters");
+		assertTrue(buffer.isOversized());
+	}
+
+	@Test
+	void messageUnderMaxSizeDoesNotReportOversized() {
+		var buffer = bufferAfterEncoding("logging.encoder.list.maxSize=1000\n", "short");
+		assertFalse(buffer.isOversized());
+	}
+
+	@Test
+	void unsetMaxSizeNeverReportsOversized() {
+		var buffer = bufferAfterEncoding("",
+				"a message well past five characters, over and over again to grow it a lot more just in case");
+		assertFalse(buffer.isOversized());
+	}
+
+	/*
+	 * Confirms one of the previously-flagged gaps in the appender-side exploration
+	 * (core's AppenderBufferSizeLimitTest) no longer applies now that maxSize moved to
+	 * the encoder: the built-in "console" appender's default encoder - resolved via
+	 * PatternConfigurator's own CONSOLE_OUT registration below, not through an explicit
+	 * logging.appender.console.encoder property - is built with
+	 * PatternEncoderBuilder(name).fromProperties(...) using the SAME name ("console") a
+	 * real appender would pass, so logging.encoder.console.maxSize is picked up exactly
+	 * the same way logging.encoder.console.charset already was, with no separate wiring
+	 * needed.
+	 */
+	@Test
+	void consoleDefaultEncoderPicksUpMaxSizeTheSameWayAsAnyOtherEncoder() {
+		String properties = "logging.encoder.console.maxSize=5\n";
+		var config = LogConfig.builder()
+			.properties(LogProperties.builder().fromProperties(properties).build())
+			.configurator(new PatternConfigurator())
+			.build();
+		// Mirrors exactly what DefaultAppenderRegistry.defaultConsoleAppender() (core)
+		// does to resolve the console appender's encoder when none is explicitly
+		// configured.
+		LogEncoder encoder = config.encoderRegistry()
+			.encoderForOutputType(OutputType.CONSOLE_OUT)
+			.provide("console", config);
+		var buffer = encoder.buffer(WriteMethod.STRING);
+		var event = LogEvent.of(System.Logger.Level.INFO, "test", "a message well past five characters", KeyValues.of(),
+				null);
+		encoder.encode(event, buffer);
+		assertTrue(buffer.isOversized());
+	}
+
+}


### PR DESCRIPTION
…buffer

Adds LogEncoder.Buffer#approximateSize() (default 0 = opt-out), a logging.appender.{name}.maxBufferSize property (negative/unset = disabled, unchanged behavior), and wires LockThreadLocalBufferLogAppender/ SynchronizedThreadLocalBufferLogAppender to check it once per event - before the current event reuses the buffer, not after - and swap in a fresh buffer from the encoder instead of the oversized one, letting it become garbage. A reused buffer only ever grows (setLength(0) resets logical length, not capacity), so without this a single huge event permanently bloats a thread's cached buffer for the life of that thread - worse on platform threads, which are reused from a pool, than short-lived virtual threads.

Deliberately does not touch LogEvent/LogMessageFormatter - a sibling exploration branch covers bounding message formatting itself. Also does not cover ReuseBufferLogAppender (single shared buffer, not per-thread, out of scope for this), the batch append(LogEvent[], int) path, or defaultConsoleAppender() (built via LogAppender.builder(...), a separate construction path from the AppenderConfig-based one this wires into) - only "file" and custom-named appenders configured via logging.appender.{name}.* pick up maxBufferSize for now.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5