### PR TITLE
Explore: LogEvent.formattedMessage(sb, maxSize) with early-exit for S…

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEvent.java
@@ -347,6 +347,36 @@ public sealed interface LogEvent {
 	}
 
 	/**
+	 * Appends the formatted message but stops appending once {@code maxSize} characters
+	 * have been appended to {@code sb} (counted from {@code sb}'s length when this call
+	 * started).
+	 * @param sb string builder to use.
+	 * @param maxSize maximum number of characters this call may append to {@code sb}, or
+	 * a non-positive value for unbounded (equivalent to
+	 * {@link #formattedMessage(StringBuilder)}).
+	 * @apiNote The default implementation here is a safe fallback for any
+	 * {@link LogEvent} that does not override it: it formats the message unbounded via
+	 * {@link #formattedMessage(StringBuilder)} and then truncates {@code sb} back down if
+	 * needed - it does <em>not</em> avoid the cost of formatting an oversized message, it
+	 * only bounds what ends up in {@code sb} afterward. {@link OneArgLogEvent},
+	 * {@link TwoArgLogEvent}, and {@link ArrayArgLogEvent} override this to stop early
+	 * instead, by threading {@code maxSize} into {@link LogMessageFormatter}, but even
+	 * there a single argument's own {@code toString()} is not itself bounded.
+	 * @see LogMessageFormatter
+	 */
+	default void formattedMessage(StringBuilder sb, int maxSize) {
+		if (maxSize <= 0) {
+			formattedMessage(sb);
+			return;
+		}
+		int start = sb.length();
+		formattedMessage(sb);
+		if (sb.length() - start > maxSize) {
+			sb.setLength(start + maxSize);
+		}
+	}
+
+	/**
 	 * Throwable at the time of the event passed from the logger.
 	 * @return if the event does not have a throwable <code>null</code> will be returned.
 	 */
@@ -807,6 +837,11 @@ record OneArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 	}
 
 	@Override
+	public void formattedMessage(StringBuilder sb, int maxSize) {
+		messageFormatter.format(sb, message, arg1, maxSize);
+	}
+
+	@Override
 	public LogEvent freeze() {
 		return freeze(timestamp);
 	}
@@ -838,6 +873,11 @@ record TwoArgLogEvent(Instant timestamp, String threadName, long threadId, Syste
 	@Override
 	public void formattedMessage(StringBuilder sb) {
 		messageFormatter.format(sb, message, arg1, arg2);
+	}
+
+	@Override
+	public void formattedMessage(StringBuilder sb, int maxSize) {
+		messageFormatter.format(sb, message, arg1, arg2, maxSize);
 	}
 
 	@Override
@@ -874,6 +914,11 @@ record ArrayArgLogEvent(Instant timestamp, String threadName, long threadId, Sys
 		messageFormatter.formatArray(sb, message, args, length);
 	}
 
+	@Override
+	public void formattedMessage(StringBuilder sb, int maxSize) {
+		messageFormatter.formatArray(sb, message, args, length, maxSize);
+	}
+
 	public int argCount() {
 		return args.length;
 	}
@@ -908,6 +953,21 @@ record DefaultLogEvent(Instant timestamp, String threadName, long threadId, Syst
 	@Override
 	public void formattedMessage(StringBuilder sb) {
 		sb.append(this.formattedMessage);
+	}
+
+	@Override
+	public void formattedMessage(StringBuilder sb, int maxSize) {
+		String m = this.formattedMessage;
+		if (maxSize <= 0 || m == null) {
+			formattedMessage(sb);
+			return;
+		}
+		/*
+		 * Unlike the interface default (format unbounded then truncate) this only ever
+		 * copies up to maxSize characters in the first place, since the message here is
+		 * already a plain String with a known length - no formatting work to bound.
+		 */
+		sb.append(m, 0, Math.min(m.length(), maxSize));
 	}
 
 	@Override
@@ -982,6 +1042,16 @@ record StackFrameLogEvent(LogEvent event, Caller callerOrNull) implements LogEve
 	public void formattedMessage(StringBuilder sb) {
 		event.formattedMessage(sb);
 
+	}
+
+	@Override
+	public void formattedMessage(StringBuilder sb, int maxSize) {
+		/*
+		 * Delegate rather than fall through to the interface default - the wrapped event
+		 * may itself have an early-exit override (OneArgLogEvent etc.) that would
+		 * otherwise be silently lost behind the generic format-then-truncate fallback.
+		 */
+		event.formattedMessage(sb, maxSize);
 	}
 
 	@Override

--- a/core/src/main/java/io/jstach/rainbowgum/LogMessageFormatter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogMessageFormatter.java
@@ -25,6 +25,29 @@ public sealed interface LogMessageFormatter {
 	void format(StringBuilder builder, String message, @Nullable Object arg1);
 
 	/**
+	 * Formats and appends the results, stopping early once {@code maxSize} characters
+	 * have been appended to {@code builder} (counted from {@code builder}'s length when
+	 * this call started).
+	 * @param builder output.
+	 * @param message message usually with formatting delimiters for replacement.
+	 * @param arg1 to use for replacement.
+	 * @param maxSize maximum number of characters this call may append to
+	 * {@code builder}, or a non-positive value for unbounded (equivalent to
+	 * {@link #format(StringBuilder, String, Object)}).
+	 * @apiNote The default implementation is a safe fallback that formats unbounded first
+	 * and truncates after - it does not avoid the cost of formatting an oversized
+	 * message. {@link StandardMessageFormatter#SLF4J} overrides this to stop appending as
+	 * soon as the cap is reached instead, though even there a single argument's own
+	 * {@code toString()} is not itself bounded - see {@code SLF4JMessageFormatter}'s own
+	 * javadoc for that limitation.
+	 */
+	default void format(StringBuilder builder, String message, @Nullable Object arg1, int maxSize) {
+		int start = builder.length();
+		format(builder, message, arg1);
+		capAfter(builder, start, maxSize);
+	}
+
+	/**
 	 * Formats and appends the results.
 	 * @param builder output.
 	 * @param message message usually with formatting delimiters for replacement.
@@ -32,6 +55,26 @@ public sealed interface LogMessageFormatter {
 	 * @param arg2 to use for replacement.
 	 */
 	void format(StringBuilder builder, String message, @Nullable Object arg1, @Nullable Object arg2);
+
+	/**
+	 * Formats and appends the results, stopping early once {@code maxSize} characters
+	 * have been appended to {@code builder} (counted from {@code builder}'s length when
+	 * this call started).
+	 * @param builder output.
+	 * @param message message usually with formatting delimiters for replacement.
+	 * @param arg1 to use for replacement.
+	 * @param arg2 to use for replacement.
+	 * @param maxSize maximum number of characters this call may append to
+	 * {@code builder}, or a non-positive value for unbounded.
+	 * @apiNote see {@link #format(StringBuilder, String, Object, int)} for the fallback
+	 * vs early-exit distinction between formatters.
+	 */
+	default void format(StringBuilder builder, String message, @Nullable Object arg1, @Nullable Object arg2,
+			int maxSize) {
+		int start = builder.length();
+		format(builder, message, arg1, arg2);
+		capAfter(builder, start, maxSize);
+	}
 
 	/**
 	 * Formats and appends the result.
@@ -53,6 +96,35 @@ public sealed interface LogMessageFormatter {
 	void formatArray(StringBuilder builder, String message, @Nullable Object[] args, int length);
 
 	/**
+	 * Formats and appends the result, stopping early once {@code maxSize} characters have
+	 * been appended to {@code builder} (counted from {@code builder}'s length when this
+	 * call started).
+	 * @param builder output.
+	 * @param message message usually with formatting delimiters for replacement.
+	 * @param args array of args.
+	 * @param length of args array which will be used even if args is larger.
+	 * @param maxSize maximum number of characters this call may append to
+	 * {@code builder}, or a non-positive value for unbounded.
+	 * @apiNote see {@link #format(StringBuilder, String, Object, int)} for the fallback
+	 * vs early-exit distinction between formatters.
+	 */
+	default void formatArray(StringBuilder builder, String message, @Nullable Object[] args, int length, int maxSize) {
+		int start = builder.length();
+		formatArray(builder, message, args, length);
+		capAfter(builder, start, maxSize);
+	}
+
+	/**
+	 * Truncates {@code builder} back to {@code start + maxSize} if it grew past that
+	 * while formatting, unless {@code maxSize} is non-positive (unbounded).
+	 */
+	private static void capAfter(StringBuilder builder, int start, int maxSize) {
+		if (maxSize > 0 && builder.length() - start > maxSize) {
+			builder.setLength(start + maxSize);
+		}
+	}
+
+	/**
 	 * Built-in message formatters.
 	 */
 	@CaseChanging
@@ -69,13 +141,30 @@ public sealed interface LogMessageFormatter {
 			}
 
 			@Override
+			public void format(StringBuilder builder, String message, @Nullable Object arg1, int maxSize) {
+				SLF4JMessageFormatter.format(builder, message, arg1, maxSize);
+			}
+
+			@Override
 			public void format(StringBuilder builder, String message, @Nullable Object arg1, @Nullable Object arg2) {
 				SLF4JMessageFormatter.format(builder, message, arg1, arg2);
 			}
 
 			@Override
+			public void format(StringBuilder builder, String message, @Nullable Object arg1, @Nullable Object arg2,
+					int maxSize) {
+				SLF4JMessageFormatter.format(builder, message, arg1, arg2, maxSize);
+			}
+
+			@Override
 			public void formatArray(StringBuilder builder, String message, @Nullable Object[] args, int length) {
 				SLF4JMessageFormatter.format(builder, message, args, length);
+			}
+
+			@Override
+			public void formatArray(StringBuilder builder, String message, @Nullable Object[] args, int length,
+					int maxSize) {
+				SLF4JMessageFormatter.format(builder, message, args, length, maxSize);
 			}
 		},
 		/**
@@ -140,36 +229,87 @@ final class SLF4JMessageFormatter {
 
 	private static final char ESCAPE_CHAR = '\\';
 
+	/**
+	 * Sentinel passed as the internal absolute {@code limit} to mean "unbounded" - not a
+	 * valid {@link StringBuilder#length()} value to target, so safe to distinguish from
+	 * every real (always {@code >= 0}) limit.
+	 */
+	private static final int UNBOUNDED = -1;
+
 	private SLF4JMessageFormatter() {
 	}
 
 	public static void format(final StringBuilder sbuf, final @Nullable String messagePattern,
 			final @Nullable Object arg1) {
-		format(sbuf, messagePattern, arg1, null, null, 1);
+		format(sbuf, messagePattern, arg1, null, null, 1, UNBOUNDED);
+	}
+
+	public static void format(final StringBuilder sbuf, final @Nullable String messagePattern,
+			final @Nullable Object arg1, int maxSize) {
+		format(sbuf, messagePattern, arg1, null, null, 1, absoluteLimit(sbuf, maxSize));
 	}
 
 	public static void format(final StringBuilder sbuf, final @Nullable String messagePattern,
 			final @Nullable Object arg1, final @Nullable Object arg2) {
-		format(sbuf, messagePattern, arg1, arg2, null, 2);
+		format(sbuf, messagePattern, arg1, arg2, null, 2, UNBOUNDED);
+	}
+
+	public static void format(final StringBuilder sbuf, final @Nullable String messagePattern,
+			final @Nullable Object arg1, final @Nullable Object arg2, int maxSize) {
+		format(sbuf, messagePattern, arg1, arg2, null, 2, absoluteLimit(sbuf, maxSize));
 	}
 
 	public static void format(final StringBuilder sbuf, final @Nullable String messagePattern,
 			final @Nullable Object @Nullable [] args, int length) {
+		formatArray(sbuf, messagePattern, args, length, UNBOUNDED);
+	}
+
+	public static void format(final StringBuilder sbuf, final @Nullable String messagePattern,
+			final @Nullable Object @Nullable [] args, int length, int maxSize) {
+		formatArray(sbuf, messagePattern, args, length, absoluteLimit(sbuf, maxSize));
+	}
+
+	private static void formatArray(final StringBuilder sbuf, final @Nullable String messagePattern,
+			final @Nullable Object @Nullable [] args, int length, int limit) {
 		if (args == null || length == 0) {
-			format(sbuf, messagePattern, null, null, null, 0);
-			return;
+			format(sbuf, messagePattern, null, null, null, 0, limit);
 		}
 		else if (length == 1) {
-			format(sbuf, messagePattern, args[0], null, null, 1);
-			return;
+			format(sbuf, messagePattern, args[0], null, null, 1, limit);
 		}
 		else if (length == 2) {
-			format(sbuf, messagePattern, args[0], args[1], null, 2);
-			return;
+			format(sbuf, messagePattern, args[0], args[1], null, 2, limit);
 		}
 		else {
-			format(sbuf, messagePattern, null, null, args, length);
+			format(sbuf, messagePattern, null, null, args, length, limit);
 		}
+	}
+
+	/**
+	 * Converts a caller-supplied {@code maxSize} (max characters this call may append,
+	 * counted from {@code sbuf}'s length at the start of the call) into an absolute
+	 * target {@link StringBuilder#length()} to stop at, or {@link #UNBOUNDED}.
+	 */
+	private static int absoluteLimit(StringBuilder sbuf, int maxSize) {
+		return maxSize <= 0 ? UNBOUNDED : sbuf.length() + maxSize;
+	}
+
+	/**
+	 * If {@code sbuf} has reached or passed {@code limit}, truncates it to exactly
+	 * {@code limit} and reports that the caller should stop. A single call to
+	 * {@link #deeplyAppendParameter(StringBuilder, Object, IdentityHashMap)} can still
+	 * push {@code sbuf} arbitrarily far past {@code limit} in one step (an argument's own
+	 * {@code toString()} is not itself bounded) - this only guarantees the check runs
+	 * (and the loop stops) between segments/arguments, not that any single append is
+	 * capped mid-flight.
+	 * @return {@code true} if {@code sbuf} was capped and the caller should stop.
+	 */
+	private static boolean capped(StringBuilder sbuf, int limit) {
+		if (limit != UNBOUNDED && sbuf.length() >= limit) {
+			sbuf.setLength(limit);
+			return true;
+		}
+		return false;
 	}
 
 	private static void format(final StringBuilder sbuf, //
@@ -177,7 +317,8 @@ final class SLF4JMessageFormatter {
 			final @Nullable Object arg1, //
 			final @Nullable Object arg2, //
 			final @Nullable Object @Nullable [] args, //
-			final int argCount) {
+			final int argCount, //
+			final int limit) {
 
 		if (messagePattern == null) {
 			return;
@@ -185,6 +326,7 @@ final class SLF4JMessageFormatter {
 
 		if (argCount == 0) {
 			sbuf.append(messagePattern);
+			capped(sbuf, limit);
 			return;
 		}
 
@@ -199,11 +341,13 @@ final class SLF4JMessageFormatter {
 				// no more variables
 				if (i == 0) { // this is a simple string
 					sbuf.append(messagePattern);
+					capped(sbuf, limit);
 					return;
 				}
 				else { // add the tail string which contains no variables and return
 						// the result.
 					sbuf.append(messagePattern, i, messagePattern.length());
+					capped(sbuf, limit);
 					return;
 				}
 			}
@@ -213,6 +357,9 @@ final class SLF4JMessageFormatter {
 						L--; // DELIM_START was escaped, thus should not be incremented
 						sbuf.append(messagePattern, i, j - 1);
 						sbuf.append(DELIM_START);
+						if (capped(sbuf, limit)) {
+							return;
+						}
 						i = j + 1;
 					}
 					else {
@@ -222,6 +369,9 @@ final class SLF4JMessageFormatter {
 						sbuf.append(messagePattern, i, j - 1);
 						Object arg = resolveArg(L, arg1, arg2, args, argCount);
 						deeplyAppendParameter(sbuf, arg, null);
+						if (capped(sbuf, limit)) {
+							return;
+						}
 						i = j + 2;
 					}
 				}
@@ -230,12 +380,16 @@ final class SLF4JMessageFormatter {
 					sbuf.append(messagePattern, i, j);
 					Object arg = resolveArg(L, arg1, arg2, args, argCount);
 					deeplyAppendParameter(sbuf, arg, null);
+					if (capped(sbuf, limit)) {
+						return;
+					}
 					i = j + 2;
 				}
 			}
 		}
 		// append the characters following the last {} pair.
 		sbuf.append(messagePattern, i, messagePattern.length());
+		capped(sbuf, limit);
 	}
 
 	private static @Nullable Object resolveArg(int i, @Nullable Object arg1, @Nullable Object arg2,

--- a/core/src/test/java/io/jstach/rainbowgum/MessageSizeLimitTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/MessageSizeLimitTest.java
@@ -1,0 +1,152 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.System.Logger.Level;
+
+import org.junit.jupiter.api.Test;
+
+import io.jstach.rainbowgum.LogMessageFormatter.StandardMessageFormatter;
+
+/*
+ * Exploration branch A of the message-size-limiting design discussion (see todo.md):
+ * bounding LogEvent's message formatting itself with a maxSize parameter so the append
+ * work can stop early instead of materializing an unbounded message before truncating.
+ */
+class MessageSizeLimitTest {
+
+	private static final KeyValues NO_KEY_VALUES = KeyValues.of();
+
+	@Test
+	void shortMessageUnderMaxSizeIsIdenticalBoundedOrNot() {
+		var event = LogEvent.of(Level.INFO, "logger", "Hello {}!", NO_KEY_VALUES, StandardMessageFormatter.SLF4J,
+				"world");
+
+		StringBuilder unbounded = new StringBuilder();
+		event.formattedMessage(unbounded);
+
+		StringBuilder bounded = new StringBuilder();
+		event.formattedMessage(bounded, 1000);
+
+		assertEquals("Hello world!", unbounded.toString());
+		assertEquals(unbounded.toString(), bounded.toString());
+	}
+
+	@Test
+	void messageExceedingMaxSizeIsCappedToExactlyMaxSize() {
+		var event = LogEvent.of(Level.INFO, "logger", "Hello {}!", NO_KEY_VALUES, StandardMessageFormatter.SLF4J,
+				"world");
+
+		StringBuilder sb = new StringBuilder();
+		event.formattedMessage(sb, 5);
+
+		assertEquals(5, sb.length());
+		assertEquals("Hello", sb.toString());
+	}
+
+	@Test
+	void multipleArgsStopsAsSoonAsCapIsCrossedTailArgNeverAppears() {
+		Object[] args = new Object[] { "AAAA", "BBBB", "CCCCCCCCCCCCCCCCCCCCCCCCCCCC" };
+		var event = LogEvent.ofArgs(Level.INFO, "logger", "{} {} {}", NO_KEY_VALUES, StandardMessageFormatter.SLF4J,
+				args);
+
+		StringBuilder sb = new StringBuilder();
+		// Cap lands inside the second argument's contribution - the third argument's
+		// content must never be touched/appended at all.
+		event.formattedMessage(sb, 6);
+
+		assertEquals(6, sb.length());
+		assertFalse(sb.toString().contains("C"), "third arg must never have been appended: " + sb);
+	}
+
+	@Test
+	void arrayArgLogEventCapAcrossManyArgsNeverReachesLastArg() {
+		Object[] args = new Object[] { "one", "two", "three", "four", "VERY_LONG_TAIL_MARKER" };
+		var event = LogEvent.ofArgs(Level.INFO, "logger", "{}-{}-{}-{}-{}", NO_KEY_VALUES,
+				StandardMessageFormatter.SLF4J, args);
+
+		StringBuilder sb = new StringBuilder();
+		event.formattedMessage(sb, 10);
+
+		assertEquals(10, sb.length());
+		assertFalse(sb.toString().contains("VERY_LONG_TAIL_MARKER"));
+	}
+
+	@Test
+	void defaultLogEventPlainMessageIsCappedCorrectly() {
+		var event = LogEvent.of(Level.INFO, "logger", "0123456789ABCDEF", NO_KEY_VALUES, null);
+
+		StringBuilder sb = new StringBuilder();
+		event.formattedMessage(sb, 8);
+
+		assertEquals("01234567", sb.toString());
+	}
+
+	@Test
+	void nonPositiveMaxSizeMeansUnboundedAndMatchesNoArgOverload() {
+		var event = LogEvent.of(Level.INFO, "logger", "Hello {}!", NO_KEY_VALUES, StandardMessageFormatter.SLF4J,
+				"world");
+
+		StringBuilder unbounded = new StringBuilder();
+		event.formattedMessage(unbounded);
+
+		StringBuilder zero = new StringBuilder();
+		event.formattedMessage(zero, 0);
+
+		StringBuilder negative = new StringBuilder();
+		event.formattedMessage(negative, -1);
+
+		assertEquals(unbounded.toString(), zero.toString());
+		assertEquals(unbounded.toString(), negative.toString());
+	}
+
+	@Test
+	void preExistingBuilderContentIsNeverTruncatedOnlyTheAppendedPortionIsBounded() {
+		var event = LogEvent.of(Level.INFO, "logger", "Hello {}!", NO_KEY_VALUES, StandardMessageFormatter.SLF4J,
+				"world");
+
+		StringBuilder sb = new StringBuilder("PREFIX:");
+		event.formattedMessage(sb, 5);
+
+		assertTrue(sb.toString().startsWith("PREFIX:"), sb.toString());
+		assertEquals("PREFIX:Hello", sb.toString());
+	}
+
+	@Test
+	void twoArgLogEventStopsBeforeSecondArgWhenCapLandsInFirst() {
+		var event = LogEvent.of(Level.INFO, "logger", "{} {}", NO_KEY_VALUES, StandardMessageFormatter.SLF4J, "first",
+				"SECOND_MUST_NOT_APPEAR");
+
+		StringBuilder sb = new StringBuilder();
+		event.formattedMessage(sb, 3);
+
+		assertEquals(3, sb.length());
+		assertFalse(sb.toString().contains("SECOND_MUST_NOT_APPEAR"));
+	}
+
+	@Test
+	void stackFrameLogEventDelegatesEarlyExitInsteadOfFallingBackToDefault() {
+		// StackFrameLogEvent (added via LogEvent.withCaller) must delegate
+		// formattedMessage(sb, maxSize) to the wrapped event's own override, not
+		// silently fall back to the generic format-then-truncate default - otherwise
+		// any event with caller info attached would lose the early-exit behavior.
+		var inner = LogEvent.ofArgs(Level.INFO, "logger", "{} {} {}", NO_KEY_VALUES, StandardMessageFormatter.SLF4J,
+				new Object[] { "A", "B", "TAIL_SHOULD_NOT_APPEAR" });
+		var caller = LogEvent.Caller.ofDepthOrNull(0);
+		if (caller == null) {
+			fail("expected a real caller frame at depth 0");
+			throw new IllegalStateException();
+		}
+		var withCaller = LogEvent.withCaller(inner, caller);
+
+		StringBuilder sb = new StringBuilder();
+		withCaller.formattedMessage(sb, 3);
+
+		assertEquals(3, sb.length());
+		assertFalse(sb.toString().contains("TAIL_SHOULD_NOT_APPEAR"));
+	}
+
+}


### PR DESCRIPTION
…LF4J

Exploration branch A of the message-size-limiting design discussion (see todo.md): threads an optional maxSize through LogEvent's message formatting instead of only being able to bound after the fact.

LogMessageFormatter gains maxSize-aware default overloads whose fallback behavior is format-fully-then-truncate (what JUL uses unchanged, since MessageFormat has no natural early-exit point). StandardMessageFormatter.SLF4J overrides these to route into SLF4JMessageFormatter's {}-substitution loop, which now checks the absolute target length after each append/argument and stops - and therefore never resolves or appends - as soon as the cap is crossed, rather than finishing every remaining argument first. A single argument's own toString() is still unbounded once started; that's documented as a known, accepted limitation rather than solved here.

LogEvent gets a formattedMessage(StringBuilder, int) default (safe generic fallback: format unbounded, then setLength), overridden by OneArgLogEvent/TwoArgLogEvent/ArrayArgLogEvent to thread maxSize into the formatter, by DefaultLogEvent with a direct bounded substring append (its message is already a plain String, no formatting to bound), and by StackFrameLogEvent to delegate to the wrapped event rather than silently losing early-exit behavior behind the fallback.

Deliberately not wired into any appender/encoder/config yet - this branch only makes the capability exist and is correctly tested, for comparison against the sibling appender-level buffer-replacement exploration branch.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5