### PR TITLE
Turn the "prefer the aggregated doc" note into a GitHub alert box

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ The long term goal of Rainbow Gum is to be a logging framework **for all** with 
 * **[Latest SNAPSHOT RainbowGum doc](https://jstach.io/rainbowgum/)**
 * **[Current released RainbowGum doc](https://jstach.io/doc/rainbowgum/current/apidocs)**
 
+> [!WARNING]
+> While this readme does contain some documentation the above is the preferred documentation and
+> more likely to be up to date and correct! The rest of this readme is mainly for ~~propaganda~~
+> marketing purposes.
+
 The doc is also on javadoc.io but is not aggregated like the above.
-The aggregated javadoc is the preferred documentation and the rest of this readme
-is mainly for ~~propaganda~~ marketing purposes.
 
 For previous releases:
 


### PR DESCRIPTION
Matches the [!WARNING] callout Adam already uses in ezkv's readme.md, right after its own documentation links - same trick, same placement. Keeps the existing wording/joke, just gives it the visual callout treatment instead of being a plain paragraph easy to skim past.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5