### PR TITLE
Rename DefaultContentType to SimpleContentType and hide it 

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -145,8 +145,7 @@ public interface LogEncoder {
 
 		/**
 		 * Content type reported to the output. Use this when the formatter produces
-		 * something other than plain text (e.g. a custom
-		 * {@link ContentType.DefaultContentType}). Defaults to
+		 * something other than plain text. Defaults to
 		 * {@link StandardContentType#TEXT_PLAIN} with whatever charset is in effect (see
 		 * {@link #charset(Charset)}).
 		 * @param contentType content type reported to the output.

--- a/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutput.java
@@ -148,8 +148,7 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 		 * modern Java (e.g. {@code String#getBytes()}'s no-charset overload) to treat as
 		 * the assumed default rather than "unspecified" - an encoder actually configured
 		 * with a different charset (see {@link LogEncoder#builder(LogFormatter)}) reports
-		 * a {@link DefaultContentType} instead, not
-		 * {@link StandardContentType#TEXT_PLAIN}.
+		 * a different content type instead, not {@link StandardContentType#TEXT_PLAIN}.
 		 * @return charset or <code>null</code> if not fixed/known.
 		 */
 		@Nullable
@@ -157,11 +156,11 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 
 		/**
 		 * Finds the matching {@link StandardContentType} for the given content type and
-		 * charset if one exists, otherwise creates a new {@link DefaultContentType}.
+		 * charset if one exists, otherwise creates a new plain {@link ContentType}.
 		 * @param contentType content type, e.g. <code>text/plain</code>.
 		 * @param charsetOrNull charset or <code>null</code> if not fixed/known.
-		 * @return a {@link StandardContentType} if one matches, otherwise a
-		 * {@link DefaultContentType}.
+		 * @return a {@link StandardContentType} if one matches, otherwise a plain
+		 * {@link ContentType}.
 		 */
 		static ContentType of(String contentType, @Nullable Charset charsetOrNull) {
 			for (var standard : StandardContentType.values()) {
@@ -170,19 +169,7 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 					return standard;
 				}
 			}
-			return new DefaultContentType(contentType, charsetOrNull);
-		}
-
-		/**
-		 * A plain {@link ContentType} for content types not covered by
-		 * {@link StandardContentType}. Use {@link ContentType#of(String, Charset)} to
-		 * create one (or reuse a matching {@link StandardContentType} instead if one
-		 * matches).
-		 *
-		 * @param contentType content type, e.g. <code>text/plain</code>.
-		 * @param charsetOrNull charset or <code>null</code> if not fixed/known.
-		 */
-		public record DefaultContentType(String contentType, @Nullable Charset charsetOrNull) implements ContentType {
+			return new SimpleContentType(contentType, charsetOrNull);
 		}
 
 		/**
@@ -538,6 +525,18 @@ public interface LogOutput extends LogLifecycle, Flushable, LogComponent {
 
 	}
 
+}
+
+/**
+ * A plain {@link LogOutput.ContentType} for content types not covered by
+ * {@link LogOutput.ContentType.StandardContentType}. Created via
+ * {@link LogOutput.ContentType#of(String, Charset)} (or reuses a matching
+ * {@link LogOutput.ContentType.StandardContentType} instead if one matches).
+ *
+ * @param contentType content type, e.g. <code>text/plain</code>.
+ * @param charsetOrNull charset or <code>null</code> if not fixed/known.
+ */
+record SimpleContentType(String contentType, @Nullable Charset charsetOrNull) implements LogOutput.ContentType {
 }
 
 class StdOutOutput extends LogOutput.AbstractOutputStreamOutput {

--- a/core/src/test/java/io/jstach/rainbowgum/ContentTypeTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/ContentTypeTest.java
@@ -1,4 +1,4 @@
-package io.jstach.rainbowgum.output;
+package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -8,9 +8,13 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import io.jstach.rainbowgum.LogOutput.ContentType;
-import io.jstach.rainbowgum.LogOutput.ContentType.DefaultContentType;
 import io.jstach.rainbowgum.LogOutput.ContentType.StandardContentType;
 
+/*
+ * Moved into io.jstach.rainbowgum (from io.jstach.rainbowgum.output) so this can
+ * construct SimpleContentType directly - it's package-private now (see the "minimize
+ * public API" note), not something outside this package should ever need to touch.
+ */
 class ContentTypeTest {
 
 	@Test
@@ -30,9 +34,9 @@ class ContentTypeTest {
 	}
 
 	@Test
-	void ofCreatesADefaultContentTypeWhenNothingMatches() {
+	void ofCreatesASimpleContentTypeWhenNothingMatches() {
 		var contentType = ContentType.of("text/plain", StandardCharsets.ISO_8859_1);
-		assertEquals(new DefaultContentType("text/plain", StandardCharsets.ISO_8859_1), contentType);
+		assertEquals(new SimpleContentType("text/plain", StandardCharsets.ISO_8859_1), contentType);
 		assertEquals("text/plain", contentType.contentType());
 		assertEquals(StandardCharsets.ISO_8859_1, contentType.charsetOrNull());
 	}
@@ -40,7 +44,7 @@ class ContentTypeTest {
 	@Test
 	void ofDoesNotMatchApplicationJsonWithAWrongCharset() {
 		var contentType = ContentType.of("application/json", StandardCharsets.ISO_8859_1);
-		assertEquals(new DefaultContentType("application/json", StandardCharsets.ISO_8859_1), contentType);
+		assertEquals(new SimpleContentType("application/json", StandardCharsets.ISO_8859_1), contentType);
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogEncoderCharsetTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEncoderCharsetTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import io.jstach.rainbowgum.LogOutput.ContentType;
-import io.jstach.rainbowgum.LogOutput.ContentType.DefaultContentType;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
 
 /*
@@ -63,7 +62,7 @@ class LogEncoderCharsetTest {
 	@Test
 	void ofContentTypeUsesTheGivenContentTypeAndItsCharset() {
 		var output = new CapturingOutput(WriteMethod.BYTES);
-		var contentType = new DefaultContentType("text/csv", StandardCharsets.ISO_8859_1);
+		var contentType = new SimpleContentType("text/csv", StandardCharsets.ISO_8859_1);
 		var config = LogConfig.builder().build();
 		var gum = RainbowGum.builder(config)
 			.route(r -> r.appender("list",
@@ -79,7 +78,7 @@ class LogEncoderCharsetTest {
 	@Test
 	void ofContentTypeWithNoCharsetDefaultsToUtf8ForEncoding() {
 		var output = new CapturingOutput(WriteMethod.BYTES);
-		var contentType = new DefaultContentType("text/csv", null);
+		var contentType = new SimpleContentType("text/csv", null);
 		var config = LogConfig.builder().build();
 		var gum = RainbowGum.builder(config)
 			.route(r -> r.appender("list",


### PR DESCRIPTION
Moves the record out of the ContentType interface (where interface nesting forced it public) to a top-level package-private sibling in LogOutput.java, matching the existing pattern used for FormatterEncoder/StdOutOutput/etc. Public javadoc no longer names the type at all, since it's just an internal implementation detail of ContentType.of(...).


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5