### PR TITLE
Refactor/encoder provider

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -266,7 +266,7 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 * @see LogEncoder#of(LogFormatter)
 		 */
 		public Builder formatter(LogFormatter formatter) {
-			this.encoder = LogProvider.of(LogEncoder.of(formatter));
+			this.encoder = LogEncoder.of(formatter);
 			return this;
 		}
 
@@ -277,7 +277,7 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		 * @see LogEncoder#of(LogFormatter)
 		 */
 		public Builder formatter(LogFormatter.EventFormatter formatter) {
-			this.encoder = LogProvider.of(LogEncoder.of(formatter));
+			this.encoder = LogEncoder.of(formatter);
 			return this;
 		}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -80,7 +80,7 @@ public interface LogEncoder {
 	 * @param formatter formatter.
 	 * @return encoder.
 	 */
-	public static LogEncoder of(LogFormatter formatter) {
+	public static LogProvider<LogEncoder> of(LogFormatter formatter) {
 		return builder(formatter).build();
 	}
 
@@ -196,7 +196,7 @@ public interface LogEncoder {
 		 * Builds the encoder.
 		 * @return encoder.
 		 */
-		public LogEncoder build() {
+		public LogProvider<LogEncoder> build() {
 			Charset c = charset;
 			ContentType ct = contentType;
 			if (ct != null) {
@@ -210,7 +210,9 @@ public interface LogEncoder {
 			if (ct == null) {
 				ct = ContentType.of(StandardContentType.TEXT_PLAIN.contentType(), c);
 			}
-			return new FormatterEncoder(formatter, c, ct, maxBufferSize, initialBufferSize);
+			var resolvedCharset = c;
+			var resolvedContentType = ct;
+			return (n, config) -> new FormatterEncoder(formatter, resolvedCharset, resolvedContentType, maxBufferSize, initialBufferSize);
 		}
 
 	}
@@ -262,8 +264,8 @@ public interface LogEncoder {
 		 * @param encoder already configured encoder.
 		 * @return encoder provider.
 		 */
-		static EncoderProvider of(LogEncoder encoder) {
-			return ref -> LogProvider.of(encoder);
+		static EncoderProvider of(LogProvider<LogEncoder> encoder) {
+			return ref -> encoder;
 		}
 
 	}

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -212,7 +212,8 @@ public interface LogEncoder {
 			}
 			var resolvedCharset = c;
 			var resolvedContentType = ct;
-			return (n, config) -> new FormatterEncoder(formatter, resolvedCharset, resolvedContentType, maxBufferSize, initialBufferSize);
+			return (n, config) -> new FormatterEncoder(formatter, resolvedCharset, resolvedContentType, maxBufferSize,
+					initialBufferSize);
 		}
 
 	}

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
@@ -56,7 +56,7 @@ class AppenderAlertReportingTest {
 		var output = new ListLogOutput();
 		var throwingEncoder = LogEncoder.of((LogFormatter.EventFormatter) (sb, event) -> {
 			throw new RuntimeException("encode boom");
-		});
+		}).provide("test", LogConfig.builder().build());
 		var alerts = LogAlerts.of();
 		var appender = appender(flags, output, throwingEncoder, alerts);
 		assertEquals(expectedType, appender.getClass());
@@ -87,7 +87,7 @@ class AppenderAlertReportingTest {
 	}
 
 	private static LogEncoder encoder() {
-		return LogEncoder.of(LogFormatter.builder().message().build());
+		return LogFormatter.builder().message().encoder().build().provide("test", LogConfig.builder().build());
 	}
 
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output, LogEncoder encoder,

--- a/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
@@ -41,7 +41,11 @@ class BufferSelfShrinkTest {
 
 	@Test
 	void stringBuilderBufferShrinksAfterOversizedClear() {
-		LogEncoder encoder = LogEncoder.builder(FORMATTER).charset(StandardCharsets.UTF_8).maxBufferSize(100).build();
+		LogEncoder encoder = LogEncoder.builder(FORMATTER)
+			.charset(StandardCharsets.UTF_8)
+			.maxBufferSize(100)
+			.build()
+			.provide("test", LogConfig.builder().build());
 		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
 
 		encoder.encode(event("x".repeat(2000)), buffer);
@@ -59,7 +63,8 @@ class BufferSelfShrinkTest {
 		LogEncoder encoder = LogEncoder.builder(FORMATTER)
 			.charset(StandardCharsets.UTF_8)
 			.maxBufferSize(100_000)
-			.build();
+			.build()
+			.provide("test", LogConfig.builder().build());
 		var buffer = (StringBuilderBuffer) encoder.buffer(WriteMethod.STRING);
 
 		encoder.encode(event("small"), buffer);
@@ -83,7 +88,8 @@ class BufferSelfShrinkTest {
 		LogEncoder encoder = LogEncoder.builder(FORMATTER)
 			.charset(StandardCharsets.UTF_8)
 			.maxBufferSize(10_000)
-			.build();
+			.build()
+			.provide("test", LogConfig.builder().build());
 		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
 		var output = new CapturingOutput();
 
@@ -112,7 +118,8 @@ class BufferSelfShrinkTest {
 		LogEncoder encoder = LogEncoder.builder(FORMATTER)
 			.charset(StandardCharsets.UTF_8)
 			.maxBufferSize(100_000)
-			.build();
+			.build()
+			.provide("test", LogConfig.builder().build());
 		var buffer = (DirectByteBufferBuffer) encoder.buffer(WriteMethod.BYTE_BUFFER);
 		var output = new CapturingOutput();
 
@@ -148,7 +155,8 @@ class BufferSelfShrinkTest {
 		LogEncoder encoder = LogEncoder.builder(FORMATTER)
 			.charset(StandardCharsets.UTF_8)
 			.maxBufferSize(10_000)
-			.build();
+			.build()
+			.provide("test", LogConfig.builder().build());
 		var output = new CapturingOutput();
 		var appender = new LockThreadLocalBufferLogAppender("test", output, encoder, EnumSet.noneOf(AppenderFlag.class),
 				new ReentrantLock(), LogAlerts.of());

--- a/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
@@ -124,13 +124,26 @@ class DefaultAppenderSelectionTest {
 		assertTrue(diagnostic.contains("reentrant appender"), () -> "expected reentry diagnostic, got: " + diagnostic);
 	}
 
+	/*
+	 * Built once, at class load - not per call inside appender(...) below. Constructing a
+	 * LogConfig re-evaluates LogProperties#GLOBAL_APPENDER_REENTRANT_LOCK_PROPERTY and
+	 * resets AbstractLogAppender.forceReentrantLockAppenders as a side effect (see
+	 * LogConfig#applyGlobalAppenderReentrantLockProperty) - doing that on every
+	 * appender() call would wipe out a test's own direct override of that field before
+	 * DirectLogAppender.of gets a chance to read it.
+	 */
+	private static final LogEncoder ENCODER = LogFormatter.builder()
+		.message()
+		.encoder()
+		.build()
+		.provide("test", LogConfig.builder().build());
+
 	private static LogAppender appender(Set<AppenderFlag> flags) {
 		return appender(flags, new ListLogOutput());
 	}
 
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output) {
-		var encoder = LogEncoder.of(LogFormatter.builder().message().build());
-		return DirectLogAppender.of("test", output, encoder, flags, LogAlerts.of());
+		return DirectLogAppender.of("test", output, ENCODER, flags, LogAlerts.of());
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogEncoderRegistryTest.java
@@ -69,13 +69,25 @@ class LogEncoderRegistryTest {
 
 				@Override
 				public LogProvider<LogEncoder> provide(LogProviderRef ref) {
-					return (n, c) -> LogFormatter.builder().text("CUSTOM ").message().newline().encoder().build();
+					return (n, c) -> LogFormatter.builder()
+						.text("CUSTOM ")
+						.message()
+						.newline()
+						.encoder()
+						.build()
+						.provide(n, c);
 				}
 			};
 			config.encoderRegistry().register("custom", provider);
 			config.encoderRegistry()
 				.setEncoderForOutputType(OutputType.MEMORY,
-						(name, c) -> LogFormatter.builder().text("OUTPUT_TYPE ").message().newline().encoder().build());
+						(name, c) -> LogFormatter.builder()
+							.text("OUTPUT_TYPE ")
+							.message()
+							.newline()
+							.encoder()
+							.build()
+							.provide(name, c));
 			return true;
 		}
 

--- a/core/src/test/java/io/jstach/rainbowgum/output/ForwardingOutputTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/output/ForwardingOutputTest.java
@@ -61,7 +61,8 @@ class ForwardingOutputTest {
 	void writeBatchForwardsWhenDelegatePresentAndNoopsWhenAbsent() {
 		var delegate = new RecordingListLogOutput();
 		var event = TestLogEventFactory.of().event("hello");
-		var encoder = io.jstach.rainbowgum.LogEncoder.of(io.jstach.rainbowgum.LogFormatter.builder().message().build());
+		var config = LogConfig.builder().build();
+		var encoder = io.jstach.rainbowgum.LogFormatter.builder().message().encoder().build().provide("test", config);
 
 		assertDoesNotThrow(() -> new TestForwardingOutput(null).write(new LogEvent[] { event }, 1, encoder));
 		assertTrue(delegate.events().isEmpty());
@@ -74,7 +75,8 @@ class ForwardingOutputTest {
 	void writeBatchWithBufferForwardsWhenDelegatePresentAndNoopsWhenAbsent() {
 		var delegate = new RecordingListLogOutput();
 		var event = TestLogEventFactory.of().event("hello");
-		var encoder = io.jstach.rainbowgum.LogEncoder.of(io.jstach.rainbowgum.LogFormatter.builder().message().build());
+		var config = LogConfig.builder().build();
+		var encoder = io.jstach.rainbowgum.LogFormatter.builder().message().encoder().build().provide("test", config);
 		var buffer = encoder.buffer(delegate.bufferHints());
 
 		assertDoesNotThrow(() -> new TestForwardingOutput(null).write(new LogEvent[] { event }, 1, encoder, buffer));
@@ -91,7 +93,8 @@ class ForwardingOutputTest {
 		// StringBuilderBuffer isn't public - go through the same public
 		// LogEncoder/LogFormatter pipeline every other test in this file uses to get a
 		// populated buffer instead of constructing one directly.
-		var encoder = io.jstach.rainbowgum.LogEncoder.of(io.jstach.rainbowgum.LogFormatter.builder().message().build());
+		var config = LogConfig.builder().build();
+		var encoder = io.jstach.rainbowgum.LogFormatter.builder().message().encoder().build().provide("test", config);
 		var buffer = encoder.buffer(io.jstach.rainbowgum.LogOutput.WriteMethod.STRING);
 		encoder.encode(event, buffer);
 

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
@@ -54,8 +54,7 @@ public class JAnsiConfigurator implements RainbowGumServiceProvider.Configurator
 		 * if they want colors.
 		 */
 		var jansiFormatter = JansiLogFormatter.builder().disableAnsi(disableAnsi).build();
-		config.encoderRegistry()
-			.setEncoderForOutputType(OutputType.CONSOLE_OUT, LogEncoder.of(jansiFormatter));
+		config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, LogEncoder.of(jansiFormatter));
 	}
 
 	boolean installJansi(LogConfig config) {

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
@@ -55,7 +55,7 @@ public class JAnsiConfigurator implements RainbowGumServiceProvider.Configurator
 		 */
 		var jansiFormatter = JansiLogFormatter.builder().disableAnsi(disableAnsi).build();
 		config.encoderRegistry()
-			.setEncoderForOutputType(OutputType.CONSOLE_OUT, LogProvider.of(LogEncoder.of(jansiFormatter)));
+			.setEncoderForOutputType(OutputType.CONSOLE_OUT, LogEncoder.of(jansiFormatter));
 	}
 
 	boolean installJansi(LogConfig config) {

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -98,7 +98,7 @@ public final class PatternConfigurator implements Configurator {
 			if (maxBufferSize != null) {
 				builder.maxBufferSize(maxBufferSize);
 			}
-			return builder.build();
+			return builder.build().provide(n, config);
 		};
 	}
 


### PR DESCRIPTION
Encoders need config for alerts. This fix is to make it so the factories return the wrapped log provider versions instead.