### PR TITLE
Extract LogMetrics as a sealed type separate from LogAlerts

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAlerts.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAlerts.java
@@ -6,10 +6,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -33,26 +31,6 @@ public sealed interface LogAlerts permits DefaultLogAlerts {
 	 * Default capacity of the alert ring buffer.
 	 */
 	static final int DEFAULT_CAPACITY = 100;
-
-	/**
-	 * Counter name (see {@link #errorCounter(String, long)}) for the global count of log
-	 * events dropped without ever being written anywhere - for example an appender
-	 * dropping events on reentry. Incremented whenever a drop happens regardless of
-	 * whether that particular drop is also logged/alerted, since counting and
-	 * alerting/logging are separate concerns.
-	 */
-	static final String EVENTS_DROPPED_METRIC = "events.dropped";
-
-	/**
-	 * Counter name (see {@link #warnCounter(String, long)}) for the global count of times
-	 * a reused encoder buffer had its backing storage shrunk back down after growing past
-	 * its configured max size (see {@link LogEncoder.Buffer#isOversized()}). An
-	 * occasional trim is normal and expected once in a while, but resizing <em>often</em>
-	 * is a sign the configured max size (or the initial size) doesn't match the actual
-	 * event sizes being logged - worth watching, not erroring on, hence
-	 * {@link #warnCounter(String, long)} rather than {@link #errorCounter(String, long)}.
-	 */
-	static final String BUFFER_TRIMMED_METRIC = "buffer.trimmed";
 
 	/**
 	 * Records an alert.
@@ -84,56 +62,6 @@ public sealed interface LogAlerts permits DefaultLogAlerts {
 	}
 
 	/**
-	 * Increments a counter for something worth tracking as "this happens and it matters"
-	 * but too frequent to record as a discrete {@link #error(LogEvent) alert event} -
-	 * incrementing a counter is far cheaper than recording an event (no ring buffer
-	 * entry, no listener dispatch per call). Every {@link #error(LogEvent)} call (and
-	 * therefore the {@code error(Class, ...)} overloads too) also increments the counter
-	 * named after the event's {@link LogEvent#loggerName() logger name}, so counts stay
-	 * available even once older alerts have been evicted from the ring buffer. Read
-	 * current values back with {@link #counters()}.
-	 * <p>
-	 * This is intentionally minimal - a future dedicated metrics API is expected to take
-	 * over counters like this. Using this method now instead of hand rolling an ad hoc
-	 * counter keeps the eventual migration to one call site per counter.
-	 * @param name counter name, e.g. {@code "queue.dropped"} or a logger name.
-	 * @param increment amount to add, usually {@code 1}.
-	 */
-	public void errorCounter(String name, long increment);
-
-	/**
-	 * Like {@link #errorCounter(String, long)} but for something worth tracking yet less
-	 * significant than an error - a trend worth watching rather than something that, by
-	 * itself, indicates a problem. Kept as a separate counter namespace from
-	 * {@link #errorCounter(String, long)}: the same {@code name} passed to both is two
-	 * distinct counters, not one shared one.
-	 * @param name counter name, e.g. {@link #BUFFER_TRIMMED_METRIC}.
-	 * @param increment amount to add, usually {@code 1}.
-	 */
-	public void warnCounter(String name, long increment);
-
-	/**
-	 * A snapshot of every counter recorded via methods like
-	 * {@link #errorCounter(String, long)} and {@link #warnCounter(String, long)}.
-	 * @return immutable snapshot.
-	 */
-	public List<Counter> counters();
-
-	/**
-	 * A single named counter's current value, as returned by {@link #counters()}.
-	 *
-	 * @param name counter name, as passed to a counter method like
-	 * {@link #errorCounter(String, long)}.
-	 * @param level how much this counter matters - not a log level routing decision, just
-	 * a signal of significance, mirroring the counter method it came from (e.g.
-	 * {@link Level#ERROR} for {@link #errorCounter(String, long)}, {@link Level#WARNING}
-	 * for {@link #warnCounter(String, long)}).
-	 * @param count current value.
-	 */
-	record Counter(String name, Level level, long count) {
-	}
-
-	/**
 	 * A snapshot of the alerts currently held in the ring buffer, oldest first. Alerts
 	 * are evicted oldest first once the buffer is at {@link Stats#capacity()}.
 	 * @return immutable snapshot.
@@ -141,11 +69,10 @@ public sealed interface LogAlerts permits DefaultLogAlerts {
 	public List<LogEvent> dump();
 
 	/**
-	 * Clears the ring buffer. Does not reset {@link Stats#total()} or any counter
-	 * recorded via {@link #errorCounter(String, long)}/{@link #warnCounter(String, long)}
-	 * - like a Prometheus/Micrometer counter, these are meant to be monotonically
-	 * increasing for the life of the process; a downstream metrics system computes rate
-	 * of change rather than relying on the counter itself being reset.
+	 * Clears the ring buffer. Does not reset {@link Stats#total()} - like a
+	 * Prometheus/Micrometer counter, that is meant to be monotonically increasing for the
+	 * life of the process; a downstream metrics system computes rate of change rather
+	 * than relying on the counter itself being reset.
 	 */
 	public void clear();
 
@@ -235,10 +162,6 @@ final class DefaultLogAlerts implements LogAlerts {
 
 	private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
 
-	private final ConcurrentHashMap<String, LongAdder> errorCounters = new ConcurrentHashMap<>();
-
-	private final ConcurrentHashMap<String, LongAdder> warnCounters = new ConcurrentHashMap<>();
-
 	private final LogEventFactory eventFactory = LogEventFactory.of(DefaultLogAlerts.class.getName());
 
 	DefaultLogAlerts(int capacity) {
@@ -252,7 +175,6 @@ final class DefaultLogAlerts implements LogAlerts {
 	public void error(LogEvent event) {
 		var frozen = event.freeze();
 		total.incrementAndGet();
-		errorCounter(frozen.loggerName(), 1);
 		lock.lock();
 		try {
 			if (size < ring.length) {
@@ -282,28 +204,6 @@ final class DefaultLogAlerts implements LogAlerts {
 	public AutoCloseable addListener(Listener listener) {
 		listeners.add(listener);
 		return () -> listeners.remove(listener);
-	}
-
-	@Override
-	public void errorCounter(String name, long increment) {
-		errorCounters.computeIfAbsent(name, k -> new LongAdder()).add(increment);
-	}
-
-	@Override
-	public void warnCounter(String name, long increment) {
-		warnCounters.computeIfAbsent(name, k -> new LongAdder()).add(increment);
-	}
-
-	@Override
-	public List<Counter> counters() {
-		List<Counter> list = new ArrayList<>(errorCounters.size() + warnCounters.size());
-		for (var e : errorCounters.entrySet()) {
-			list.add(new Counter(e.getKey(), Level.ERROR, e.getValue().sum()));
-		}
-		for (var e : warnCounters.entrySet()) {
-			list.add(new Counter(e.getKey(), Level.WARNING, e.getValue().sum()));
-		}
-		return List.copyOf(list);
 	}
 
 	@Override

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -526,18 +526,19 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 	}
 
 	static DirectLogAppender of(String name, LogOutput output, LogEncoder encoder, Set<LogAppender.AppenderFlag> flags,
-			LogAlerts alerts) {
+			LogAlerts alerts, LogMetrics metrics) {
 		flags = AbstractLogAppender.guardSynchronizedFlag(flags);
 		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
-			return new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts);
+			return new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
 		}
 		if (flags.contains(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts);
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
 		}
 		if (flags.contains(AppenderFlag.LOCK_THREAD_LOCAL_BUFFER)) {
-			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts);
+			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts,
+					metrics);
 		}
-		return defaultAppender(name, output, encoder, flags, alerts);
+		return defaultAppender(name, output, encoder, flags, alerts, metrics);
 	}
 
 	/**
@@ -559,8 +560,8 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 	 * platform-thread-heavy deployments that want that edge.
 	 */
 	static DirectLogAppender defaultAppender(String name, LogOutput output, LogEncoder encoder,
-			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts) {
-		return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts);
+			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts, LogMetrics metrics) {
+		return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
 	}
 
 	// @Override
@@ -615,20 +616,20 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 	 * whether it does so via a {@link ReentrantLock} (
 	 * {@code lock.isHeldByCurrentThread()}) or a {@code synchronized} block (
 	 * {@link Thread#holdsLock(Object)}) - callers pass in whichever check applies to
-	 * them. Whenever this returns {@code true}, {@link LogAlerts#EVENTS_DROPPED_METRIC}
+	 * them. Whenever this returns {@code true}, {@link LogMetrics#EVENTS_DROPPED_METRIC}
 	 * is incremented by {@code count} regardless of whether
 	 * {@link AppenderFlag#REENTRY_LOG} is set - counting and logging/alerting are
 	 * separate concerns, so the count still happens even when the drop itself is silent.
 	 * @param reentrant whether the current thread already holds this appender's
 	 * lock/monitor.
 	 * @param flags the appender's flags.
-	 * @param alerts where to record {@link LogAlerts#EVENTS_DROPPED_METRIC} if events are
-	 * dropped.
+	 * @param metrics where to record {@link LogMetrics#EVENTS_DROPPED_METRIC} if events
+	 * are dropped.
 	 * @param count number of events that would be dropped - {@code 1} for a single event
 	 * append, or the batch size for a batch append.
 	 * @return {@code true} if the caller should drop the event(s) without appending.
 	 */
-	static boolean shouldDropForReentry(boolean reentrant, Set<LogAppender.AppenderFlag> flags, LogAlerts alerts,
+	static boolean shouldDropForReentry(boolean reentrant, Set<LogAppender.AppenderFlag> flags, LogMetrics metrics,
 			int count) {
 		if (!reentrant) {
 			return false;
@@ -636,11 +637,11 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 		if (flags.contains(LogAppender.AppenderFlag.REENTRY_LOG)) {
 			Exception exception = new Exception("reentrant appender");
 			MetaLog.error(LogAppender.class, exception);
-			alerts.errorCounter(LogAlerts.EVENTS_DROPPED_METRIC, count);
+			metrics.errorCounter(LogMetrics.EVENTS_DROPPED_METRIC, count);
 			return true;
 		}
 		if (flags.contains(LogAppender.AppenderFlag.REENTRY_DROP)) {
-			alerts.errorCounter(LogAlerts.EVENTS_DROPPED_METRIC, count);
+			metrics.errorCounter(LogMetrics.EVENTS_DROPPED_METRIC, count);
 			return true;
 		}
 		return false;
@@ -672,14 +673,20 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 	protected final LogAlerts alerts;
 
 	/**
+	 * metrics for recording counters like {@link LogMetrics#EVENTS_DROPPED_METRIC}.
+	 */
+	protected final LogMetrics metrics;
+
+	/**
 	 * Creates an appender from an output and encoder.
 	 * @param output set the output field and will be started and closed with the
 	 * appender.
 	 * @param encoder set the encoder field.
 	 * @param alerts alerts for reporting encode/write failures.
+	 * @param metrics metrics for recording counters.
 	 */
 	protected AbstractLogAppender(String name, LogOutput output, LogEncoder encoder,
-			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts) {
+			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts, LogMetrics metrics) {
 		super();
 		this.name = name;
 		this.output = output;
@@ -687,6 +694,7 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 		this.flags = flags;
 		this.immediateFlush = !flags.contains(LogAppender.AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
 		this.alerts = alerts;
+		this.metrics = metrics;
 	}
 
 	@Override
@@ -800,8 +808,8 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 	protected final ReentrantLock lock;
 
 	public LockLogAppender(String name, LogOutput output, LogEncoder encoder, Set<LogAppender.AppenderFlag> flags,
-			ReentrantLock lock, LogAlerts alerts) {
-		super(name, output, encoder, flags, alerts);
+			ReentrantLock lock, LogAlerts alerts, LogMetrics metrics) {
+		super(name, output, encoder, flags, alerts, metrics);
 		this.lock = lock;
 	}
 
@@ -842,15 +850,15 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 		flags.addAll(this.flags);
 		flags = guardSynchronizedFlag(flags);
 		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
-			return new ReuseBufferLogAppender(name, output, encoder, flags, lock, alerts);
+			return new ReuseBufferLogAppender(name, output, encoder, flags, lock, alerts, metrics);
 		}
 		if (flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts);
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
 		}
 		if (flags.contains(LogAppender.AppenderFlag.LOCK_THREAD_LOCAL_BUFFER)) {
-			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, lock, alerts);
+			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, lock, alerts, metrics);
 		}
-		return DirectLogAppender.defaultAppender(name, output, encoder, flags, alerts);
+		return DirectLogAppender.defaultAppender(name, output, encoder, flags, alerts, metrics);
 	}
 
 }
@@ -863,14 +871,14 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 	private final LogEncoder.Buffer buffer;
 
 	ReuseBufferLogAppender(String name, LogOutput output, LogEncoder encoder, Set<LogAppender.AppenderFlag> flags,
-			ReentrantLock lock, LogAlerts alerts) {
-		super(name, output, encoder, flags, lock, alerts);
+			ReentrantLock lock, LogAlerts alerts, LogMetrics metrics) {
+		super(name, output, encoder, flags, lock, alerts, metrics);
 		this.buffer = encoder.buffer(output.bufferHints());
 	}
 
 	@Override
 	public final void append(LogEvent event) {
-		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, alerts, 1)) {
+		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, metrics, 1)) {
 			return;
 		}
 		try {
@@ -894,7 +902,7 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 
 	@Override
 	public void append(LogEvent[] events, int count) {
-		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, alerts, count)) {
+		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, metrics, count)) {
 			return;
 		}
 		try {
@@ -951,8 +959,8 @@ final class LockThreadLocalBufferLogAppender extends LockLogAppender implements 
 	private final ThreadLocal<LogEncoder.Buffer> bufferThreadLocal;
 
 	LockThreadLocalBufferLogAppender(String name, LogOutput output, LogEncoder encoder,
-			Set<LogAppender.AppenderFlag> flags, ReentrantLock lock, LogAlerts alerts) {
-		super(name, output, encoder, flags, lock, alerts);
+			Set<LogAppender.AppenderFlag> flags, ReentrantLock lock, LogAlerts alerts, LogMetrics metrics) {
+		super(name, output, encoder, flags, lock, alerts, metrics);
 		this.bufferThreadLocal = ThreadLocal.withInitial(() -> encoder.buffer(output.bufferHints()));
 	}
 
@@ -970,7 +978,7 @@ final class LockThreadLocalBufferLogAppender extends LockLogAppender implements 
 	}
 
 	private void writeLocked(LogEvent event, LogEncoder.Buffer buffer) {
-		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, alerts, 1)) {
+		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, metrics, 1)) {
 			return;
 		}
 		lock.lock();
@@ -987,7 +995,7 @@ final class LockThreadLocalBufferLogAppender extends LockLogAppender implements 
 
 	@Override
 	public void append(LogEvent[] events, int count) {
-		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, alerts, count)) {
+		if (shouldDropForReentry(lock.isHeldByCurrentThread(), flags, metrics, count)) {
 			return;
 		}
 		try {
@@ -1026,8 +1034,8 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 	private final ThreadLocal<LogEncoder.Buffer> bufferThreadLocal;
 
 	SynchronizedThreadLocalBufferLogAppender(String name, LogOutput output, LogEncoder encoder,
-			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts) {
-		super(name, output, encoder, flags, alerts);
+			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts, LogMetrics metrics) {
+		super(name, output, encoder, flags, alerts, metrics);
 		this.bufferThreadLocal = ThreadLocal.withInitial(() -> encoder.buffer(output.bufferHints()));
 	}
 
@@ -1045,7 +1053,7 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 	}
 
 	private void writeSynchronized(LogEvent event, LogEncoder.Buffer buffer) {
-		if (shouldDropForReentry(Thread.holdsLock(monitor), flags, alerts, 1)) {
+		if (shouldDropForReentry(Thread.holdsLock(monitor), flags, metrics, 1)) {
 			return;
 		}
 		synchronized (monitor) {
@@ -1058,7 +1066,7 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 
 	@Override
 	public void append(LogEvent[] events, int count) {
-		if (shouldDropForReentry(Thread.holdsLock(monitor), flags, alerts, count)) {
+		if (shouldDropForReentry(Thread.holdsLock(monitor), flags, metrics, count)) {
 			return;
 		}
 		try {
@@ -1105,15 +1113,16 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 		flags.addAll(this.flags);
 		flags = guardSynchronizedFlag(flags);
 		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
-			return new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts);
+			return new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
 		}
 		if (flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts);
+			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
 		}
 		if (flags.contains(LogAppender.AppenderFlag.LOCK_THREAD_LOCAL_BUFFER)) {
-			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts);
+			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts,
+					metrics);
 		}
-		return DirectLogAppender.defaultAppender(name, output, encoder, flags, alerts);
+		return DirectLogAppender.defaultAppender(name, output, encoder, flags, alerts, metrics);
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -209,7 +209,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			flags = resolveFlags(config, name);
 		}
 
-		return DirectLogAppender.of(name, output, encoder, flags, config.alerts());
+		return DirectLogAppender.of(name, output, encoder, flags, config.alerts(), config.metrics());
 	}
 
 	private static PropertyValue<LogEncoder> resolveEncoder(String name, LogConfig config, LogOutput output,

--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -88,6 +88,13 @@ public sealed interface LogConfig extends LogProperty.PropertySupport {
 	public LogAlerts alerts();
 
 	/**
+	 * Metrics about the logging system itself (as opposed to application logging routed
+	 * through the {@link LogRouter}).
+	 * @return metrics.
+	 */
+	public LogMetrics metrics();
+
+	/**
 	 * Mixin for config support.
 	 */
 	interface ConfigSupport extends LogProperty.PropertySupport {
@@ -428,6 +435,8 @@ final class DefaultLogConfig implements LogConfig {
 
 	private final LogAlerts alerts;
 
+	private final LogMetrics metrics;
+
 	DefaultLogConfig(ServiceRegistry registry, LogProperties properties, LevelConfig levelResolver) {
 		super();
 		this.registry = registry;
@@ -444,6 +453,8 @@ final class DefaultLogConfig implements LogConfig {
 		this.encoderRegistry = DefaultEncoderRegistry.of();
 		this.publisherRegistry = DefaultPublisherRegistry.of();
 		this.alerts = LogAlerts.of();
+		this.metrics = LogMetrics.of();
+		this.alerts.addListener(event -> this.metrics.errorCounter(event.loggerName(), 1));
 	}
 
 	/*
@@ -515,6 +526,11 @@ final class DefaultLogConfig implements LogConfig {
 	@Override
 	public LogAlerts alerts() {
 		return this.alerts;
+	}
+
+	@Override
+	public LogMetrics metrics() {
+		return this.metrics;
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoder.java
@@ -213,7 +213,7 @@ public interface LogEncoder {
 			var resolvedCharset = c;
 			var resolvedContentType = ct;
 			return (n, config) -> new FormatterEncoder(formatter, resolvedCharset, resolvedContentType, maxBufferSize,
-					initialBufferSize, config.alerts());
+					initialBufferSize, config.metrics());
 		}
 
 	}
@@ -446,28 +446,28 @@ final class StringBuilderBuffer implements TextBuffer {
 
 	private final int maxBufferSize;
 
-	private final LogAlerts alerts;
+	private final LogMetrics metrics;
 
 	/**
 	 * Creates a StringBuilder based buffer that reports {@link #isOversized()} once
 	 * {@code sb}'s capacity exceeds {@code maxBufferSize}, reporting
-	 * {@link LogAlerts#BUFFER_TRIMMED_METRIC} to {@code alerts} each time
+	 * {@link LogMetrics#BUFFER_TRIMMED_METRIC} to {@code metrics} each time
 	 * {@link #clear()} actually shrinks the backing storage.
 	 * @param sb string builder.
 	 * @param maxBufferSize a negative value disables {@link #isOversized()} entirely
 	 * (always {@code false}).
-	 * @param alerts where to report {@link LogAlerts#BUFFER_TRIMMED_METRIC}.
+	 * @param metrics where to report {@link LogMetrics#BUFFER_TRIMMED_METRIC}.
 	 * @return buffer.
 	 */
-	public static StringBuilderBuffer of(StringBuilder sb, int maxBufferSize, LogAlerts alerts) {
-		return new StringBuilderBuffer(sb, maxBufferSize, alerts);
+	public static StringBuilderBuffer of(StringBuilder sb, int maxBufferSize, LogMetrics metrics) {
+		return new StringBuilderBuffer(sb, maxBufferSize, metrics);
 	}
 
-	private StringBuilderBuffer(StringBuilder stringBuilder, int maxBufferSize, LogAlerts alerts) {
+	private StringBuilderBuffer(StringBuilder stringBuilder, int maxBufferSize, LogMetrics metrics) {
 		super();
 		this.stringBuilder = stringBuilder;
 		this.maxBufferSize = maxBufferSize;
-		this.alerts = alerts;
+		this.metrics = metrics;
 	}
 
 	@Override
@@ -484,7 +484,7 @@ final class StringBuilderBuffer implements TextBuffer {
 		// fine through the public final field above).
 		if (isOversized()) {
 			stringBuilder.trimToSize();
-			alerts.warnCounter(LogAlerts.BUFFER_TRIMMED_METRIC, 1);
+			metrics.warnCounter(LogMetrics.BUFFER_TRIMMED_METRIC, 1);
 		}
 	}
 
@@ -555,7 +555,7 @@ final class DirectByteBufferBuffer implements TextBuffer {
 
 	private final int initialByteCapacity;
 
-	private final LogAlerts alerts;
+	private final LogMetrics metrics;
 
 	private ByteBuffer byteBuffer;
 
@@ -581,11 +581,11 @@ final class DirectByteBufferBuffer implements TextBuffer {
 	 * {@link #isOversized()} unconditionally {@code true} from the very first event -
 	 * {@code maxBufferSize} should normally be set well above whatever initial capacity
 	 * is in play.
-	 * @param alerts where to report {@link LogAlerts#BUFFER_TRIMMED_METRIC} each time
+	 * @param metrics where to report {@link LogMetrics#BUFFER_TRIMMED_METRIC} each time
 	 * {@link #clear()} actually shrinks the backing storage.
 	 */
 	DirectByteBufferBuffer(LogOutput.WriteMethod writeMethod, int initialByteCapacity, Charset charset,
-			LogOutput.ContentType contentType, int maxBufferSize, LogAlerts alerts) {
+			LogOutput.ContentType contentType, int maxBufferSize, LogMetrics metrics) {
 		this.writeMethod = writeMethod;
 		this.byteBuffer = ByteBuffer.allocate(initialByteCapacity);
 		this.charsetEncoder = charset.newEncoder()
@@ -594,7 +594,7 @@ final class DirectByteBufferBuffer implements TextBuffer {
 		this.contentType = contentType;
 		this.maxBufferSize = maxBufferSize;
 		this.initialByteCapacity = initialByteCapacity;
-		this.alerts = alerts;
+		this.metrics = metrics;
 	}
 
 	/**
@@ -663,7 +663,7 @@ final class DirectByteBufferBuffer implements TextBuffer {
 		if (isOversized()) {
 			stringBuilder.trimToSize();
 			byteBuffer = ByteBuffer.allocate(initialByteCapacity);
-			alerts.warnCounter(LogAlerts.BUFFER_TRIMMED_METRIC, 1);
+			metrics.warnCounter(LogMetrics.BUFFER_TRIMMED_METRIC, 1);
 		}
 	}
 
@@ -690,25 +690,25 @@ final class FormatterEncoder implements LogEncoder {
 
 	private final int initialBufferSize;
 
-	private final LogAlerts alerts;
+	private final LogMetrics metrics;
 
 	FormatterEncoder(LogFormatter formatter, Charset charset, ContentType contentType, int maxBufferSize,
-			int initialBufferSize, LogAlerts alerts) {
+			int initialBufferSize, LogMetrics metrics) {
 		super();
 		this.formatter = formatter;
 		this.charset = charset;
 		this.contentType = contentType;
 		this.maxBufferSize = maxBufferSize;
 		this.initialBufferSize = initialBufferSize;
-		this.alerts = alerts;
+		this.metrics = metrics;
 	}
 
 	@Override
 	public Buffer buffer(BufferHints hints) {
 		return switch (hints.writeMethod()) {
-			case STRING -> StringBuilderBuffer.of(new StringBuilder(initialBufferSize), maxBufferSize, alerts);
+			case STRING -> StringBuilderBuffer.of(new StringBuilder(initialBufferSize), maxBufferSize, metrics);
 			case BYTES, BYTE_BUFFER -> new DirectByteBufferBuffer(hints.writeMethod(), initialBufferSize, charset,
-					contentType, maxBufferSize, alerts);
+					contentType, maxBufferSize, metrics);
 		};
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogMetrics.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogMetrics.java
@@ -1,0 +1,128 @@
+package io.jstach.rainbowgum;
+
+import java.lang.System.Logger.Level;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Metrics are cheap, numeric counters about the logging system itself - for example how
+ * many events an appender has dropped, or how often a reused encoder buffer had to shrink
+ * itself back down. Unlike {@link LogAlerts}, which records discrete events (each with a
+ * message/throwable, kept in a bounded ring buffer), metrics are just running totals: no
+ * per-call allocation, no ring buffer entry, no listener dispatch.
+ * <p>
+ * An instance is available from every {@link LogConfig#metrics()}. Components that are
+ * {@linkplain LogProvider provided} config, or that are
+ * {@linkplain LogLifecycle#start( LogConfig) started} with config, should prefer
+ * capturing {@code config.metrics()} over reaching for global state.
+ * <p>
+ * Deliberately a separate type from {@link LogAlerts} rather than more methods on it -
+ * the two are meant to be independently replaceable (e.g. a future Micrometer-backed
+ * {@code LogMetrics} without needing to also replace how alerts are recorded).
+ *
+ * @see LogConfig#metrics()
+ */
+public sealed interface LogMetrics permits DefaultLogMetrics {
+
+	/**
+	 * Counter name for the global count of log events dropped without ever being written
+	 * anywhere - for example an appender dropping events on reentry. Incremented whenever
+	 * a drop happens regardless of whether that particular drop is also logged/alerted,
+	 * since counting and alerting/logging are separate concerns.
+	 */
+	static final String EVENTS_DROPPED_METRIC = "events.dropped";
+
+	/**
+	 * Counter name for the global count of times a reused encoder buffer had its backing
+	 * storage shrunk back down after growing past its configured max size (see
+	 * {@link LogEncoder.Buffer#isOversized()}). An occasional trim is normal and expected
+	 * once in a while, but resizing <em>often</em> is a sign the configured max size (or
+	 * the initial size) doesn't match the actual event sizes being logged - worth
+	 * watching, not erroring on, hence {@link #warnCounter(String, long)} rather than
+	 * {@link #errorCounter(String, long)}.
+	 */
+	static final String BUFFER_TRIMMED_METRIC = "buffer.trimmed";
+
+	/**
+	 * Increments a counter for something worth tracking as "this happens and it matters".
+	 * @param name counter name, e.g. {@link #EVENTS_DROPPED_METRIC} or a logger name.
+	 * @param increment amount to add, usually {@code 1}.
+	 */
+	public void errorCounter(String name, long increment);
+
+	/**
+	 * Like {@link #errorCounter(String, long)} but for something worth tracking yet less
+	 * significant than an error - a trend worth watching rather than something that, by
+	 * itself, indicates a problem. Kept as a separate counter namespace from
+	 * {@link #errorCounter(String, long)}: the same {@code name} passed to both is two
+	 * distinct counters, not one shared one.
+	 * @param name counter name, e.g. {@link #BUFFER_TRIMMED_METRIC}.
+	 * @param increment amount to add, usually {@code 1}.
+	 */
+	public void warnCounter(String name, long increment);
+
+	/**
+	 * A snapshot of every counter recorded via {@link #errorCounter(String, long)} and
+	 * {@link #warnCounter(String, long)}. Counters are monotonically increasing for the
+	 * life of the process, like a Prometheus/Micrometer counter - there is no reset
+	 * method; a downstream metrics system computes rate of change rather than relying on
+	 * the counter itself being reset.
+	 * @return immutable snapshot.
+	 */
+	public List<Counter> counters();
+
+	/**
+	 * A single named counter's current value, as returned by {@link #counters()}.
+	 *
+	 * @param name counter name, as passed to a counter method like
+	 * {@link #errorCounter(String, long)}.
+	 * @param level how much this counter matters - not a log level routing decision, just
+	 * a signal of significance, mirroring the counter method it came from (e.g.
+	 * {@link Level#ERROR} for {@link #errorCounter(String, long)}, {@link Level#WARNING}
+	 * for {@link #warnCounter(String, long)}).
+	 * @param count current value.
+	 */
+	record Counter(String name, Level level, long count) {
+	}
+
+	/**
+	 * Creates a new, empty metrics instance.
+	 * @return metrics.
+	 */
+	public static LogMetrics of() {
+		return new DefaultLogMetrics();
+	}
+
+}
+
+final class DefaultLogMetrics implements LogMetrics {
+
+	private final ConcurrentHashMap<String, LongAdder> errorCounters = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, LongAdder> warnCounters = new ConcurrentHashMap<>();
+
+	@Override
+	public void errorCounter(String name, long increment) {
+		errorCounters.computeIfAbsent(name, k -> new LongAdder()).add(increment);
+	}
+
+	@Override
+	public void warnCounter(String name, long increment) {
+		warnCounters.computeIfAbsent(name, k -> new LongAdder()).add(increment);
+	}
+
+	@Override
+	public List<Counter> counters() {
+		List<Counter> list = new ArrayList<>(errorCounters.size() + warnCounters.size());
+		for (var e : errorCounters.entrySet()) {
+			list.add(new Counter(e.getKey(), Level.ERROR, e.getValue().sum()));
+		}
+		for (var e : warnCounters.entrySet()) {
+			list.add(new Counter(e.getKey(), Level.WARNING, e.getValue().sum()));
+		}
+		return List.copyOf(list);
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
@@ -92,7 +92,7 @@ class AppenderAlertReportingTest {
 
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output, LogEncoder encoder,
 			LogAlerts alerts) {
-		return DirectLogAppender.of("test", output, encoder, flags, alerts);
+		return DirectLogAppender.of("test", output, encoder, flags, alerts, LogMetrics.of());
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
@@ -140,11 +140,11 @@ class AppenderAsModeReentryTest {
 		// The dropped-events counter is incremented for both flags - counting is
 		// separate from (and happens regardless of) whether the drop is also logged via
 		// REENTRY_LOG.
-		long dropped = config.alerts()
+		long dropped = config.metrics()
 			.counters()
 			.stream()
-			.filter(c -> c.name().equals(LogAlerts.EVENTS_DROPPED_METRIC))
-			.mapToLong(LogAlerts.Counter::count)
+			.filter(c -> c.name().equals(LogMetrics.EVENTS_DROPPED_METRIC))
+			.mapToLong(LogMetrics.Counter::count)
 			.sum();
 		assertEquals(1, dropped, () -> "expected exactly one dropped event for flag " + reentryFlag);
 

--- a/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/BufferSelfShrinkTest.java
@@ -29,8 +29,8 @@ import io.jstach.rainbowgum.LogOutput.WriteMethod;
  * These tests assert actual capacity() values before/after clear(), not just that
  * isOversized() flips back to false, to prove the backing storage genuinely shrank rather
  * than just re-deriving the same predicate under test. They also assert
- * LogAlerts.BUFFER_TRIMMED_METRIC via the LogConfig each encoder is provided from - the
- * encoder captures that LogConfig's alerts once at provide(...) time, so the same
+ * LogMetrics.BUFFER_TRIMMED_METRIC via the LogConfig each encoder is provided from - the
+ * encoder captures that LogConfig's metrics once at provide(...) time, so the same
  * LogConfig used to provide the encoder is what reads the counter back.
  */
 class BufferSelfShrinkTest {
@@ -43,11 +43,11 @@ class BufferSelfShrinkTest {
 	}
 
 	private static long trimmedCount(LogConfig config) {
-		return config.alerts()
+		return config.metrics()
 			.counters()
 			.stream()
-			.filter(c -> c.name().equals(LogAlerts.BUFFER_TRIMMED_METRIC))
-			.mapToLong(LogAlerts.Counter::count)
+			.filter(c -> c.name().equals(LogMetrics.BUFFER_TRIMMED_METRIC))
+			.mapToLong(LogMetrics.Counter::count)
 			.sum();
 	}
 
@@ -73,7 +73,7 @@ class BufferSelfShrinkTest {
 
 		assertTrue(buffer.stringBuilder.capacity() < grownCapacity,
 				"clear() must shrink the backing StringBuilder back down once oversized");
-		assertEquals(1, trimmedCount(config), "a shrink must report LogAlerts.BUFFER_TRIMMED_METRIC");
+		assertEquals(1, trimmedCount(config), "a shrink must report LogMetrics.BUFFER_TRIMMED_METRIC");
 	}
 
 	@Test
@@ -125,7 +125,7 @@ class BufferSelfShrinkTest {
 
 		assertTrue(buffer.stringBuilder.capacity() < grownStringCapacity,
 				"clear() must shrink the backing StringBuilder back down once oversized");
-		assertEquals(1, trimmedCount(config), "a shrink must report LogAlerts.BUFFER_TRIMMED_METRIC");
+		assertEquals(1, trimmedCount(config), "a shrink must report LogMetrics.BUFFER_TRIMMED_METRIC");
 
 		// Encode a small event so encodeToByteBuffer() doesn't need to regrow the
 		// now-shrunk ByteBuffer, then drain again to observe its new capacity.
@@ -184,7 +184,7 @@ class BufferSelfShrinkTest {
 			.provide("test", config);
 		var output = new CapturingOutput();
 		var appender = new LockThreadLocalBufferLogAppender("test", output, encoder, EnumSet.noneOf(AppenderFlag.class),
-				new ReentrantLock(), config.alerts());
+				new ReentrantLock(), config.alerts(), config.metrics());
 
 		appender.append(new LogEvent[] { event("x".repeat(20_000)), event("small") }, 2);
 

--- a/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
@@ -143,7 +143,7 @@ class DefaultAppenderSelectionTest {
 	}
 
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output) {
-		return DirectLogAppender.of("test", output, ENCODER, flags, LogAlerts.of());
+		return DirectLogAppender.of("test", output, ENCODER, flags, LogAlerts.of(), LogMetrics.of());
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogAlertsTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAlertsTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -158,30 +157,6 @@ class LogAlertsTest {
 		String reported = outputStream.toString(StandardCharsets.UTF_8).split("\n")[0];
 		assertTrue(reported.contains("LogAlerts.Listener threw"),
 				() -> "expected listener failure to be reported, got: " + reported);
-	}
-
-	@Test
-	void errorCounterAccumulatesByName() {
-		var alerts = LogAlerts.of();
-		alerts.errorCounter("queue.dropped", 1);
-		alerts.errorCounter("queue.dropped", 2);
-		alerts.errorCounter("queue.overflow", 1);
-
-		var counters = alerts.counters();
-		assertEquals(2, counters.size());
-		assertTrue(counters.contains(new LogAlerts.Counter("queue.dropped", Level.ERROR, 3)));
-		assertTrue(counters.contains(new LogAlerts.Counter("queue.overflow", Level.ERROR, 1)));
-	}
-
-	@Test
-	void errorAlsoIncrementsACounterNamedAfterTheLoggerName() {
-		var alerts = LogAlerts.of();
-		alerts.error(LogAlertsTest.class, "first", new RuntimeException());
-		alerts.error(LogAlertsTest.class, "second", new RuntimeException());
-
-		var counters = alerts.counters();
-		assertEquals(1, counters.size());
-		assertEquals(new LogAlerts.Counter(LogAlertsTest.class.getName(), Level.ERROR, 2), counters.get(0));
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -107,11 +107,11 @@ class LogAppenderFlagTest {
 		testAppender.append(TestLogEventFactory.of().event("original"));
 
 		assertEquals(List.of("original"), output.events().stream().map(e -> e.getKey().message()).toList());
-		long dropped = config.alerts()
+		long dropped = config.metrics()
 			.counters()
 			.stream()
-			.filter(c -> c.name().equals(LogAlerts.EVENTS_DROPPED_METRIC))
-			.mapToLong(LogAlerts.Counter::count)
+			.filter(c -> c.name().equals(LogMetrics.EVENTS_DROPPED_METRIC))
+			.mapToLong(LogMetrics.Counter::count)
 			.sum();
 		assertEquals(3, dropped);
 	}

--- a/core/src/test/java/io/jstach/rainbowgum/LogConfigTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogConfigTest.java
@@ -22,4 +22,15 @@ class LogConfigTest {
 		assertEquals(Level.DEBUG, actual);
 	}
 
+	@Test
+	void alertsErrorAlsoIncrementsAMetricsCounterNamedAfterTheLoggerName() {
+		var config = LogConfig.builder().build();
+		config.alerts().error(LogConfigTest.class, "first", new RuntimeException());
+		config.alerts().error(LogConfigTest.class, "second", new RuntimeException());
+
+		var counters = config.metrics().counters();
+		assertEquals(1, counters.size());
+		assertEquals(new LogMetrics.Counter(LogConfigTest.class.getName(), Level.ERROR, 2), counters.get(0));
+	}
+
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogMetricsTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogMetricsTest.java
@@ -1,0 +1,37 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger.Level;
+
+import org.junit.jupiter.api.Test;
+
+class LogMetricsTest {
+
+	@Test
+	void errorCounterAccumulatesByName() {
+		var metrics = LogMetrics.of();
+		metrics.errorCounter("queue.dropped", 1);
+		metrics.errorCounter("queue.dropped", 2);
+		metrics.errorCounter("queue.overflow", 1);
+
+		var counters = metrics.counters();
+		assertEquals(2, counters.size());
+		assertTrue(counters.contains(new LogMetrics.Counter("queue.dropped", Level.ERROR, 3)));
+		assertTrue(counters.contains(new LogMetrics.Counter("queue.overflow", Level.ERROR, 1)));
+	}
+
+	@Test
+	void warnCounterAccumulatesByNameSeparatelyFromErrorCounter() {
+		var metrics = LogMetrics.of();
+		metrics.errorCounter("buffer.trimmed", 1);
+		metrics.warnCounter("buffer.trimmed", 2);
+
+		var counters = metrics.counters();
+		assertEquals(2, counters.size());
+		assertTrue(counters.contains(new LogMetrics.Counter("buffer.trimmed", Level.ERROR, 1)));
+		assertTrue(counters.contains(new LogMetrics.Counter("buffer.trimmed", Level.WARNING, 2)));
+	}
+
+}


### PR DESCRIPTION
Counters (errorCounter/warnCounter/counters()) move off LogAlerts onto a new LogMetrics, reachable via LogConfig#metrics(). Alerts stay event-focused (ring buffer + listeners); metrics stay cheap counters
- the two are meant to be independently replaceable later (e.g. a Micrometer-backed LogMetrics without touching how alerts work). LogAlerts.error(...) still bumps a per-logger-name error counter, now via DefaultLogConfig wiring an alerts listener into metrics rather than a hard dependency between the two.

Both LogAlerts and LogMetrics stay sealed for now - no custom implementations until something actually needs one.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5