### PR TITLE
Add rainbowgum-spring-boot4-actuator: bridge LogMetrics to Micrometer

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -27,5 +27,6 @@
     <module>rainbowgum-spring-boot3-starter</module>
     <module>rainbowgum-spring-boot4</module>
     <module>rainbowgum-spring-boot4-starter</module>
+    <module>rainbowgum-spring-boot4-actuator</module>
   </modules>
 </project>

--- a/spring/rainbowgum-spring-boot4-actuator/pom.xml
+++ b/spring/rainbowgum-spring-boot4-actuator/pom.xml
@@ -1,0 +1,88 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach.rainbowgum</groupId>
+    <artifactId>rainbowgum-spring-parent</artifactId>
+    <version>0.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>rainbowgum-spring-boot4-actuator</artifactId>
+  <name>rainbowgum-spring-boot4-actuator</name>
+  <properties>
+    <!--
+      Deliberately self-contained (not inherited from rainbowgum-spring-parent):
+      rainbowgum-spring-boot3 and rainbowgum-spring-boot4 (and their satellite modules)
+      each pin their own Spring Boot major version and must never share a
+      dependencyManagement import.
+    -->
+    <spring-boot.version>4.1.0</spring-boot.version>
+    <doc.resources>../../</doc.resources>
+    <parent.root>${basedir}/../..</parent.root>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!--
+            See rainbowgum-spring-boot4's module-info for why the module name is
+            suffixed with the Spring Boot major version while the packages are not.
+          -->
+          <compilerArgs combine.children="append">
+            <arg>-Xlint:-module</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-core</artifactId>
+    </dependency>
+    <!--
+      spring-boot-autoconfigure is where @AutoConfiguration/@ConditionalOnClass
+      themselves live; spring-boot-micrometer-metrics does not re-export it (it depends
+      on it as `provided`, non-transitive), so both are needed explicitly even though
+      only spring-boot-micrometer-metrics is used directly by name in this module's code.
+    -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <!--
+      spring-boot-micrometer-metrics is the module Spring Boot itself uses for its own
+      logging binders (LogbackMetricsAutoConfiguration, Log4J2MetricsAutoConfiguration -
+      the direct precedent for this class), which lets @AutoConfiguration#after order us
+      the same way they order themselves, after
+      MetricsAutoConfiguration/CompositeMeterRegistryAutoConfiguration. Real consumer
+      applications bring this in via spring-boot-starter-micrometer-metrics (the Spring
+      Boot 4 starter - metrics moved out of spring-boot-starter-actuator into its own
+      starter in Boot 4); depending on it here (rather than the app supplying it) is what
+      this whole module is for, mirroring how micrometer-core below is also a hard,
+      non-optional dependency - opting into rainbowgum-spring-boot4-actuator at all is
+      already the opt in.
+    -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-micrometer-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMeterBinder.java
+++ b/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMeterBinder.java
@@ -1,8 +1,7 @@
 package io.jstach.rainbowgum.spring.boot4.actuator;
 
-import java.lang.System.Logger.Level;
-
 import io.jstach.rainbowgum.LogMetrics;
+import io.jstach.rainbowgum.LogMetrics.StandardMetric;
 import io.jstach.rainbowgum.RainbowGum;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -16,15 +15,16 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * rather than a push style {@link io.micrometer.core.instrument.Counter} that expects
  * Micrometer itself to own the increments.
  * <p>
- * Only binds the small, fixed set of well known counter names -
- * {@link LogMetrics#EVENTS_DROPPED_METRIC} and {@link LogMetrics#BUFFER_TRIMMED_METRIC} -
+ * Binds every {@link StandardMetric} by looping over {@link StandardMetric#values()},
  * <strong>not</strong> the per logger name counters that {@link LogMetrics} also
  * accumulates as a side effect of {@code LogAlerts#error(LogEvent)}. Logger names are
  * effectively unbounded (arbitrary class/category names, chosen by application code), so
  * turning each one into its own Micrometer meter would be an unbounded cardinality source
  * - exactly what Micrometer's own naming guidance warns against. Reporting that per
  * logger detail is left to a future, explicitly opt in mechanism rather than bound
- * automatically here.
+ * automatically here. Looping over {@link StandardMetric#values()} rather than binding
+ * each constant by hand also means a future new {@link StandardMetric} constant is bound
+ * here automatically, with no change needed in this class.
  */
 final class RainbowGumMeterBinder implements MeterBinder {
 
@@ -40,19 +40,20 @@ final class RainbowGumMeterBinder implements MeterBinder {
 			return;
 		}
 		var metrics = gum.config().metrics();
-		bind(registry, metrics, LogMetrics.EVENTS_DROPPED_METRIC, Level.ERROR);
-		bind(registry, metrics, LogMetrics.BUFFER_TRIMMED_METRIC, Level.WARNING);
+		for (var metric : StandardMetric.values()) {
+			bind(registry, metrics, metric);
+		}
 	}
 
-	private static void bind(MeterRegistry registry, LogMetrics metrics, String name, Level level) {
-		FunctionCounter.builder(METRIC_PREFIX + name, metrics, m -> currentValue(m, name, level))
-			.tag("level", level.toString())
+	private static void bind(MeterRegistry registry, LogMetrics metrics, StandardMetric metric) {
+		FunctionCounter.builder(METRIC_PREFIX + metric.metricName(), metrics, m -> currentValue(m, metric))
+			.tag("level", metric.level().toString())
 			.register(registry);
 	}
 
-	private static long currentValue(LogMetrics metrics, String name, Level level) {
+	private static long currentValue(LogMetrics metrics, StandardMetric metric) {
 		for (var counter : metrics.counters()) {
-			if (counter.name().equals(name) && counter.level() == level) {
+			if (counter.name().equals(metric.metricName()) && counter.level() == metric.level()) {
 				return counter.count();
 			}
 		}

--- a/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMeterBinder.java
+++ b/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMeterBinder.java
@@ -1,0 +1,62 @@
+package io.jstach.rainbowgum.spring.boot4.actuator;
+
+import java.lang.System.Logger.Level;
+
+import io.jstach.rainbowgum.LogMetrics;
+import io.jstach.rainbowgum.RainbowGum;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * Bridges RainbowGum's {@link LogMetrics} counters to Micrometer as
+ * {@link FunctionCounter}s - a pull based counter backed by a supplier, matching how
+ * RainbowGum itself already owns and accumulates these values (see
+ * {@link LogMetrics#errorCounter(String, long)}/{@link LogMetrics#warnCounter(String, long)})
+ * rather than a push style {@link io.micrometer.core.instrument.Counter} that expects
+ * Micrometer itself to own the increments.
+ * <p>
+ * Only binds the small, fixed set of well known counter names -
+ * {@link LogMetrics#EVENTS_DROPPED_METRIC} and {@link LogMetrics#BUFFER_TRIMMED_METRIC} -
+ * <strong>not</strong> the per logger name counters that {@link LogMetrics} also
+ * accumulates as a side effect of {@code LogAlerts#error(LogEvent)}. Logger names are
+ * effectively unbounded (arbitrary class/category names, chosen by application code), so
+ * turning each one into its own Micrometer meter would be an unbounded cardinality source
+ * - exactly what Micrometer's own naming guidance warns against. Reporting that per
+ * logger detail is left to a future, explicitly opt in mechanism rather than bound
+ * automatically here.
+ */
+final class RainbowGumMeterBinder implements MeterBinder {
+
+	static final String METRIC_PREFIX = "rainbowgum.";
+
+	RainbowGumMeterBinder() {
+	}
+
+	@Override
+	public void bindTo(MeterRegistry registry) {
+		var gum = RainbowGum.getOrNull();
+		if (gum == null) {
+			return;
+		}
+		var metrics = gum.config().metrics();
+		bind(registry, metrics, LogMetrics.EVENTS_DROPPED_METRIC, Level.ERROR);
+		bind(registry, metrics, LogMetrics.BUFFER_TRIMMED_METRIC, Level.WARNING);
+	}
+
+	private static void bind(MeterRegistry registry, LogMetrics metrics, String name, Level level) {
+		FunctionCounter.builder(METRIC_PREFIX + name, metrics, m -> currentValue(m, name, level))
+			.tag("level", level.toString())
+			.register(registry);
+	}
+
+	private static long currentValue(LogMetrics metrics, String name, Level level) {
+		for (var counter : metrics.counters()) {
+			if (counter.name().equals(name) && counter.level() == level) {
+				return counter.count();
+			}
+		}
+		return 0;
+	}
+
+}

--- a/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMetricsAutoConfiguration.java
+++ b/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMetricsAutoConfiguration.java
@@ -1,0 +1,53 @@
+package io.jstach.rainbowgum.spring.boot4.actuator;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * Registers a {@link MeterBinder} that bridges RainbowGum's
+ * {@link io.jstach.rainbowgum.LogMetrics} counters to Micrometer, when Micrometer is on
+ * the classpath. Modeled directly on Spring Boot's own
+ * {@code LogbackMetricsAutoConfiguration}/{@code Log4J2MetricsAutoConfiguration} in
+ * {@code spring-boot-micrometer-metrics} - same {@code @AutoConfiguration(after = ...)}
+ * ordering, same "one {@link MeterBinder} bean, let Spring Boot's own metrics
+ * infrastructure apply it" shape.
+ * <p>
+ * This is deliberately its own module (not folded into
+ * {@code rainbowgum-spring-boot4-starter}): pulling in Micrometer/metrics is an opt in
+ * choice for applications that already have
+ * {@code spring-boot-starter-micrometer-metrics} (the Spring Boot 4 starter - metrics
+ * moved out of {@code spring-boot-starter-actuator} into its own starter in Boot 4), not
+ * something every RainbowGum + Spring Boot user should get by default. Runs as a normal
+ * {@link AutoConfiguration}, well after {@code RainbowGumLoggingSystemFactory} has
+ * already bootstrapped {@link io.jstach.rainbowgum.RainbowGum} during the earlier,
+ * bean-free {@code LoggingSystemFactory} phase - see that class for why the two can't be
+ * combined into one step.
+ */
+@AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class })
+@ConditionalOnClass(MeterRegistry.class)
+public class RainbowGumMetricsAutoConfiguration {
+
+	/**
+	 * Creates the auto configuration.
+	 */
+	public RainbowGumMetricsAutoConfiguration() {
+	}
+
+	/**
+	 * Creates the meter binder bean. Spring Boot's own metrics autoconfiguration applies
+	 * every {@link MeterBinder} bean to the {@link MeterRegistry} once one is available,
+	 * so this class does not need to inject or depend on the registry directly.
+	 * @return meter binder.
+	 */
+	@Bean
+	public MeterBinder rainbowGumMeterBinder() {
+		return new RainbowGumMeterBinder();
+	}
+
+}

--- a/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/package-info.java
+++ b/spring/rainbowgum-spring-boot4-actuator/src/main/java/io/jstach/rainbowgum/spring/boot4/actuator/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Rainbow Gum Spring Boot Actuator/Micrometer integration.
+ */
+@org.eclipse.jdt.annotation.NonNullByDefault
+package io.jstach.rainbowgum.spring.boot4.actuator;

--- a/spring/rainbowgum-spring-boot4-actuator/src/main/java/module-info.java
+++ b/spring/rainbowgum-spring-boot4-actuator/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+/**
+ * Rainbow Gum Spring Boot 4 Actuator/Micrometer integration.
+ * <p>
+ * See {@code io.jstach.rainbowgum.spring.boot4}'s module-info for why the module name is
+ * suffixed with the Spring Boot major version while the packages are not, and why this
+ * is deliberately its own module rather than folded into
+ * {@code io.jstach.rainbowgum.spring.boot4} itself: Micrometer/Actuator are an opt in
+ * dependency, not something every RainbowGum + Spring Boot user should be forced onto.
+ */
+module io.jstach.rainbowgum.spring.boot4.actuator {
+	requires transitive io.jstach.rainbowgum;
+
+	requires spring.boot.autoconfigure;
+	requires spring.boot.micrometer.metrics;
+	requires spring.context;
+	requires micrometer.core;
+
+	requires static org.eclipse.jdt.annotation;
+
+	// Spring reflectively instantiates the auto configuration class and, since
+	// @AutoConfiguration defaults to full (CGLIB proxied) @Configuration mode,
+	// ConfigurationClassEnhancer (in spring.context) reflectively sets a field on the
+	// generated subclass. Left unqualified rather than naming just spring.context - which
+	// exact Spring module needs access has already changed once between what seemed like
+	// the obvious guess (spring.core, where CGLIB itself lives) and the module actually
+	// doing the reflective field access, so pinning to one risks the same break again on
+	// a future Spring version.
+	opens io.jstach.rainbowgum.spring.boot4.actuator;
+}

--- a/spring/rainbowgum-spring-boot4-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/rainbowgum-spring-boot4-actuator/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.jstach.rainbowgum.spring.boot4.actuator.RainbowGumMetricsAutoConfiguration

--- a/spring/rainbowgum-spring-boot4-actuator/src/test/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMetricsAutoConfigurationTest.java
+++ b/spring/rainbowgum-spring-boot4-actuator/src/test/java/io/jstach/rainbowgum/spring/boot4/actuator/RainbowGumMetricsAutoConfigurationTest.java
@@ -1,0 +1,72 @@
+package io.jstach.rainbowgum.spring.boot4.actuator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogMetrics;
+import io.jstach.rainbowgum.RainbowGum;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/*
+ * Boots a real (if minimal) Spring context, registering the same
+ * MetricsAutoConfiguration/CompositeMeterRegistryAutoConfiguration that a real Spring
+ * Boot app with spring-boot-starter-micrometer-metrics on the classpath would run - not
+ * just this module's own RainbowGumMetricsAutoConfiguration - so the whole chain
+ * (MeterBinder bean created, then Spring Boot's own metrics machinery actually calling
+ * MeterBinder#bindTo(registry)) runs for real rather than assuming it would. Also
+ * exercises the JPMS module boundary (CGLIB enhancement of the auto configuration class,
+ * see module-info's `opens`) which a plain unit test of RainbowGumMeterBinder would not.
+ * <p>
+ * Touches RainbowGum's static current-instance holder - see RainbowGumTest's identical
+ * note (in rainbowgum-core) for why @Isolated/@Execution(SAME_THREAD) are needed.
+ */
+@Isolated
+@Execution(ExecutionMode.SAME_THREAD)
+class RainbowGumMetricsAutoConfigurationTest {
+
+	@Test
+	void countersAreBoundToMicrometer() throws Exception {
+		LogConfig config = LogConfig.builder().build();
+		try (var gum = RainbowGum.builder(config).set()) {
+			config.metrics().errorCounter(LogMetrics.EVENTS_DROPPED_METRIC, 3);
+			config.metrics().warnCounter(LogMetrics.BUFFER_TRIMMED_METRIC, 5);
+
+			try (var context = new AnnotationConfigApplicationContext()) {
+				context.register(CompositeMeterRegistryAutoConfiguration.class, MetricsAutoConfiguration.class,
+						SimpleMetricsExportAutoConfiguration.class, RainbowGumMetricsAutoConfiguration.class);
+				context.refresh();
+
+				var registry = context.getBean(MeterRegistry.class);
+
+				assertEquals(3.0,
+						registry.get(RainbowGumMeterBinder.METRIC_PREFIX + LogMetrics.EVENTS_DROPPED_METRIC)
+							.tag("level", "ERROR")
+							.functionCounter()
+							.count());
+				assertEquals(5.0,
+						registry.get(RainbowGumMeterBinder.METRIC_PREFIX + LogMetrics.BUFFER_TRIMMED_METRIC)
+							.tag("level", "WARNING")
+							.functionCounter()
+							.count());
+
+				config.metrics().errorCounter(LogMetrics.EVENTS_DROPPED_METRIC, 4);
+				assertEquals(7.0,
+						registry.get(RainbowGumMeterBinder.METRIC_PREFIX + LogMetrics.EVENTS_DROPPED_METRIC)
+							.tag("level", "ERROR")
+							.functionCounter()
+							.count(),
+						"a FunctionCounter reads the live value on each poll, not a snapshot taken at bind time");
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
New opt-in module, separate from rainbowgum-spring-boot4-starter since Micrometer/metrics is an opt-in choice, not something every RainbowGum Spring Boot user should get by default. A RainbowGumMeterBinder binds LogMetrics.EVENTS_DROPPED_METRIC/BUFFER_TRIMMED_METRIC as FunctionCounters - deliberately not the per-logger-name error counters LogAlerts also drives, since logger names are unbounded and would be a Micrometer cardinality footgun. Modeled directly on Spring Boot's own LogbackMetricsAutoConfiguration/Log4J2MetricsAutoConfiguration in spring-boot-micrometer-metrics (same @AutoConfiguration(after = ...) ordering, same one-MeterBinder-bean shape).

A static "what's actually wired up" report (old status() API's territory, see todo.md) is a natural next Actuator surface but out of scope here - this is metrics only.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5