### PR TITLE
Remove public LogAlerts/LogMetrics static factories

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAlerts.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAlerts.java
@@ -117,25 +117,6 @@ public sealed interface LogAlerts permits DefaultLogAlerts {
 	}
 
 	/**
-	 * Creates alerts backed by a ring buffer of the {@link #DEFAULT_CAPACITY default
-	 * capacity}.
-	 * @return alerts.
-	 */
-	public static LogAlerts of() {
-		return of(DEFAULT_CAPACITY);
-	}
-
-	/**
-	 * Creates alerts backed by a ring buffer of the given capacity.
-	 * @param capacity maximum number of alerts to retain. Older alerts are evicted first
-	 * once capacity is reached.
-	 * @return alerts.
-	 */
-	public static LogAlerts of(int capacity) {
-		return new DefaultLogAlerts(capacity);
-	}
-
-	/**
 	 * Stats about alerts recorded.
 	 *
 	 * @param total total number of alerts ever recorded, including ones since evicted

--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -452,8 +452,8 @@ final class DefaultLogConfig implements LogConfig {
 		this.outputRegistry = DefaultOutputRegistry.of(registry);
 		this.encoderRegistry = DefaultEncoderRegistry.of();
 		this.publisherRegistry = DefaultPublisherRegistry.of();
-		this.alerts = LogAlerts.of();
-		this.metrics = LogMetrics.of();
+		this.alerts = new DefaultLogAlerts(LogAlerts.DEFAULT_CAPACITY);
+		this.metrics = new DefaultLogMetrics();
 		this.alerts.addListener(event -> this.metrics.errorCounter(event.loggerName(), 1));
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogMetrics.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogMetrics.java
@@ -137,14 +137,6 @@ public sealed interface LogMetrics permits DefaultLogMetrics {
 
 	}
 
-	/**
-	 * Creates a new, empty metrics instance.
-	 * @return metrics.
-	 */
-	public static LogMetrics of() {
-		return new DefaultLogMetrics();
-	}
-
 }
 
 final class DefaultLogMetrics implements LogMetrics {

--- a/core/src/main/java/io/jstach/rainbowgum/publisher/BlockingQueueAsyncLogPublisher.java
+++ b/core/src/main/java/io/jstach/rainbowgum/publisher/BlockingQueueAsyncLogPublisher.java
@@ -30,15 +30,16 @@ public final class BlockingQueueAsyncLogPublisher implements LogPublisher.AsyncL
 	private final LogAlerts alerts;
 
 	/**
-	 * Creates the publisher with its own standalone {@link LogAlerts} (not one shared
-	 * with the rest of a {@link LogConfig}) - mainly useful standalone/in tests. Prefer
-	 * {@link #of(LogAppender, int, LogAlerts)} when a {@link LogConfig} is available.
+	 * Creates the publisher with its own standalone {@link LogConfig} (not one shared
+	 * with the rest of the application) for its {@link LogAlerts} - mainly useful
+	 * standalone/in tests. Prefer {@link #of(LogAppender, int, LogAlerts)} when a
+	 * {@link LogConfig} is already available.
 	 * @param appender appenders.
 	 * @param bufferSize the queue size.
 	 * @return async publisher.
 	 */
 	public static BlockingQueueAsyncLogPublisher of(LogAppender appender, int bufferSize) {
-		return of(appender, bufferSize, LogAlerts.of());
+		return of(appender, bufferSize, LogConfig.builder().build().alerts());
 	}
 
 	/**

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
@@ -40,31 +40,31 @@ class AppenderAlertReportingTest {
 		output.setConsumer((e, s) -> {
 			throw new RuntimeException("output boom");
 		});
-		var alerts = LogAlerts.of();
-		var appender = appender(flags, output, encoder(), alerts);
+		var config = LogConfig.builder().build();
+		var appender = appender(flags, output, encoder(), config);
 		assertEquals(expectedType, appender.getClass());
 
 		assertDoesNotThrow(() -> appender.append(TestLogEventFactory.of().event("event")));
 
-		assertEquals(1, alerts.dump().size());
-		assertTrue(alerts.dump().get(0).message().contains("failed to append"));
+		assertEquals(1, config.alerts().dump().size());
+		assertTrue(config.alerts().dump().get(0).message().contains("failed to append"));
 	}
 
 	@ParameterizedTest
 	@MethodSource("appenderFlags")
 	void encoderFailureIsCaughtAndReported(Set<AppenderFlag> flags, Class<?> expectedType) {
 		var output = new ListLogOutput();
+		var config = LogConfig.builder().build();
 		var throwingEncoder = LogEncoder.of((LogFormatter.EventFormatter) (sb, event) -> {
 			throw new RuntimeException("encode boom");
-		}).provide("test", LogConfig.builder().build());
-		var alerts = LogAlerts.of();
-		var appender = appender(flags, output, throwingEncoder, alerts);
+		}).provide("test", config);
+		var appender = appender(flags, output, throwingEncoder, config);
 		assertEquals(expectedType, appender.getClass());
 
 		assertDoesNotThrow(() -> appender.append(TestLogEventFactory.of().event("event")));
 
-		assertEquals(1, alerts.dump().size());
-		assertTrue(alerts.dump().get(0).message().contains("failed to append"));
+		assertEquals(1, config.alerts().dump().size());
+		assertTrue(config.alerts().dump().get(0).message().contains("failed to append"));
 	}
 
 	@ParameterizedTest
@@ -74,16 +74,16 @@ class AppenderAlertReportingTest {
 		output.setConsumer((e, s) -> {
 			throw new RuntimeException("output boom");
 		});
-		var alerts = LogAlerts.of();
-		var appender = appender(flags, output, encoder(), alerts);
+		var config = LogConfig.builder().build();
+		var appender = appender(flags, output, encoder(), config);
 		assertEquals(expectedType, appender.getClass());
 
 		var events = new LogEvent[] { TestLogEventFactory.of().event("one"), TestLogEventFactory.of().event("two") };
 
 		assertDoesNotThrow(() -> appender.append(events, events.length));
 
-		assertEquals(1, alerts.dump().size());
-		assertTrue(alerts.dump().get(0).message().contains("failed to append batch"));
+		assertEquals(1, config.alerts().dump().size());
+		assertTrue(config.alerts().dump().get(0).message().contains("failed to append batch"));
 	}
 
 	private static LogEncoder encoder() {
@@ -91,8 +91,8 @@ class AppenderAlertReportingTest {
 	}
 
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output, LogEncoder encoder,
-			LogAlerts alerts) {
-		return DirectLogAppender.of("test", output, encoder, flags, alerts, LogMetrics.of());
+			LogConfig config) {
+		return DirectLogAppender.of("test", output, encoder, flags, config.alerts(), config.metrics());
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
@@ -132,18 +132,20 @@ class DefaultAppenderSelectionTest {
 	 * appender() call would wipe out a test's own direct override of that field before
 	 * DirectLogAppender.of gets a chance to read it.
 	 */
+	private static final LogConfig CONFIG = LogConfig.builder().build();
+
 	private static final LogEncoder ENCODER = LogFormatter.builder()
 		.message()
 		.encoder()
 		.build()
-		.provide("test", LogConfig.builder().build());
+		.provide("test", CONFIG);
 
 	private static LogAppender appender(Set<AppenderFlag> flags) {
 		return appender(flags, new ListLogOutput());
 	}
 
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output) {
-		return DirectLogAppender.of("test", output, ENCODER, flags, LogAlerts.of(), LogMetrics.of());
+		return DirectLogAppender.of("test", output, ENCODER, flags, CONFIG.alerts(), CONFIG.metrics());
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/LogAlertsTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAlertsTest.java
@@ -42,7 +42,7 @@ class LogAlertsTest {
 	@Test
 	@SuppressWarnings("StringSplitter")
 	void errorRecordsIntoDumpAndStillReportsToStderr() {
-		var alerts = LogAlerts.of();
+		var alerts = alerts();
 		alerts.error(LogAlertsTest.class, new RuntimeException("expected"));
 
 		var dump = alerts.dump();
@@ -59,7 +59,7 @@ class LogAlertsTest {
 
 	@Test
 	void errorWithMessageOverload() {
-		var alerts = LogAlerts.of();
+		var alerts = alerts();
 		alerts.error(LogAlertsTest.class, "custom message", new RuntimeException("cause"));
 
 		var dump = alerts.dump();
@@ -69,7 +69,7 @@ class LogAlertsTest {
 
 	@Test
 	void ringBufferEvictsOldestFirstOnceAtCapacity() {
-		var alerts = LogAlerts.of(2);
+		var alerts = new DefaultLogAlerts(2);
 
 		alerts.error(LogAlertsTest.class, "first", new RuntimeException());
 		alerts.error(LogAlertsTest.class, "second", new RuntimeException());
@@ -86,7 +86,7 @@ class LogAlertsTest {
 
 	@Test
 	void clearEmptiesRingBufferButKeepsTotal() {
-		var alerts = LogAlerts.of();
+		var alerts = alerts();
 		alerts.error(LogAlertsTest.class, "first", new RuntimeException());
 		alerts.error(LogAlertsTest.class, "second", new RuntimeException());
 
@@ -99,8 +99,8 @@ class LogAlertsTest {
 	}
 
 	@Test
-	void ofRejectsNonPositiveCapacity() {
-		org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> LogAlerts.of(0));
+	void constructorRejectsNonPositiveCapacity() {
+		org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> new DefaultLogAlerts(0));
 	}
 
 	@Test
@@ -110,9 +110,13 @@ class LogAlertsTest {
 		assertEquals(1, config.alerts().dump().size());
 	}
 
+	private static LogAlerts alerts() {
+		return LogConfig.builder().build().alerts();
+	}
+
 	@Test
 	void listenerIsNotifiedSynchronouslyOnEachError() {
-		var alerts = LogAlerts.of();
+		var alerts = alerts();
 		List<String> seen = new ArrayList<>();
 		alerts.addListener(e -> seen.add(e.message()));
 
@@ -124,7 +128,7 @@ class LogAlertsTest {
 
 	@Test
 	void closingRegistrationStopsFurtherNotifications() {
-		var alerts = LogAlerts.of();
+		var alerts = alerts();
 		List<String> seen = new ArrayList<>();
 		var registration = alerts.addListener(e -> seen.add(e.message()));
 
@@ -143,7 +147,7 @@ class LogAlertsTest {
 	@Test
 	@SuppressWarnings("StringSplitter")
 	void aThrowingListenerDoesNotStopRecordingOrOtherListeners() {
-		var alerts = LogAlerts.of();
+		var alerts = alerts();
 		List<String> seen = new ArrayList<>();
 		alerts.addListener(e -> {
 			throw new RuntimeException("listener boom");

--- a/core/src/test/java/io/jstach/rainbowgum/LogMetricsTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogMetricsTest.java
@@ -11,7 +11,7 @@ class LogMetricsTest {
 
 	@Test
 	void errorCounterAccumulatesByName() {
-		var metrics = LogMetrics.of();
+		var metrics = LogConfig.builder().build().metrics();
 		metrics.errorCounter("queue.dropped", 1);
 		metrics.errorCounter("queue.dropped", 2);
 		metrics.errorCounter("queue.overflow", 1);
@@ -24,7 +24,7 @@ class LogMetricsTest {
 
 	@Test
 	void warnCounterAccumulatesByNameSeparatelyFromErrorCounter() {
-		var metrics = LogMetrics.of();
+		var metrics = LogConfig.builder().build().metrics();
 		metrics.errorCounter("buffer.trimmed", 1);
 		metrics.warnCounter("buffer.trimmed", 2);
 


### PR DESCRIPTION
LogAlerts.of()/of(int) and LogMetrics.of() are gone - both may need LogProperties down the line, and a public no-arg/capacity-only factory now would just be something to work around later. LogConfig builds DefaultLogAlerts/DefaultLogMetrics directly (same package); everywhere else that needs one for testing gets it from a LogConfig instead.