### PR TITLE
Increment LogMetrics.EVENTS_FAILED_METRIC on appender exception

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -897,6 +897,7 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 		}
 		catch (Exception e) {
 			alerts.error(getClass(), "appender '" + name + "' failed to append event", e);
+			metrics.errorCounter(LogMetrics.EVENTS_FAILED_METRIC, 1);
 		}
 	}
 
@@ -919,6 +920,7 @@ final class ReuseBufferLogAppender extends LockLogAppender implements InternalLo
 		}
 		catch (Exception e) {
 			alerts.error(getClass(), "appender '" + name + "' failed to append batch of " + count + " event(s)", e);
+			metrics.errorCounter(LogMetrics.EVENTS_FAILED_METRIC, count);
 		}
 	}
 
@@ -974,6 +976,7 @@ final class LockThreadLocalBufferLogAppender extends LockLogAppender implements 
 		}
 		catch (Exception e) {
 			alerts.error(getClass(), "appender '" + name + "' failed to append event", e);
+			metrics.errorCounter(LogMetrics.EVENTS_FAILED_METRIC, 1);
 		}
 	}
 
@@ -1012,6 +1015,7 @@ final class LockThreadLocalBufferLogAppender extends LockLogAppender implements 
 		}
 		catch (Exception e) {
 			alerts.error(getClass(), "appender '" + name + "' failed to append batch of " + count + " event(s)", e);
+			metrics.errorCounter(LogMetrics.EVENTS_FAILED_METRIC, count);
 		}
 	}
 
@@ -1049,6 +1053,7 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 		}
 		catch (Exception e) {
 			alerts.error(getClass(), "appender '" + name + "' failed to append event", e);
+			metrics.errorCounter(LogMetrics.EVENTS_FAILED_METRIC, 1);
 		}
 	}
 
@@ -1079,6 +1084,7 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 		}
 		catch (Exception e) {
 			alerts.error(getClass(), "appender '" + name + "' failed to append batch of " + count + " event(s)", e);
+			metrics.errorCounter(LogMetrics.EVENTS_FAILED_METRIC, count);
 		}
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogMetrics.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogMetrics.java
@@ -46,6 +46,16 @@ public sealed interface LogMetrics permits DefaultLogMetrics {
 	static final String BUFFER_TRIMMED_METRIC = "buffer.trimmed";
 
 	/**
+	 * Counter name for the global count of log events an appender failed to write - the
+	 * encoder or output threw while appending, so the event was caught, alerted (see
+	 * {@link LogAlerts#error(Class, String, Throwable)}), and lost rather than retried.
+	 * Kept separate from {@link #EVENTS_DROPPED_METRIC}: a drop is a deliberate skip (the
+	 * appender chose not to write), while this is an unexpected failure partway through
+	 * actually trying to - different root causes worth distinguishing when triaging.
+	 */
+	static final String EVENTS_FAILED_METRIC = "events.failed";
+
+	/**
 	 * Increments a counter for something worth tracking as "this happens and it matters".
 	 * @param name counter name, e.g. {@link #EVENTS_DROPPED_METRIC} or a logger name.
 	 * @param increment amount to add, usually {@code 1}.
@@ -104,7 +114,11 @@ public sealed interface LogMetrics permits DefaultLogMetrics {
 		/**
 		 * See {@link #BUFFER_TRIMMED_METRIC}.
 		 */
-		BUFFER_TRIMMED(BUFFER_TRIMMED_METRIC, Level.WARNING);
+		BUFFER_TRIMMED(BUFFER_TRIMMED_METRIC, Level.WARNING),
+		/**
+		 * See {@link #EVENTS_FAILED_METRIC}.
+		 */
+		EVENTS_FAILED(EVENTS_FAILED_METRIC, Level.ERROR);
 
 		private final String metricName;
 

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
@@ -20,9 +20,9 @@ import io.jstach.rainbowgum.output.ListLogOutput;
  * one - catches encoder and output failures instead of letting them propagate back to the
  * caller of {@link LogAppender#append(LogEvent)}/
  * {@link LogAppender#append(LogEvent[], int)}, and reports them through the appender's
- * own {@link LogAlerts} instead. Deliberately does not distinguish encoder vs output
- * failures in the alert itself - both land as one appender-level "failed to append"
- * alert.
+ * own {@link LogAlerts} as well as {@link LogMetrics#EVENTS_FAILED_METRIC}. Deliberately
+ * does not distinguish encoder vs output failures in either - both land as one
+ * appender-level "failed to append" alert and the same counter.
  */
 class AppenderAlertReportingTest {
 
@@ -48,6 +48,7 @@ class AppenderAlertReportingTest {
 
 		assertEquals(1, config.alerts().dump().size());
 		assertTrue(config.alerts().dump().get(0).message().contains("failed to append"));
+		assertEquals(1, failedEventsCount(config));
 	}
 
 	@ParameterizedTest
@@ -65,6 +66,7 @@ class AppenderAlertReportingTest {
 
 		assertEquals(1, config.alerts().dump().size());
 		assertTrue(config.alerts().dump().get(0).message().contains("failed to append"));
+		assertEquals(1, failedEventsCount(config));
 	}
 
 	@ParameterizedTest
@@ -84,6 +86,7 @@ class AppenderAlertReportingTest {
 
 		assertEquals(1, config.alerts().dump().size());
 		assertTrue(config.alerts().dump().get(0).message().contains("failed to append batch"));
+		assertEquals(events.length, failedEventsCount(config));
 	}
 
 	private static LogEncoder encoder() {
@@ -93,6 +96,15 @@ class AppenderAlertReportingTest {
 	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output, LogEncoder encoder,
 			LogConfig config) {
 		return DirectLogAppender.of("test", output, encoder, flags, config.alerts(), config.metrics());
+	}
+
+	private static long failedEventsCount(LogConfig config) {
+		return config.metrics()
+			.counters()
+			.stream()
+			.filter(c -> c.name().equals(LogMetrics.EVENTS_FAILED_METRIC))
+			.mapToLong(LogMetrics.Counter::count)
+			.sum();
 	}
 
 }


### PR DESCRIPTION
An appender catching an encoder/output exception during append(...) already alerts; now it also bumps a counter, mirroring how reentry already increments EVENTS_DROPPED_METRIC. Kept as a separate metric rather than folded into EVENTS_DROPPED_METRIC or a combined total: a drop is a deliberate skip, this is an unexpected failure partway through actually trying to write - different root causes worth distinguishing when triaging. Batch failures increment by the batch count, matching the reentry-drop convention.

Automatically picked up by RainbowGumMeterBinder's StandardMetric.values() loop with no changes needed there.


Claude-Session: https://claude.ai/code/session_013BQbaWwWG4WXH4KcGad1J5