### PR TITLE
Split appender buffer/lock strategy into its own AppenderType enum

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppender.java
@@ -58,6 +58,12 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 	static final String APPENDER_FLAGS_PROPERTY = LogProperties.APPENDER_FLAGS_PROPERTY;
 
 	/**
+	 * Appender type.
+	 * @see AppenderType
+	 */
+	static final String APPENDER_TYPE_PROPERTY = LogProperties.APPENDER_TYPE_PROPERTY;
+
+	/**
 	 * Batch of events. <strong>DO NOT MODIFY THE ARRAY</strong>. Do not use the
 	 * <code>length</code> of the passed in array but instead use <code>count</code>
 	 * parameter.
@@ -71,79 +77,12 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 
 	/**
 	 * Boolean like flags for appender that can be set with
-	 * {@link LogAppender#APPENDER_FLAGS_PROPERTY}. Publisher may choose to add flags to
-	 * the appenders and will be added if no flags are set on the appenders. Consequently
-	 * great care should be taken when setting flags as performance maybe greatly impacted
-	 * if a publisher is not designed for the flag.
+	 * {@link LogAppender#APPENDER_FLAGS_PROPERTY}. Unlike {@link AppenderType} more than
+	 * one flag can be set at once.
 	 */
 	@CaseChanging
 	public enum AppenderFlag {
 
-		/**
-		 * The appender will create a single buffer that will be reused and will be
-		 * protected by the appenders locking.
-		 */
-		REUSE_BUFFER,
-		/**
-		 * The appender will give each thread its own reusable buffer (a
-		 * {@link ThreadLocal}) instead of allocating a new buffer per event. Unlike
-		 * {@link #REUSE_BUFFER} the encoding is done <strong>outside</strong> the
-		 * appender's lock (the thread's buffer is only visited by that thread so no
-		 * protection is needed while encoding) with the lock only held for the final
-		 * write to the output, which is the same trade-off {@link #REUSE_BUFFER} makes
-		 * except without serializing the encoding step itself.
-		 * <p>
-		 * This flag is ignored if {@link #REUSE_BUFFER} is also set.
-		 * <p>
-		 * The same {@link ThreadLocal} buffer is used regardless of whether the calling
-		 * thread is a platform or virtual thread. A virtual thread's entry becomes
-		 * collectible once the thread itself terminates, and a typical unit of work (e.g.
-		 * one HTTP request) logs several times on the same thread, so reusing the buffer
-		 * across those calls still pays off even for short-lived virtual threads.
-		 * <p>
-		 * This is the strategy an appender uses <strong>even when no flag is explicitly
-		 * set</strong> - see {@code DirectLogAppender#defaultAppender} for the default
-		 * selection, and {@link #SYNCHRONIZED_THREAD_LOCAL_BUFFER} for the alternative
-		 * lock-kind opt-in.
-		 */
-		LOCK_THREAD_LOCAL_BUFFER,
-		/**
-		 * Like {@link #LOCK_THREAD_LOCAL_BUFFER} (a reused per-thread buffer, encoding
-		 * done outside any lock) except the final write to the output is protected by a
-		 * plain {@code synchronized} block (the JVM's intrinsic monitor) instead of a
-		 * {@link ReentrantLock}.
-		 * <p>
-		 * The Java language has no way to acquire a monitor in one method call and
-		 * release it in another, so this appender's critical sections are written as
-		 * literal {@code synchronized} blocks rather than going through a shared lock
-		 * abstraction the way every other flag combination does. {@link #REENTRY_DROP}
-		 * and {@link #REENTRY_LOG} are still honored though -
-		 * {@link Thread#holdsLock(Object)} is the {@code synchronized} equivalent of
-		 * {@code ReentrantLock}'s {@code isHeldByCurrentThread()}, so reentrancy is
-		 * detected the same way.
-		 * <p>
-		 * Motivated by Log4j2's own garbage-free appenders using {@code synchronized}
-		 * rather than a {@code java.util.concurrent} lock around their buffer-transfer
-		 * step, and confirmed by real-workload benchmarking to outperform
-		 * {@link ReentrantLock} under platform-thread contention - this was the default
-		 * for a time. Real-workload benchmarking under virtual threads found the
-		 * opposite, a large and reproducible loss versus {@link ReentrantLock} for
-		 * reasons not fully understood (classic JEP 491 pinning was checked and ruled
-		 * out), so {@link #LOCK_THREAD_LOCAL_BUFFER} is the default now and this flag is
-		 * an opt-in for platform-thread-heavy deployments that want the edge. Takes
-		 * precedence over {@link #LOCK_THREAD_LOCAL_BUFFER} (redundant if both are set)
-		 * but not {@link #REUSE_BUFFER}.
-		 * <p>
-		 * <strong>Explicitly setting this flag honors it</strong> even on a JDK where
-		 * {@code synchronized} still pins the carrier platform thread when called from a
-		 * virtual thread (before <a href="https://openjdk.org/jeps/491">JEP 491</a>,
-		 * finalized in JDK 24) - the one exception is
-		 * {@code LogProperties#GLOBAL_APPENDER_REENTRANT_LOCK_PROPERTY}: when that global
-		 * property is active it downgrades even an explicit request for this flag to
-		 * {@link #LOCK_THREAD_LOCAL_BUFFER}, since its whole point is a hard guarantee
-		 * independent of anything else in the configuration.
-		 */
-		SYNCHRONIZED_THREAD_LOCAL_BUFFER,
 		/**
 		 * By default the appender will call flush on each item appended or if in async
 		 * batch mode for each batch. This flag disables that behavior so that flushing is
@@ -203,6 +142,80 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 	}
 
 	/**
+	 * The buffer/locking strategy an appender uses. Unlike {@link AppenderFlag} exactly
+	 * one is in effect for a given appender - set on the {@link LogAppender.Builder} (or
+	 * via {@link LogAppender#APPENDER_TYPE_PROPERTY}) at construction time and fixed for
+	 * the appender's lifetime; a publisher cannot change it afterward.
+	 */
+	@CaseChanging
+	public enum AppenderType {
+
+		/**
+		 * The appender will create a single buffer that will be reused and will be
+		 * protected by the appenders locking.
+		 */
+		REUSE_BUFFER,
+		/**
+		 * The appender will give each thread its own reusable buffer (a
+		 * {@link ThreadLocal}) instead of allocating a new buffer per event. Encoding is
+		 * done <strong>outside</strong> the appender's lock (the thread's buffer is only
+		 * visited by that thread so no protection is needed while encoding) with the lock
+		 * only held for the final write to the output.
+		 * <p>
+		 * The same {@link ThreadLocal} buffer is used regardless of whether the calling
+		 * thread is a platform or virtual thread. A virtual thread's entry becomes
+		 * collectible once the thread itself terminates, and a typical unit of work (e.g.
+		 * one HTTP request) logs several times on the same thread, so reusing the buffer
+		 * across those calls still pays off even for short-lived virtual threads.
+		 * <p>
+		 * This is the default type - see {@link #SYNCHRONIZED_THREAD_LOCAL_BUFFER} for
+		 * the alternative lock-kind opt-in.
+		 */
+		LOCK_THREAD_LOCAL_BUFFER,
+		/**
+		 * Like {@link #LOCK_THREAD_LOCAL_BUFFER} (a reused per-thread buffer, encoding
+		 * done outside any lock) except the final write to the output is protected by a
+		 * plain {@code synchronized} block (the JVM's intrinsic monitor) instead of a
+		 * {@link ReentrantLock}.
+		 * <p>
+		 * The Java language has no way to acquire a monitor in one method call and
+		 * release it in another, so this appender's critical sections are written as
+		 * literal {@code synchronized} blocks rather than going through a shared lock
+		 * abstraction the way {@link #LOCK_THREAD_LOCAL_BUFFER} does.
+		 * {@link AppenderFlag#REENTRY_DROP} and {@link AppenderFlag#REENTRY_LOG} are
+		 * still honored though - {@link Thread#holdsLock(Object)} is the
+		 * {@code synchronized} equivalent of {@code ReentrantLock}'s
+		 * {@code isHeldByCurrentThread()}, so reentrancy is detected the same way.
+		 * <p>
+		 * Motivated by Log4j2's own garbage-free appenders using {@code synchronized}
+		 * rather than a {@code java.util.concurrent} lock around their buffer-transfer
+		 * step, and confirmed by real-workload benchmarking to outperform
+		 * {@link ReentrantLock} under platform-thread contention - this was the default
+		 * for a time. Real-workload benchmarking under virtual threads found the
+		 * opposite, a large and reproducible loss versus {@link ReentrantLock} for
+		 * reasons not fully understood (classic JEP 491 pinning was checked and ruled
+		 * out), so {@link #LOCK_THREAD_LOCAL_BUFFER} is the default now and this type is
+		 * an opt-in for platform-thread-heavy deployments that want the edge.
+		 * <p>
+		 * <strong>Explicitly setting this type honors it</strong> even on a JDK where
+		 * {@code synchronized} still pins the carrier platform thread when called from a
+		 * virtual thread (before <a href="https://openjdk.org/jeps/491">JEP 491</a>,
+		 * finalized in JDK 24) - the one exception is
+		 * {@code LogProperties#GLOBAL_APPENDER_REENTRANT_LOCK_PROPERTY}: when that global
+		 * property is active it downgrades even an explicit request for this type to
+		 * {@link #LOCK_THREAD_LOCAL_BUFFER}, since its whole point is a hard guarantee
+		 * independent of anything else in the configuration.
+		 */
+		SYNCHRONIZED_THREAD_LOCAL_BUFFER;
+
+		static AppenderType parse(String value) {
+			String v = value.toUpperCase(Locale.ROOT);
+			return AppenderType.valueOf(v);
+		}
+
+	}
+
+	/**
 	 * Creates a builder.
 	 * @param name appender name.
 	 * @return builder.
@@ -224,6 +237,8 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		private @Nullable LogProvider<? extends LogEncoder> encoder = null;
 
 		private @Nullable EnumSet<AppenderFlag> flags = null;
+
+		private @Nullable AppenderType appenderType = null;
 
 		private final String name;
 
@@ -330,6 +345,18 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		}
 
 		/**
+		 * Sets the appender type (buffer/locking strategy). If not set it is resolved
+		 * from {@link LogAppender#APPENDER_TYPE_PROPERTY} or otherwise defaults to
+		 * {@link AppenderType#LOCK_THREAD_LOCAL_BUFFER}.
+		 * @param appenderType appender type.
+		 * @return this.
+		 */
+		public Builder appenderType(AppenderType appenderType) {
+			this.appenderType = appenderType;
+			return this;
+		}
+
+		/**
 		 * Builds.
 		 * @return an appender factory.
 		 */
@@ -341,12 +368,13 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 			var _output = output;
 			var _encoder = encoder;
 			var _flags = flags;
+			var _appenderType = appenderType;
 			/*
 			 * TODO should we use the parent name for resolution?
 			 */
 			return (n, config) -> {
 				AppenderConfig a = new AppenderConfig(_name, LogProvider.provideOrNull(_output, _name, config),
-						LogProvider.provideOrNull(_encoder, _name, config), _flags);
+						LogProvider.provideOrNull(_encoder, _name, config), _flags, _appenderType);
 				return DefaultAppenderRegistry.appender(a, config);
 			};
 		}
@@ -367,23 +395,11 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 
 		private final List<LogProvider<LogAppender>> appenders;
 
-		private Set<LogAppender.AppenderFlag> flags = EnumSet.noneOf(LogAppender.AppenderFlag.class);
-
 		Appenders(String name, LogConfig config, List<LogProvider<LogAppender>> appenders) {
 			super();
 			this.name = name;
 			this.config = config;
 			this.appenders = appenders;
-		}
-
-		/**
-		 * Sets flags for the appenders which should be done prior to <code>asXXX</code>.
-		 * @param flags appender flags.
-		 * @return this;
-		 */
-		public Appenders flags(Set<LogAppender.AppenderFlag> flags) {
-			this.flags = flags;
-			return this;
 		}
 
 		/**
@@ -427,14 +443,12 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 		private LogAppender register(LogAppender appender) {
 			return switch (appender) {
 				case DirectLogAppender ia -> {
-					var _a = ia.withFlags(flags);
-					config.serviceRegistry().put(LogAppender.class, name + "." + _a.name(), _a);
-					yield _a;
+					config.serviceRegistry().put(LogAppender.class, name + "." + ia.name(), ia);
+					yield ia;
 				}
 				case CompositeLogAppender ca -> {
-					var _a = ca.withFlags(flags);
-					config.serviceRegistry().put(LogAppender.class, name, _a);
-					yield _a;
+					config.serviceRegistry().put(LogAppender.class, name, ca);
+					yield ca;
 				}
 				default -> {
 					throw new IllegalStateException();
@@ -461,7 +475,7 @@ public sealed interface LogAppender extends LogLifecycle, LogEventConsumer {
 			if (appenders.size() == 1) {
 				return Objects.requireNonNull(appenders.get(0));
 			}
-			return CompositeLogAppender.of(appenders, Set.of());
+			return CompositeLogAppender.of(appenders);
 		}
 
 	}
@@ -525,47 +539,18 @@ sealed interface DirectLogAppender extends InternalLogAppender {
 		return new Response(LogOutput.class, name(), LogResponse.Status.StandardStatus.OK);
 	}
 
-	static DirectLogAppender of(String name, LogOutput output, LogEncoder encoder, Set<LogAppender.AppenderFlag> flags,
-			LogAlerts alerts, LogMetrics metrics) {
-		flags = AbstractLogAppender.guardSynchronizedFlag(flags);
-		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
-			return new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
-		}
-		if (flags.contains(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
-		}
-		if (flags.contains(AppenderFlag.LOCK_THREAD_LOCAL_BUFFER)) {
-			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts,
-					metrics);
-		}
-		return defaultAppender(name, output, encoder, flags, alerts, metrics);
-	}
-
-	/**
-	 * Picks the appender used when no {@link AppenderFlag} explicitly requests a
-	 * buffer/lock strategy: {@link AppenderFlag#LOCK_THREAD_LOCAL_BUFFER}, the same
-	 * appender a caller gets from setting that flag explicitly. Supports
-	 * {@link AppenderFlag#REENTRY_DROP}/{@link AppenderFlag#REENTRY_LOG} directly (see
-	 * {@link AbstractLogAppender#shouldDropForReentry}), so no fallback to a third
-	 * appender is needed here for those flags.
-	 * <p>
-	 * {@link AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER} measured faster under
-	 * platform-thread contention in real-workload benchmarking and was the default for a
-	 * time, but real-workload benchmarking under virtual threads found the opposite - a
-	 * large, reproducible win for {@code LOCK_THREAD_LOCAL_BUFFER} there, for reasons not
-	 * fully understood (checked and ruled out classic JEP 491 pinning as the cause).
-	 * Given RainbowGum's own audience skews toward newer JDKs and virtual-thread
-	 * workloads, {@code LOCK_THREAD_LOCAL_BUFFER} is the safer default;
-	 * {@code synchronized} remains available as an explicit opt-in for
-	 * platform-thread-heavy deployments that want that edge.
-	 */
-	static DirectLogAppender defaultAppender(String name, LogOutput output, LogEncoder encoder,
+	static DirectLogAppender of(String name, LogOutput output, LogEncoder encoder, AppenderType type,
 			Set<LogAppender.AppenderFlag> flags, LogAlerts alerts, LogMetrics metrics) {
-		return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
+		type = AbstractLogAppender.guardSynchronizedAppenderType(type);
+		return switch (type) {
+			case REUSE_BUFFER ->
+				new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
+			case SYNCHRONIZED_THREAD_LOCAL_BUFFER ->
+				new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
+			case LOCK_THREAD_LOCAL_BUFFER -> new LockThreadLocalBufferLogAppender(name, output, encoder, flags,
+					new ReentrantLock(), alerts, metrics);
+		};
 	}
-
-	// @Override
-	DirectLogAppender withFlags(Set<LogAppender.AppenderFlag> flags);
 
 }
 
@@ -586,26 +571,21 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 
 	/**
 	 * Downgrades an explicit
-	 * {@link LogAppender.AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER} to
-	 * {@link LogAppender.AppenderFlag#LOCK_THREAD_LOCAL_BUFFER} if
+	 * {@link LogAppender.AppenderType#SYNCHRONIZED_THREAD_LOCAL_BUFFER} to
+	 * {@link LogAppender.AppenderType#LOCK_THREAD_LOCAL_BUFFER} if
 	 * {@link #forceReentrantLockAppenders} is active - the enforcement point that makes
 	 * the global no-synchronized guarantee a real guarantee rather than just a changed
-	 * default, since an explicit flag would otherwise bypass
-	 * {@link DirectLogAppender#defaultAppender} entirely.
-	 * @param flags flags as given to an appender factory method.
-	 * @return {@code flags} unchanged, unless the guarantee is active and
-	 * {@code SYNCHRONIZED_THREAD_LOCAL_BUFFER} was requested, in which case a copy with
-	 * that flag replaced by {@code LOCK_THREAD_LOCAL_BUFFER}.
+	 * default.
+	 * @param type type as given to an appender factory method.
+	 * @return {@code type} unchanged, unless the guarantee is active and
+	 * {@code SYNCHRONIZED_THREAD_LOCAL_BUFFER} was requested, in which case
+	 * {@code LOCK_THREAD_LOCAL_BUFFER} instead.
 	 */
-	static Set<LogAppender.AppenderFlag> guardSynchronizedFlag(Set<LogAppender.AppenderFlag> flags) {
-		if (!forceReentrantLockAppenders
-				|| !flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return flags;
+	static LogAppender.AppenderType guardSynchronizedAppenderType(LogAppender.AppenderType type) {
+		if (!forceReentrantLockAppenders || type != LogAppender.AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER) {
+			return type;
 		}
-		var copy = EnumSet.copyOf(flags);
-		copy.remove(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER);
-		copy.add(LogAppender.AppenderFlag.LOCK_THREAD_LOCAL_BUFFER);
-		return copy;
+		return LogAppender.AppenderType.LOCK_THREAD_LOCAL_BUFFER;
 	}
 
 	/**
@@ -743,11 +723,10 @@ sealed abstract class AbstractLogAppender implements DirectLogAppender {
 @SuppressWarnings("ArrayRecordComponent")
 record CompositeLogAppender(DirectLogAppender[] appenders) implements InternalLogAppender {
 
-	public static CompositeLogAppender of(List<? extends LogAppender> appenders, Set<LogAppender.AppenderFlag> flags) {
+	public static CompositeLogAppender of(List<? extends LogAppender> appenders) {
 		@SuppressWarnings("null") // TODO Eclipse issue here
 		DirectLogAppender @NonNull [] array = appenders.stream()
 			.map(CompositeLogAppender::cast)
-			.map(a -> a.withFlags(flags))
 			.toArray(i -> new DirectLogAppender[i]);
 		return new CompositeLogAppender(array);
 	}
@@ -787,13 +766,6 @@ record CompositeLogAppender(DirectLogAppender[] appenders) implements InternalLo
 	@Override
 	public List<LogResponse> act(LogAction action) {
 		return Actor.act(appenders, action);
-	}
-
-	public CompositeLogAppender withFlags(Set<LogAppender.AppenderFlag> flags) {
-		if (flags.isEmpty()) {
-			return this;
-		}
-		return of(List.of(appenders), flags);
 	}
 
 	@Override
@@ -836,29 +808,6 @@ sealed abstract class LockLogAppender extends AbstractLogAppender implements Int
 		finally {
 			lock.unlock();
 		}
-	}
-
-	@Override
-	public DirectLogAppender withFlags(Set<LogAppender.AppenderFlag> flags) {
-		if (flags.isEmpty()) {
-			return this;
-		}
-		if (this.flags.containsAll(flags)) {
-			return this;
-		}
-		flags = EnumSet.copyOf(flags);
-		flags.addAll(this.flags);
-		flags = guardSynchronizedFlag(flags);
-		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
-			return new ReuseBufferLogAppender(name, output, encoder, flags, lock, alerts, metrics);
-		}
-		if (flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
-		}
-		if (flags.contains(LogAppender.AppenderFlag.LOCK_THREAD_LOCAL_BUFFER)) {
-			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, lock, alerts, metrics);
-		}
-		return DirectLogAppender.defaultAppender(name, output, encoder, flags, alerts, metrics);
 	}
 
 }
@@ -1105,30 +1054,6 @@ final class SynchronizedThreadLocalBufferLogAppender extends AbstractLogAppender
 				return List.of(new Response(LogOutput.class, name, Status.ErrorStatus.of(ioe)));
 			}
 		}
-	}
-
-	@Override
-	public DirectLogAppender withFlags(Set<LogAppender.AppenderFlag> flags) {
-		if (flags.isEmpty()) {
-			return this;
-		}
-		if (this.flags.containsAll(flags)) {
-			return this;
-		}
-		flags = EnumSet.copyOf(flags);
-		flags.addAll(this.flags);
-		flags = guardSynchronizedFlag(flags);
-		if (flags.contains(LogAppender.AppenderFlag.REUSE_BUFFER)) {
-			return new ReuseBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts, metrics);
-		}
-		if (flags.contains(LogAppender.AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			return new SynchronizedThreadLocalBufferLogAppender(name, output, encoder, flags, alerts, metrics);
-		}
-		if (flags.contains(LogAppender.AppenderFlag.LOCK_THREAD_LOCAL_BUFFER)) {
-			return new LockThreadLocalBufferLogAppender(name, output, encoder, flags, new ReentrantLock(), alerts,
-					metrics);
-		}
-		return DirectLogAppender.defaultAppender(name, output, encoder, flags, alerts, metrics);
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.Nullable;
 
 import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.LogProperty.Property;
 import io.jstach.rainbowgum.LogProperty.PropertyValue;
 import io.jstach.rainbowgum.LogProperty.Result;
@@ -22,7 +23,7 @@ sealed interface LogAppenderRegistry permits DefaultAppenderRegistry {
 }
 
 record AppenderConfig(String name, @Nullable LogOutput output, @Nullable LogEncoder encoder,
-		@Nullable Set<AppenderFlag> flags) {
+		@Nullable Set<AppenderFlag> flags, @Nullable AppenderType appenderType) {
 
 	AppenderConfig {
 		validateName(name);
@@ -102,7 +103,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			if (name.equals(LogAppender.CONSOLE_APPENDER_NAME)) {
 				return defaultConsoleAppender(config);
 			}
-			var builder = new AppenderConfig(name, null, null, null);
+			var builder = new AppenderConfig(name, null, null, null, null);
 			var outputProperty = outputProperty(LogAppender.APPENDER_OUTPUT_PROPERTY, name, config);
 			var encoderProperty = encoderProperty(LogAppender.APPENDER_ENCODER_PROPERTY, name, config);
 			return appender(builder, config, outputProperty, encoderProperty);
@@ -138,6 +139,14 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			.buildWithName(LogAppender.APPENDER_FLAGS_PROPERTY, name) //
 			.get(config.properties())
 			.value(EnumSet.noneOf(LogAppender.AppenderFlag.class));
+	}
+
+	private static AppenderType resolveAppenderType(LogConfig config, String name) {
+		return Property.builder() //
+			.map(AppenderType::parse) //
+			.buildWithName(LogAppender.APPENDER_TYPE_PROPERTY, name) //
+			.get(config.properties())
+			.value(AppenderType.LOCK_THREAD_LOCAL_BUFFER);
 	}
 
 	static LogAppender fileAppender(LogConfig config) {
@@ -209,7 +218,13 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			flags = resolveFlags(config, name);
 		}
 
-		return DirectLogAppender.of(name, output, encoder, flags, config.alerts(), config.metrics());
+		@Nullable
+		AppenderType appenderType = appenderConfig.appenderType();
+		if (appenderType == null) {
+			appenderType = resolveAppenderType(config, name);
+		}
+
+		return DirectLogAppender.of(name, output, encoder, appenderType, flags, config.alerts(), config.metrics());
 	}
 
 	private static PropertyValue<LogEncoder> resolveEncoder(String name, LogConfig config, LogOutput output,
@@ -224,7 +239,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			String name, //
 			LogConfig config, //
 			PropertyValue<LogOutput> outputProperty, PropertyValue<LogEncoder> encoderProperty) {
-		var builder = new AppenderConfig(name, null, null, null);
+		var builder = new AppenderConfig(name, null, null, null, null);
 		return appender(builder, config, outputProperty, encoderProperty);
 
 	}

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperties.java
@@ -221,17 +221,15 @@ public interface LogProperties {
 
 	/**
 	 * If true guarantees no appender will use {@code synchronized} for its locking,
-	 * regardless of JDK version or an explicitly set
-	 * {@link LogAppender.AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER}: the JDK-version
-	 * sniffed default selection (see {@code DirectLogAppender#defaultAppender}) will not
-	 * pick the {@code synchronized}-based appender no matter how new the running JDK is,
-	 * and an explicit {@code SYNCHRONIZED_THREAD_LOCAL_BUFFER} flag is downgraded to
-	 * {@link LogAppender.AppenderFlag#LOCK_THREAD_LOCAL_BUFFER} instead of being honored.
-	 * Intended for deployments that want a hard guarantee independent of the JDK-version
-	 * heuristic - e.g. still running JDK versions before
+	 * regardless of an explicitly requested
+	 * {@link LogAppender.AppenderType#SYNCHRONIZED_THREAD_LOCAL_BUFFER}: an explicit
+	 * request for that type is downgraded to
+	 * {@link LogAppender.AppenderType#LOCK_THREAD_LOCAL_BUFFER} instead of being honored.
+	 * Intended for deployments that want a hard guarantee independent of per-appender
+	 * configuration - e.g. still running JDK versions before
 	 * <a href="https://openjdk.org/jeps/491">JEP 491</a> (JDK 24), where
 	 * {@code synchronized} pins the carrier platform thread when called from a virtual
-	 * thread, and that would rather not rely on runtime JDK detection to avoid it.
+	 * thread, and that would rather not rely on per-appender configuration to avoid it.
 	 */
 	static final String GLOBAL_APPENDER_REENTRANT_LOCK_PROPERTY = ROOT_PREFIX + "global.appender.reentrantLock";
 
@@ -292,6 +290,13 @@ public interface LogProperties {
 	 * @see AppenderFlag
 	 */
 	static final String APPENDER_FLAGS_PROPERTY = LogProperties.APPENDER_PREFIX + "flags";
+
+	/**
+	 * Appender type (buffer/locking strategy). Unlike {@value #APPENDER_FLAGS_PROPERTY}
+	 * this is a single value, not a list.
+	 * @see LogAppender.AppenderType
+	 */
+	static final String APPENDER_TYPE_PROPERTY = LogProperties.APPENDER_PREFIX + "type";
 
 	/**
 	 * Logging publisher prefix for configuration.

--- a/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
@@ -1,7 +1,6 @@
 package io.jstach.rainbowgum;
 
 import java.net.URI;
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -156,8 +155,7 @@ enum DefaultPublisherProviders implements LogPublisher.PublisherProvider {
 				.buildWithName(LogPublisherRegistry.BUFFER_SIZE_PROPERTY, name) //
 				.get(properties) //
 				.value(LogPublisherRegistry.ASYNC_BUFFER_SIZE);
-			return (n, config, appenders) -> BlockingQueueAsyncLogPublisher.of(
-					appenders.flags(EnumSet.of(LogAppender.AppenderFlag.REUSE_BUFFER)).asSingle(), _bufferSize,
+			return (n, config, appenders) -> BlockingQueueAsyncLogPublisher.of(appenders.asSingle(), _bufferSize,
 					config.alerts());
 		}
 	};

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAlertReportingTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -12,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 /**
@@ -26,22 +25,21 @@ import io.jstach.rainbowgum.output.ListLogOutput;
  */
 class AppenderAlertReportingTest {
 
-	static Stream<Arguments> appenderFlags() {
-		return Stream.of(Arguments.of(EnumSet.noneOf(AppenderFlag.class), LockThreadLocalBufferLogAppender.class),
-				Arguments.of(EnumSet.of(AppenderFlag.REUSE_BUFFER), ReuseBufferLogAppender.class),
-				Arguments.of(EnumSet.of(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER),
-						SynchronizedThreadLocalBufferLogAppender.class));
+	static Stream<Arguments> appenderTypes() {
+		return Stream.of(Arguments.of(AppenderType.LOCK_THREAD_LOCAL_BUFFER, LockThreadLocalBufferLogAppender.class),
+				Arguments.of(AppenderType.REUSE_BUFFER, ReuseBufferLogAppender.class), Arguments
+					.of(AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER, SynchronizedThreadLocalBufferLogAppender.class));
 	}
 
 	@ParameterizedTest
-	@MethodSource("appenderFlags")
-	void outputFailureIsCaughtAndReported(Set<AppenderFlag> flags, Class<?> expectedType) {
+	@MethodSource("appenderTypes")
+	void outputFailureIsCaughtAndReported(AppenderType type, Class<?> expectedType) {
 		var output = new ListLogOutput();
 		output.setConsumer((e, s) -> {
 			throw new RuntimeException("output boom");
 		});
 		var config = LogConfig.builder().build();
-		var appender = appender(flags, output, encoder(), config);
+		var appender = appender(type, output, encoder(), config);
 		assertEquals(expectedType, appender.getClass());
 
 		assertDoesNotThrow(() -> appender.append(TestLogEventFactory.of().event("event")));
@@ -52,14 +50,14 @@ class AppenderAlertReportingTest {
 	}
 
 	@ParameterizedTest
-	@MethodSource("appenderFlags")
-	void encoderFailureIsCaughtAndReported(Set<AppenderFlag> flags, Class<?> expectedType) {
+	@MethodSource("appenderTypes")
+	void encoderFailureIsCaughtAndReported(AppenderType type, Class<?> expectedType) {
 		var output = new ListLogOutput();
 		var config = LogConfig.builder().build();
 		var throwingEncoder = LogEncoder.of((LogFormatter.EventFormatter) (sb, event) -> {
 			throw new RuntimeException("encode boom");
 		}).provide("test", config);
-		var appender = appender(flags, output, throwingEncoder, config);
+		var appender = appender(type, output, throwingEncoder, config);
 		assertEquals(expectedType, appender.getClass());
 
 		assertDoesNotThrow(() -> appender.append(TestLogEventFactory.of().event("event")));
@@ -70,14 +68,14 @@ class AppenderAlertReportingTest {
 	}
 
 	@ParameterizedTest
-	@MethodSource("appenderFlags")
-	void batchOutputFailureIsCaughtAndReported(Set<AppenderFlag> flags, Class<?> expectedType) {
+	@MethodSource("appenderTypes")
+	void batchOutputFailureIsCaughtAndReported(AppenderType type, Class<?> expectedType) {
 		var output = new ListLogOutput();
 		output.setConsumer((e, s) -> {
 			throw new RuntimeException("output boom");
 		});
 		var config = LogConfig.builder().build();
-		var appender = appender(flags, output, encoder(), config);
+		var appender = appender(type, output, encoder(), config);
 		assertEquals(expectedType, appender.getClass());
 
 		var events = new LogEvent[] { TestLogEventFactory.of().event("one"), TestLogEventFactory.of().event("two") };
@@ -93,9 +91,8 @@ class AppenderAlertReportingTest {
 		return LogFormatter.builder().message().encoder().build().provide("test", LogConfig.builder().build());
 	}
 
-	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output, LogEncoder encoder,
-			LogConfig config) {
-		return DirectLogAppender.of("test", output, encoder, flags, config.alerts(), config.metrics());
+	private static LogAppender appender(AppenderType type, ListLogOutput output, LogEncoder encoder, LogConfig config) {
+		return DirectLogAppender.of("test", output, encoder, type, Set.of(), config.alerts(), config.metrics());
 	}
 
 	private static long failedEventsCount(LogConfig config) {

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeFlagPermutationTest.java
@@ -15,17 +15,18 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.LogAppender.Appenders;
 import io.jstach.rainbowgum.LogAppenderFlagTest.CountingListLogOutput;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 /**
- * End-to-end permutation coverage across every {@link AppenderFlag} combination and both
- * {@link Appenders} "as" modes ({@link Appenders#asSingle()}, {@link Appenders#asList()})
- * - a baseline safety net that caught the {@code SHARED_APPENDER_LOCK}/
- * {@code asSingleSharedLock()} reentry inconsistency documented in
- * {@link AppenderAsModeReentryTest} before that whole shared-lock composite strategy was
- * removed. Appenders always keep their own independent lock now.
+ * End-to-end permutation coverage across every {@link AppenderType}/{@link AppenderFlag}
+ * combination and both {@link Appenders} "as" modes ({@link Appenders#asSingle()},
+ * {@link Appenders#asList()}) - a baseline safety net that caught the
+ * {@code SHARED_APPENDER_LOCK}/{@code asSingleSharedLock()} reentry inconsistency
+ * documented in {@link AppenderAsModeReentryTest} before that whole shared-lock composite
+ * strategy was removed. Appenders always keep their own independent lock now.
  * <p>
  * {@code asList()} has no real production caller today - only {@code asSingle()} is used
  * by the built-in DEFAULT/SYNC/ASYNC publisher factories (see
@@ -42,18 +43,20 @@ class AppenderAsModeFlagPermutationTest {
 
 	}
 
-	record CombinationCase(AsMode mode, Set<AppenderFlag> flags) {
+	record CombinationCase(AsMode mode, AppenderType type, Set<AppenderFlag> flags) {
 		@Override
 		public String toString() {
-			return mode + " " + flags;
+			return mode + " " + type + " " + flags;
 		}
 	}
 
 	static Stream<Arguments> permutations() {
 		List<Arguments> args = new ArrayList<>();
-		for (var flags : powerSet(AppenderFlag.values())) {
-			for (var mode : AsMode.values()) {
-				args.add(Arguments.of(new CombinationCase(mode, flags)));
+		for (var type : AppenderType.values()) {
+			for (var flags : powerSet(AppenderFlag.values())) {
+				for (var mode : AsMode.values()) {
+					args.add(Arguments.of(new CombinationCase(mode, type, flags)));
+				}
 			}
 		}
 		return args.stream();
@@ -78,6 +81,7 @@ class AppenderAsModeFlagPermutationTest {
 	@MethodSource("permutations")
 	void testPermutation(CombinationCase testCase) {
 		var mode = testCase.mode();
+		var type = testCase.type();
 		var flags = testCase.flags();
 
 		LogConfig config = LogConfig.builder().build();
@@ -87,12 +91,16 @@ class AppenderAsModeFlagPermutationTest {
 				LogAppender.builder("a")
 					.encoder(LogFormatter.builder().message().encoder().build())
 					.output(outputA)
+					.appenderType(type)
+					.flags(flags)
 					.build(),
 				LogAppender.builder("b")
 					.encoder(LogFormatter.builder().message().encoder().build())
 					.output(outputB)
+					.appenderType(type)
+					.flags(flags)
 					.build());
-		var appenders = new Appenders("test-route", config, providers).flags(flags);
+		var appenders = new Appenders("test-route", config, providers);
 
 		LogPublisher publisher = switch (mode) {
 			case SINGLE -> new DefaultSyncLogPublisher(appenders.asSingle());
@@ -117,22 +125,11 @@ class AppenderAsModeFlagPermutationTest {
 		assertEquals(expectedFlushes, outputA.flushCount, "outputA flush count");
 		assertEquals(expectedFlushes, outputB.flushCount, "outputB flush count");
 
-		Class<?> expectedAppenderClass;
-		if (flags.contains(AppenderFlag.REUSE_BUFFER)) {
-			expectedAppenderClass = ReuseBufferLogAppender.class;
-		}
-		else if (flags.contains(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER)) {
-			expectedAppenderClass = SynchronizedThreadLocalBufferLogAppender.class;
-		}
-		else {
-			// Either LOCK_THREAD_LOCAL_BUFFER explicitly, or no buffer-strategy flag at
-			// all (REENTRY_DROP/REENTRY_LOG alone included) - both resolve to
-			// LockThreadLocalBufferLogAppender, the default appender selection, since
-			// that's exactly what DirectLogAppender#defaultAppender picks. Both
-			// ThreadLocalBuffer appenders support reentry detection directly, so no
-			// third appender is ever needed for those flags alone.
-			expectedAppenderClass = LockThreadLocalBufferLogAppender.class;
-		}
+		Class<?> expectedAppenderClass = switch (type) {
+			case REUSE_BUFFER -> ReuseBufferLogAppender.class;
+			case SYNCHRONIZED_THREAD_LOCAL_BUFFER -> SynchronizedThreadLocalBufferLogAppender.class;
+			case LOCK_THREAD_LOCAL_BUFFER -> LockThreadLocalBufferLogAppender.class;
+		};
 		for (var direct : directAppenders(mode, publisher)) {
 			assertInstanceOf(expectedAppenderClass, direct);
 		}

--- a/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/AppenderAsModeReentryTest.java
@@ -8,7 +8,6 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -88,17 +87,6 @@ class AppenderAsModeReentryTest {
 			}
 		});
 
-		/*
-		 * The reentry flag is set both on each appender's own builder and via
-		 * Appenders.flags(...). An individual DirectLogAppender's *lock* (as opposed to
-		 * its flags field, used only for immediateFlush/REUSE_BUFFER selection) is fixed
-		 * once, from whatever flags were on its builder at construction
-		 * (LockLogAppender.withFlags always reuses `this.lock` unchanged, no matter what
-		 * flags are merged in later) - so only a REENTRY_DROP/REENTRY_LOG set on the
-		 * *appender builder* actually matters for the reentry check; Appenders.flags(...)
-		 * alone would do nothing for it. Setting both keeps this test robust regardless
-		 * of which one turns out to matter.
-		 */
 		List<LogProvider<LogAppender>> providers = List.of(
 				LogAppender.builder("a")
 					.encoder(LogFormatter.builder().message().encoder().build())
@@ -110,7 +98,7 @@ class AppenderAsModeReentryTest {
 					.output(outputB)
 					.flag(reentryFlag)
 					.build());
-		var appenders = new Appenders("test-route", config, providers).flags(Set.of(reentryFlag));
+		var appenders = new Appenders("test-route", config, providers);
 
 		LogPublisher publisher = switch (mode) {
 			case SINGLE -> new DefaultSyncLogPublisher(appenders.asSingle());

--- a/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/DefaultAppenderSelectionTest.java
@@ -19,15 +19,13 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 /**
- * Exercises {@code DirectLogAppender#defaultAppender} directly (always
- * {@code LockThreadLocalBufferLogAppender} - see that method's javadoc for why, after
- * real-workload benchmarking under virtual threads found {@code synchronized} to be a
- * large, reproducible loss there despite winning under platform threads), plus
+ * Exercises {@link DirectLogAppender#of} directly for each {@link AppenderType}, plus
  * {@code LogProperties#GLOBAL_APPENDER_REENTRANT_LOCK_PROPERTY}'s guarantee that even an
- * explicit {@link AppenderFlag#SYNCHRONIZED_THREAD_LOCAL_BUFFER} request gets downgraded
+ * explicit {@link AppenderType#SYNCHRONIZED_THREAD_LOCAL_BUFFER} request gets downgraded
  * when that global property is active, and that
  * {@code SynchronizedThreadLocalBufferLogAppender}'s reentry detection (via
  * {@link Thread#holdsLock(Object)} rather than a
@@ -62,44 +60,35 @@ class DefaultAppenderSelectionTest {
 	}
 
 	@Test
-	void noFlagsSelectsLockThreadLocalBuffer() {
-		var appender = appender(Set.of());
+	void lockThreadLocalBufferTypeSelectsLockThreadLocalBuffer() {
+		var appender = appender(AppenderType.LOCK_THREAD_LOCAL_BUFFER, Set.of());
 		assertInstanceOf(LockThreadLocalBufferLogAppender.class, appender);
 	}
 
 	@Test
-	void globalForceReentrantLockDowngradesExplicitSynchronizedFlag() {
+	void globalForceReentrantLockDowngradesExplicitSynchronizedType() {
 		AbstractLogAppender.forceReentrantLockAppenders = true;
-		var appender = appender(EnumSet.of(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER));
+		var appender = appender(AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER, Set.of());
 		assertInstanceOf(LockThreadLocalBufferLogAppender.class, appender);
 	}
 
 	@Test
-	void globalForceReentrantLockDowngradesExplicitSynchronizedFlagOnWithFlags() {
-		var appender = appender(Set.of());
-		AbstractLogAppender.forceReentrantLockAppenders = true;
-		var reflagged = ((DirectLogAppender) appender)
-			.withFlags(EnumSet.of(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER));
-		assertInstanceOf(LockThreadLocalBufferLogAppender.class, reflagged);
-	}
-
-	@Test
-	void reentryDropWithNoOtherFlagSelectsLockThreadLocalBuffer() {
-		var appender = appender(EnumSet.of(AppenderFlag.REENTRY_DROP));
+	void reentryDropWithLockThreadLocalBufferType() {
+		var appender = appender(AppenderType.LOCK_THREAD_LOCAL_BUFFER, EnumSet.of(AppenderFlag.REENTRY_DROP));
 		assertInstanceOf(LockThreadLocalBufferLogAppender.class, appender);
 	}
 
 	@Test
-	void reentryLogWithNoOtherFlagSelectsLockThreadLocalBuffer() {
-		var appender = appender(EnumSet.of(AppenderFlag.REENTRY_LOG));
+	void reentryLogWithLockThreadLocalBufferType() {
+		var appender = appender(AppenderType.LOCK_THREAD_LOCAL_BUFFER, EnumSet.of(AppenderFlag.REENTRY_LOG));
 		assertInstanceOf(LockThreadLocalBufferLogAppender.class, appender);
 	}
 
 	@Test
 	void synchronizedThreadLocalBufferReentryDropFlagDropsReentrantAppend() {
 		var output = new ListLogOutput();
-		var testAppender = appender(
-				EnumSet.of(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER, AppenderFlag.REENTRY_DROP), output);
+		var testAppender = appender(AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER,
+				EnumSet.of(AppenderFlag.REENTRY_DROP), output);
 		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, testAppender);
 		output.setConsumer((e, s) -> {
 			// A naughty output that logs during its own write - should be dropped.
@@ -112,7 +101,7 @@ class DefaultAppenderSelectionTest {
 	@Test
 	void synchronizedThreadLocalBufferReentryLogFlagDropsReentrantAppendAndLogsDiagnostic() {
 		var output = new ListLogOutput();
-		var testAppender = appender(EnumSet.of(AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER, AppenderFlag.REENTRY_LOG),
+		var testAppender = appender(AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER, EnumSet.of(AppenderFlag.REENTRY_LOG),
 				output);
 		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, testAppender);
 		output.setConsumer((e, s) -> {
@@ -140,12 +129,12 @@ class DefaultAppenderSelectionTest {
 		.build()
 		.provide("test", CONFIG);
 
-	private static LogAppender appender(Set<AppenderFlag> flags) {
-		return appender(flags, new ListLogOutput());
+	private static LogAppender appender(AppenderType type, Set<AppenderFlag> flags) {
+		return appender(type, flags, new ListLogOutput());
 	}
 
-	private static LogAppender appender(Set<AppenderFlag> flags, ListLogOutput output) {
-		return DirectLogAppender.of("test", output, ENCODER, flags, CONFIG.alerts(), CONFIG.metrics());
+	private static LogAppender appender(AppenderType type, Set<AppenderFlag> flags, ListLogOutput output) {
+		return DirectLogAppender.of("test", output, ENCODER, type, flags, CONFIG.alerts(), CONFIG.metrics());
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/FormatterEncoderTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/FormatterEncoderTest.java
@@ -6,9 +6,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
-import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.LogOutput.ContentType;
 import io.jstach.rainbowgum.LogOutput.WriteMethod;
 import io.jstach.rainbowgum.output.ListLogOutput;
@@ -53,8 +54,8 @@ class FormatterEncoderTest {
 	@Test
 	void reuseBufferAcrossEventsDoesNotLeakPreviousLongerMessage() {
 		var output = new WriteMethodOutput(WriteMethod.BYTE_BUFFER);
-		encodeInto(output, List.of(AppenderFlag.REUSE_BUFFER),
-				"this is a much longer first message that should not leak", "short");
+		encodeInto(output, AppenderType.REUSE_BUFFER, "this is a much longer first message that should not leak",
+				"short");
 		assertEquals(List.of("[INFO] this is a much longer first message that should not leak\n", "[INFO] short\n"),
 				output.events().stream().map(e -> e.getValue()).toList());
 	}
@@ -75,7 +76,7 @@ class FormatterEncoderTest {
 				write(event, new String(arr, java.nio.charset.StandardCharsets.UTF_8));
 			}
 		};
-		encodeInto(output, List.of(), "hello");
+		encodeInto(output, null, "hello");
 		assertEquals(List.of("[INFO] hello\n"), output.events().stream().map(e -> e.getValue()).toList());
 	}
 
@@ -88,7 +89,7 @@ class FormatterEncoderTest {
 						+ "not LogOutput's default ByteBuffer bridge");
 			}
 		};
-		encodeInto(output, List.of(), "hello");
+		encodeInto(output, null, "hello");
 		assertEquals(List.of("[INFO] hello\n"), output.events().stream().map(e -> e.getValue()).toList());
 	}
 
@@ -105,7 +106,7 @@ class FormatterEncoderTest {
 				fail("expected write(LogEvent, String) to be called for STRING, not the ByteBuffer overload");
 			}
 		};
-		encodeInto(output, List.of(), "hello");
+		encodeInto(output, null, "hello");
 		assertEquals(List.of("[INFO] hello\n"), output.events().stream().map(e -> e.getValue()).toList());
 	}
 
@@ -119,17 +120,19 @@ class FormatterEncoderTest {
 
 	private static String encodeWith(WriteMethod writeMethod, String message) {
 		var output = new WriteMethodOutput(writeMethod);
-		encodeInto(output, List.of(), message);
+		encodeInto(output, null, message);
 		return output.toString();
 	}
 
-	private static void encodeInto(WriteMethodOutput output, List<AppenderFlag> flags, String... messages) {
+	private static void encodeInto(WriteMethodOutput output, @Nullable AppenderType type, String... messages) {
 		var config = LogConfig.builder().build();
 		var gum = RainbowGum.builder(config).route(r -> {
 			r.appender("list", a -> {
 				a.output(output);
 				a.encoder(LogEncoder.of(FORMATTER));
-				a.flags(flags);
+				if (type != null) {
+					a.appenderType(type);
+				}
 			});
 		}).build();
 		try (var g = gum.start()) {

--- a/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogAppenderFlagTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.output.ListLogOutput;
 
 /**
@@ -48,9 +50,17 @@ class LogAppenderFlagTest {
 	}
 
 	private static LogAppender appender(String name, ListLogOutput output, AppenderFlag... flags) {
+		return appender(name, output, null, flags);
+	}
+
+	private static LogAppender appender(String name, ListLogOutput output, @Nullable AppenderType type,
+			AppenderFlag... flags) {
 		var builder = LogAppender.builder(name)
 			.encoder(LogFormatter.builder().message().encoder().build())
 			.output(output);
+		if (type != null) {
+			builder.appenderType(type);
+		}
 		for (var flag : flags) {
 			builder.flag(flag);
 		}
@@ -137,7 +147,7 @@ class LogAppenderFlagTest {
 	@Test
 	void immediateFlushFlagsRespectedWithReuseBuffer() {
 		var output = new CountingListLogOutput();
-		var testAppender = appender("test", output, AppenderFlag.REUSE_BUFFER, AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
+		var testAppender = appender("test", output, AppenderType.REUSE_BUFFER, AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
 		assertInstanceOf(ReuseBufferLogAppender.class, testAppender);
 		testAppender.append(TestLogEventFactory.of().event("single"));
 		testAppender.append(new LogEvent[] { TestLogEventFactory.of().event("batch") }, 1);
@@ -147,7 +157,7 @@ class LogAppenderFlagTest {
 	@Test
 	void immediateFlushFlagsRespectedWithThreadLocalBuffer() {
 		var output = new CountingListLogOutput();
-		var testAppender = appender("test", output, AppenderFlag.LOCK_THREAD_LOCAL_BUFFER,
+		var testAppender = appender("test", output, AppenderType.LOCK_THREAD_LOCAL_BUFFER,
 				AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
 		assertInstanceOf(LockThreadLocalBufferLogAppender.class, testAppender);
 		testAppender.append(TestLogEventFactory.of().event("single"));
@@ -158,7 +168,7 @@ class LogAppenderFlagTest {
 	@Test
 	void threadLocalBufferFlagReusesBufferPerThread() {
 		var output = new ListLogOutput();
-		var testAppender = appender("test", output, AppenderFlag.LOCK_THREAD_LOCAL_BUFFER);
+		var testAppender = appender("test", output, AppenderType.LOCK_THREAD_LOCAL_BUFFER);
 		testAppender.append(TestLogEventFactory.of().event("one"));
 		testAppender.append(TestLogEventFactory.of().event("two"));
 		assertEquals(List.of("one", "two"), output.events().stream().map(e -> e.getKey().message()).toList());
@@ -167,7 +177,7 @@ class LogAppenderFlagTest {
 	@Test
 	void immediateFlushFlagsRespectedWithSynchronizedThreadLocalBuffer() {
 		var output = new CountingListLogOutput();
-		var testAppender = appender("test", output, AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER,
+		var testAppender = appender("test", output, AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER,
 				AppenderFlag.DISABLE_IMMEDIATE_FLUSH);
 		assertInstanceOf(SynchronizedThreadLocalBufferLogAppender.class, testAppender);
 		testAppender.append(TestLogEventFactory.of().event("single"));
@@ -178,68 +188,10 @@ class LogAppenderFlagTest {
 	@Test
 	void synchronizedThreadLocalBufferFlagReusesBufferPerThread() {
 		var output = new ListLogOutput();
-		var testAppender = appender("test", output, AppenderFlag.SYNCHRONIZED_THREAD_LOCAL_BUFFER);
+		var testAppender = appender("test", output, AppenderType.SYNCHRONIZED_THREAD_LOCAL_BUFFER);
 		testAppender.append(TestLogEventFactory.of().event("one"));
 		testAppender.append(TestLogEventFactory.of().event("two"));
 		assertEquals(List.of("one", "two"), output.events().stream().map(e -> e.getKey().message()).toList());
-	}
-
-	@Test
-	void appenderLevelFlagsMergeOntoExistingAppenderWithoutReuseBuffer() {
-		LogConfig config = LogConfig.builder().build();
-		var output = new CountingListLogOutput();
-		List<LogProvider<LogAppender>> providers = List.of(LogAppender.builder("test")
-			.encoder(LogFormatter.builder().message().encoder().build())
-			.output(output)
-			.build());
-		var appenders = new LogAppender.Appenders("test-route", config, providers);
-		var result = appenders.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)).asSingle();
-		result.start(config);
-		// No buffer-strategy flag set - resolves to the default appender selection,
-		// LockThreadLocalBufferLogAppender.
-		assertInstanceOf(LockThreadLocalBufferLogAppender.class, result);
-		result.append(TestLogEventFactory.of().event("hello"));
-		assertEquals(0, output.flushCount);
-	}
-
-	@Test
-	void appenderLevelFlagsAlreadyPresentIsNoop() {
-		LogConfig config = LogConfig.builder().build();
-		var output = new CountingListLogOutput();
-		List<LogProvider<LogAppender>> providers = List.of(LogAppender.builder("test")
-			.encoder(LogFormatter.builder().message().encoder().build())
-			.output(output)
-			.flag(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)
-			.build());
-		var appenders = new LogAppender.Appenders("test-route", config, providers);
-		var result = appenders.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH)).asSingle();
-		result.start(config);
-		result.append(TestLogEventFactory.of().event("hello"));
-		assertEquals(0, output.flushCount);
-	}
-
-	@Test
-	void appenderLevelFlagsMergeOntoMultiAppenderComposite() {
-		LogConfig config = LogConfig.builder().build();
-		var outputA = new CountingListLogOutput();
-		var outputB = new CountingListLogOutput();
-		List<LogProvider<LogAppender>> providers = List.of(
-				LogAppender.builder("a")
-					.encoder(LogFormatter.builder().message().encoder().build())
-					.output(outputA)
-					.build(),
-				LogAppender.builder("b")
-					.encoder(LogFormatter.builder().message().encoder().build())
-					.output(outputB)
-					.build());
-		var appenders = new LogAppender.Appenders("test-route", config, providers)
-			.flags(Set.of(AppenderFlag.DISABLE_IMMEDIATE_FLUSH));
-		var result = appenders.asSingle();
-		result.start(config);
-		assertInstanceOf(CompositeLogAppender.class, result);
-		result.append(TestLogEventFactory.of().event("hello"));
-		assertEquals(0, outputA.flushCount);
-		assertEquals(0, outputB.flushCount);
 	}
 
 	static class CountingListLogOutput extends ListLogOutput {

--- a/core/src/test/java/io/jstach/rainbowgum/RainbowGumPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RainbowGumPropertyTest.java
@@ -74,7 +74,7 @@ class RainbowGumPropertyTest {
 				logging.appenders=list
 				logging.appender.list.output=list
 				logging.level=ERROR
-				logging.appender.list.flags=reuse_buffer
+				logging.appender.list.type=reuse_buffer
 				""", """
 				00:00:00.001 [main] ERROR com.pattern.test.Test - hello
 				""") {
@@ -92,7 +92,7 @@ class RainbowGumPropertyTest {
 				logging.appenders=list
 				logging.appender.list.output=list
 				logging.level=ERROR
-				logging.appender.list.flags=lock_thread_local_buffer
+				logging.appender.list.type=lock_thread_local_buffer
 				""", """
 				00:00:00.001 [main] ERROR com.pattern.test.Test - hello
 				""") {
@@ -110,7 +110,7 @@ class RainbowGumPropertyTest {
 				logging.appenders=list
 				logging.appender.list.output=list
 				logging.level=ERROR
-				logging.appender.list.flags=synchronized_thread_local_buffer
+				logging.appender.list.type=synchronized_thread_local_buffer
 				""", """
 				00:00:00.001 [main] ERROR com.pattern.test.Test - hello
 				""") {

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -716,14 +716,14 @@ Thus to register appenders to the default route one can use:
 
 {@snippet lang=properties :
 logging.appenders=myappender
-logging.appender.myappender.flags=reuse_buffer # an example config of appender
+logging.appender.myappender.type=reuse_buffer # an example config of appender
 }
 
 If the route is named say "example" then configuration of the appenders can be done like:
 
 {@snippet lang=properties :
 logging.route.example.appenders=myappender
-logging.appender.myappender.flags=reuse_buffer # an example config of appender
+logging.appender.myappender.type=reuse_buffer # an example config of appender
 }
 
 <h3 id="appender_config">Appender Configuration</h3>
@@ -736,6 +736,8 @@ or through properties.
   <dd>{@value io.jstach.rainbowgum.LogAppender#APPENDER_OUTPUT_PROPERTY} = URI</dd>
   <dt><a href="#encoder">Encoder</a></dt>
   <dd>{@value io.jstach.rainbowgum.LogAppender#APPENDER_ENCODER_PROPERTY} = URI</dd>
+  <dt>{@linkplain io.jstach.rainbowgum.LogAppender.AppenderType Type}</dt>
+  <dd>{@value io.jstach.rainbowgum.LogAppender#APPENDER_TYPE_PROPERTY} = a single {@link io.jstach.rainbowgum.LogAppender.AppenderType}</dd>
   <dt>{@linkplain io.jstach.rainbowgum.LogAppender.AppenderFlag Flags}</dt>
   <dd>{@value io.jstach.rainbowgum.LogAppender#APPENDER_FLAGS_PROPERTY} = List of {@link io.jstach.rainbowgum.LogAppender.AppenderFlag}</dd>
 </dl>
@@ -1230,7 +1232,7 @@ logging.appender.console.encoder=pattern
 
 logging.appender.jsonfile.output=./logs/orders.json.log
 logging.appender.jsonfile.encoder=gelf
-logging.appender.jsonfile.flags=reuse_buffer
+logging.appender.jsonfile.type=reuse_buffer
 
 logging.appender.errorfile.output=./logs/orders-error.log?bufferSize=10000
 logging.appender.errorfile.encoder=pattern

--- a/rainbowgum-disruptor/src/main/java/io/jstach/rainbowgum/disruptor/DisruptorLogPublisher.java
+++ b/rainbowgum-disruptor/src/main/java/io/jstach/rainbowgum/disruptor/DisruptorLogPublisher.java
@@ -1,7 +1,6 @@
 package io.jstach.rainbowgum.disruptor;
 
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 
@@ -45,8 +44,7 @@ public final class DisruptorLogPublisher implements AsyncLogPublisher {
 		return new PublisherFactory() {
 			@Override
 			public LogPublisher create(String name, LogConfig config, Appenders appenders) {
-				return of(appenders.flags(EnumSet.of(LogAppender.AppenderFlag.REUSE_BUFFER)).asList(),
-						DaemonThreadFactory.INSTANCE, bufferSize, config.alerts());
+				return of(appenders.asList(), DaemonThreadFactory.INSTANCE, bufferSize, config.alerts());
 			}
 		};
 	}

--- a/rainbowgum/src/test/java/snippets/FullConfigurationExample.java
+++ b/rainbowgum/src/test/java/snippets/FullConfigurationExample.java
@@ -1,10 +1,9 @@
 package snippets;
 
 import java.lang.System.Logger.Level;
-import java.util.EnumSet;
 import java.util.Optional;
 
-import io.jstach.rainbowgum.LogAppender.AppenderFlag;
+import io.jstach.rainbowgum.LogAppender.AppenderType;
 import io.jstach.rainbowgum.LogConfig;
 import io.jstach.rainbowgum.LogOutput;
 import io.jstach.rainbowgum.LogPublisher.PublisherFactory;
@@ -54,7 +53,7 @@ public class FullConfigurationExample implements RainbowGumProvider {
 						.pattern("%d{ISO8601} [%thread] %-5level %logger{50} - %msg%n")
 						.fromProperties(config.properties())
 						.build());
-					a.flags(EnumSet.of(AppenderFlag.REUSE_BUFFER));
+					a.appenderType(AppenderType.REUSE_BUFFER);
 				});
 			}) //
 			.route("errors", r -> {


### PR DESCRIPTION
REUSE_BUFFER/LOCK_THREAD_LOCAL_BUFFER/SYNCHRONIZED_THREAD_LOCAL_BUFFER move out of AppenderFlag into a new AppenderType enum where exactly one applies per appender, set on LogAppender.Builder (or via the new logging.appender.{name}.type property) at construction time. The rest of AppenderFlag (DISABLE_IMMEDIATE_FLUSH/REENTRY_DROP/REENTRY_LOG) stays as-is.

This lets DirectLogAppender.withFlags(...) go away entirely, along with LogAppender.Appenders#flags(...) and CompositeLogAppender's own withFlags - their only real caller was the async publishers forcing REUSE_BUFFER onto already-built appenders, which is exactly the "publisher changes the appender type after the fact" case we no longer want. An appender's type is now fixed for its lifetime; a publisher that wants REUSE_BUFFER has to be configured with it up front like anything else.

Net removal of code: DirectLogAppender#defaultAppender and the guardSynchronizedFlag Set-reconstruction logic are gone too, replaced by a plain switch and a one-line type comparison.