### PR TITLE
Remove Result.value(fallback) overloads in favor of or(fallback).value()

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -721,7 +721,7 @@ final class GroupLevelResolver implements LevelConfig {
 					.ifPresent(loggers -> m.put(g, loggers));
 			}
 			return m;
-		}).get(properties).value(Map.of());
+		}).get(properties).or(Map.of()).value();
 
 		Map<String, Level> groupToLevels = new LinkedHashMap<>();
 		for (var e : groupToLoggers.entrySet()) {

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -115,7 +115,8 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 
 		var output = outputProperty(LogAppender.APPENDER_OUTPUT_PROPERTY, name, config) //
 			.get() //
-			.value(() -> LogOutput.ofStandardOut().provide(name, config));
+			.or(() -> LogOutput.ofStandardOut().provide(name, config))
+			.value();
 
 		var encoderProperty = encoderProperty(LogAppender.APPENDER_ENCODER_PROPERTY, name, config);
 
@@ -138,7 +139,8 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			.map(AppenderFlag::parse) //
 			.buildWithName(LogAppender.APPENDER_FLAGS_PROPERTY, name) //
 			.get(config.properties())
-			.value(EnumSet.noneOf(LogAppender.AppenderFlag.class));
+			.or(EnumSet.noneOf(LogAppender.AppenderFlag.class))
+			.value();
 	}
 
 	private static AppenderType resolveAppenderType(LogConfig config, String name) {
@@ -146,7 +148,8 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			.map(AppenderType::parse) //
 			.buildWithName(LogAppender.APPENDER_TYPE_PROPERTY, name) //
 			.get(config.properties())
-			.value(AppenderType.LOCK_THREAD_LOCAL_BUFFER);
+			.or(AppenderType.LOCK_THREAD_LOCAL_BUFFER)
+			.value();
 	}
 
 	static LogAppender fileAppender(LogConfig config) {

--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -387,7 +387,7 @@ abstract class AbstractChangePublisher implements ChangePublisher {
 
 	@Override
 	public Set<ChangeType> allowedChanges(String loggerName) {
-		return changeSetting.get(config().properties(), loggerName).value(Set.of());
+		return changeSetting.get(config().properties(), loggerName).or(Set.of()).value();
 	}
 
 }
@@ -446,7 +446,8 @@ final class DefaultLogConfig implements LogConfig {
 			.ofBoolean()
 			.build(LogProperties.GLOBAL_CHANGE_PROPERTY)
 			.get(properties)
-			.value(false);
+			.or(false)
+			.value();
 		this.changePublisher = changeable ? new DefaultChangePublisher() : IgnoreChangePublisher.INSTANT;
 		applyGlobalAppenderReentrantLockProperty(properties);
 		this.outputRegistry = DefaultOutputRegistry.of(registry);
@@ -470,7 +471,8 @@ final class DefaultLogConfig implements LogConfig {
 			.ofBoolean()
 			.build(LogProperties.GLOBAL_APPENDER_REENTRANT_LOCK_PROPERTY)
 			.get(properties)
-			.value(false);
+			.or(false)
+			.value();
 	}
 
 	class DefaultChangePublisher extends AbstractChangePublisher {

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -421,22 +421,6 @@ public sealed interface LogProperty {
 		public T value() throws PropertyMissingException, PropertyConvertException;
 
 		/**
-		 * Gets a value if there if not uses the fallback if not null otherwise throws an
-		 * exception.
-		 * @param fallback maybe <code>null</code>.
-		 * @return value.
-		 * @throws PropertyMissingException if no property and fallback is
-		 * <code>null</code>.
-		 * @throws PropertyConvertException if the property failed conversion.
-		 */
-		default T value(@Nullable T fallback) throws PropertyMissingException, PropertyConvertException {
-			if (fallback == null) {
-				return value();
-			}
-			return value(() -> fallback);
-		}
-
-		/**
 		 * Returns the current result if fallback is null or returns fallback as a result
 		 * if this result is missing.
 		 * @param fallback maybe <code>null</code>.
@@ -462,18 +446,6 @@ public sealed interface LogProperty {
 		 */
 		@Override
 		public <U> Result<U> map(PropertyFunction<T, U, ? super Exception> mapper);
-
-		/**
-		 * Gets a value if there if not uses the fallback if not null otherwise throws an
-		 * exception.
-		 * @param fallback maybe <code>null</code>.
-		 * @return value.
-		 * @throws PropertyMissingException if no property and fallback is
-		 * <code>null</code>.
-		 * @throws PropertyConvertException if the property failed conversion.
-		 */
-		public T value(@SuppressWarnings("exports") Supplier<? extends @Nullable T> fallback)
-				throws PropertyMissingException, PropertyConvertException;
 
 		/**
 		 * Convenience that turns a value into an optional.
@@ -507,11 +479,6 @@ public sealed interface LogProperty {
 			 */
 			@Override
 			public T value();
-
-			@Override
-			default T value(@SuppressWarnings("exports") Supplier<? extends @Nullable T> fallback) {
-				return value();
-			}
 
 			@Override
 			default Success<T> or(@Nullable T fallback) {
@@ -642,16 +609,6 @@ public sealed interface LogProperty {
 			}
 
 			@Override
-			public T value(@SuppressWarnings("exports") Supplier<? extends @Nullable T> fallback)
-					throws NoSuchElementException {
-				T v = fallback.get();
-				if (v != null) {
-					return v;
-				}
-				throw new PropertyMissingException(message);
-			}
-
-			@Override
 			public Result<T> or(@Nullable T fallback) {
 				if (fallback != null) {
 					return new Success.ValueSuccess<>(keys.get(0), fallback);
@@ -706,12 +663,6 @@ public sealed interface LogProperty {
 
 			@Override
 			public T value() throws PropertyConvertException {
-				throw new PropertyConvertException(key, message, cause);
-			}
-
-			@Override
-			public T value(@SuppressWarnings("exports") Supplier<? extends @Nullable T> fallback)
-					throws PropertyConvertException {
 				throw new PropertyConvertException(key, message, cause);
 			}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
@@ -154,7 +154,8 @@ enum DefaultPublisherProviders implements LogPublisher.PublisherProvider {
 				.ofInt() //
 				.buildWithName(LogPublisherRegistry.BUFFER_SIZE_PROPERTY, name) //
 				.get(properties) //
-				.value(LogPublisherRegistry.ASYNC_BUFFER_SIZE);
+				.or(LogPublisherRegistry.ASYNC_BUFFER_SIZE)
+				.value();
 			return (n, config, appenders) -> BlockingQueueAsyncLogPublisher.of(appenders.asSingle(), _bufferSize,
 					config.alerts());
 		}

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -349,7 +349,8 @@ public sealed interface LogRouter extends LogLifecycle {
 					.map(RouteFlag::parse)
 					.buildWithName(LogProperties.ROUTE_FLAGS_PROPERTY, name)
 					.get(config.properties())
-					.value(EnumSet.noneOf(RouteFlag.class)));
+					.or(EnumSet.noneOf(RouteFlag.class))
+					.value());
 				String routerLevelPrefix = LogProperties.interpolateNamedKey(LogProperties.ROUTE_LEVEL_PREFIX, name);
 
 				/*
@@ -426,7 +427,8 @@ public sealed interface LogRouter extends LogLifecycle {
 						.map(r -> config.publisherRegistry().provide(r)) //
 						.buildWithName(LogProperties.ROUTE_PUBLISHER_PROPERTY, name)
 						.get(config.properties())
-						.value(() -> LogPublisher.SyncLogPublisher.builder().build());
+						.or(() -> LogPublisher.SyncLogPublisher.builder().build())
+						.value();
 				}
 
 				var apps = new LogAppender.Appenders(name, config, appenders);
@@ -790,7 +792,8 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 			.build(LogProperties.GLOBAL_QUEUE_LEVEL_PROPERTY)
 			.map(LevelResolver::parseLevel)
 			.get(LogProperties.StandardProperties.SYSTEM_PROPERTIES)
-			.value(Level.INFO);
+			.or(Level.INFO)
+			.value();
 	}
 
 	private static final Level errorLevel() {
@@ -798,7 +801,8 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 			.build(LogProperties.GLOBAL_QUEUE_ERROR_PROPERTY)
 			.map(LevelResolver::parseLevel)
 			.get(LogProperties.StandardProperties.SYSTEM_PROPERTIES)
-			.value(Level.ERROR);
+			.or(Level.ERROR)
+			.value();
 	}
 
 	private QueueEventsRouter(LevelResolver levelResolver, LevelResolver errorLevelResolver) {

--- a/core/src/main/java/io/jstach/rainbowgum/RainbowGum.java
+++ b/core/src/main/java/io/jstach/rainbowgum/RainbowGum.java
@@ -321,7 +321,8 @@ public sealed interface RainbowGum extends AutoCloseable, LogEventLogger {
 					.ofList()
 					.build(LogProperties.ROUTES_PROPERTY)
 					.get(config.properties())
-					.value(List.of());
+					.or(List.of())
+					.value();
 				if (routeNames.isEmpty()) {
 					routes = List.of(Router.builder(Router.DEFAULT_ROUTER_NAME, config).build());
 				}

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -157,10 +157,11 @@ class LogPropertyTest {
 	}
 
 	@Test
-	void testMissingValueWithFallbackSupplier() {
+	@SuppressWarnings({ "null", "nullness", "NullAway" })
+	void testMissingOrWithFallbackSupplier() {
 		Missing<String> missing = new Missing<>(List.of("key"), "Property missing. keys: [key]");
-		assertEquals("fallback", missing.value(() -> "fallback"));
-		assertThrows(PropertyMissingException.class, () -> missing.value(() -> null));
+		assertEquals("fallback", missing.or(() -> "fallback").value());
+		assertThrows(PropertyMissingException.class, () -> missing.or(() -> null).value());
 	}
 
 	@Test
@@ -177,7 +178,7 @@ class LogPropertyTest {
 		Error<String> error = new Error<>("key", "bad value", cause);
 		assertThrows(PropertyConvertException.class, () -> error.valueOrNull());
 		assertThrows(PropertyConvertException.class, error::value);
-		assertThrows(PropertyConvertException.class, () -> error.value(() -> "fallback"));
+		assertThrows(PropertyConvertException.class, () -> error.or(() -> "fallback").value());
 		assertEquals(error, error.or("fallback"));
 		assertEquals(error, error.or(() -> "fallback"));
 		assertEquals("Error[key](bad value)", error.describe());
@@ -195,10 +196,10 @@ class LogPropertyTest {
 	}
 
 	@Test
-	void testResultValueWithFallbackObject() {
+	void testResultOrWithFallbackObject() {
 		Result<String> missing = new Missing<>(List.of("key"), "missing");
-		assertEquals("fallback", missing.value("fallback"));
-		assertThrows(PropertyMissingException.class, () -> missing.value((String) null));
+		assertEquals("fallback", missing.or("fallback").value());
+		assertThrows(PropertyMissingException.class, () -> missing.or((String) null).value());
 	}
 
 	@Test

--- a/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
+++ b/rainbowgum-jansi/src/main/java/io/jstach/rainbowgum/jansi/JAnsiConfigurator.java
@@ -77,7 +77,8 @@ public class JAnsiConfigurator implements RainbowGumServiceProvider.Configurator
 			.ofBoolean() //
 			.build(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY) //
 			.get(config.properties()) //
-			.value(false);
+			.or(false)
+			.value();
 		return globalDisable;
 	}
 

--- a/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/JULConfigurator.java
+++ b/rainbowgum-jul/src/main/java/io/jstach/rainbowgum/jul/JULConfigurator.java
@@ -51,7 +51,7 @@ public final class JULConfigurator implements Configurator, AutoCloseable {
 		else {
 			installed = true;
 		}
-		var disableLevel = JUL_LEVEL_DISABLE_PROPERTY_.get(config.properties()).value(false);
+		var disableLevel = JUL_LEVEL_DISABLE_PROPERTY_.get(config.properties()).or(false).value();
 
 		if (!disableLevel) {
 			var logger = Logger.getLogger("");
@@ -79,7 +79,7 @@ public final class JULConfigurator implements Configurator, AutoCloseable {
 	 * @hidden
 	 */
 	public static boolean install(@SuppressWarnings("exports") LogProperties properties) {
-		if (JUL_DISABLE_PROPERTY_.get(properties).value(false)) {
+		if (JUL_DISABLE_PROPERTY_.get(properties).or(false).value()) {
 			return false;
 		}
 		if (!isLoggingModuleAvailable()) {

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternCompiler.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternCompiler.java
@@ -58,7 +58,8 @@ public sealed interface PatternCompiler {
 						.ofBoolean() //
 						.build(LogProperties.GLOBAL_ANSI_DISABLE_PROPERTY) //
 						.get(config.properties()) //
-						.value(() -> !AnsiSupport.isAnsiSupported());
+						.or(() -> !AnsiSupport.isAnsiSupported())
+						.value();
 					var b = PatternConfig.builder(name)
 						.propertyFunction(PatternConfig.propertyFunction(config.properties(),
 								PatternConfig.PATTERN_PROPERY_PREFIX))

--- a/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
+++ b/rainbowgum-pattern/src/main/java/io/jstach/rainbowgum/pattern/format/PatternConfigurator.java
@@ -68,7 +68,8 @@ public final class PatternConfigurator implements Configurator {
 			.ofBoolean()
 			.build(LOGGING_PATTERN_DISABLE_PROPERTY)
 			.get(config.properties())
-			.value(false);
+			.or(false)
+			.value();
 		if (!disable) {
 			config.encoderRegistry().setEncoderForOutputType(OutputType.CONSOLE_OUT, (name, c) -> {
 				PatternEncoderBuilder b = new PatternEncoderBuilder(name);

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
@@ -129,7 +129,8 @@ public abstract class RainbowGumSystemLoggerFinder extends System.LoggerFinder {
 			.map(InitOption::parse)
 			.build(INITIALIZE_RAINBOW_GUM_PROPERTY) //
 			.get(properties) //
-			.value(InitOption.CHECK);
+			.or(InitOption.CHECK)
+			.value();
 	}
 
 	private interface RouterProvider {


### PR DESCRIPTION
Both the plain-value and Supplier overloads of Result.value(fallback) were exactly redundant with the existing or(fallback).value() (verified identical behavior for Success/Missing/Error), just saving one method call. Rewrites every call site to the surviving form instead.