### PR TITLE
Make level resolution alert-and-fallback instead of throwing

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -324,10 +324,16 @@ public interface LevelResolver {
 		 * found for a logger name wins), and, if any {@link #fallback(LevelResolver)
 		 * fallbacks} were added, wrapping that in a priority chain where the fallbacks
 		 * are only consulted for logger names the combined resolver above has no opinion
-		 * on (resolves to {@link Level#ALL}). The result is cached.
-		 * @return level resolver.
+		 * on (resolves to {@link Level#ALL}). The result is cached - deferred as a
+		 * {@link LogProvider} (rather than building the cached resolver directly) since
+		 * the cache also needs {@link LogConfig#alerts()} to report a logger name whose
+		 * level property fails to resolve, and only a couple of resolver primitives (this
+		 * builder's cache, and separately the global resolver's own alerting wrapper)
+		 * need alerts at all - not every {@link LevelResolver}/{@link LevelConfig}
+		 * implementation.
+		 * @return level resolver provider.
 		 */
-		public LevelResolver build() {
+		public LogProvider<LevelResolver> build() {
 			var config = buildLevelConfigOrNull();
 			List<LevelResolver> copy = new ArrayList<>();
 			if (config != null) {
@@ -341,7 +347,8 @@ public interface LevelResolver {
 				priority.addAll(fallbacks);
 				resolver = PriorityLevelResolver.of(priority);
 			}
-			return cached(resolver);
+			var _resolver = resolver;
+			return (name, c) -> cached(_resolver, c.alerts());
 		}
 
 		/**
@@ -419,11 +426,11 @@ public interface LevelResolver {
 			return level;
 		}
 
-		static LevelResolver cached(LevelResolver resolver) {
+		static LevelResolver cached(LevelResolver resolver, LogAlerts alerts) {
 			if (resolver instanceof StaticLevelResolver) {
 				return resolver;
 			}
-			return new CachedLevelResolver(resolver);
+			return new CachedLevelResolver(resolver, alerts);
 		}
 
 	}
@@ -639,16 +646,39 @@ final class CachedLevelResolver implements LevelResolver {
 
 	private final LevelResolver levelResolver;
 
+	private final LogAlerts alerts;
+
 	private final ConcurrentHashMap<String, Level> levelCache = new ConcurrentHashMap<>();
 
-	public CachedLevelResolver(LevelResolver levelResolver) {
+	public CachedLevelResolver(LevelResolver levelResolver, LogAlerts alerts) {
 		super();
 		this.levelResolver = levelResolver;
+		this.alerts = alerts;
 	}
 
 	@Override
 	public Level resolveLevel(String name) {
-		return levelCache.computeIfAbsent(name, n -> levelResolver.resolveLevel(n));
+		return levelCache.computeIfAbsent(name, n -> {
+			try {
+				return levelResolver.resolveLevel(n);
+			}
+			catch (Exception e) {
+				/*
+				 * A malformed level property must not be able to break logging itself.
+				 * ConcurrentHashMap#computeIfAbsent leaves nothing cached when the
+				 * mapping function throws, so without catching here a bad property would
+				 * re-parse and re-throw on every single resolveLevel(n) call for this
+				 * logger name, not just once - a real amplification risk for a hot
+				 * logger. Fall back to a fixed, conservative default (Level.INFO,
+				 * matching LogProperties' own documented root default) and alert exactly
+				 * once per logger name instead, since the fallback value is itself cached
+				 * above just like a successful resolution would be.
+				 */
+				alerts.error(CachedLevelResolver.class,
+						"Failed to resolve level for logger '" + n + "', falling back to " + Level.INFO, e);
+				return Level.INFO;
+			}
+		});
 	}
 
 	@Override
@@ -660,6 +690,67 @@ final class CachedLevelResolver implements LevelResolver {
 	public void clear() {
 		levelCache.clear();
 		levelResolver.clear();
+	}
+
+}
+
+/**
+ * Wraps the global {@link LevelConfig} (see
+ * {@code LogConfig.Builder.buildGlobalResolver}) with the same
+ * alert-on-failure/fallback-to-INFO safety net as {@link CachedLevelResolver} gives every
+ * per-route resolver, but implemented at the {@link #levelOrNull(String)} level (not
+ * {@link #resolveLevel(String)}) so {@link LevelConfig#defaultLevel()} stays available -
+ * {@code LogConfig.levelResolver()} is declared to return {@link LevelConfig}, not just
+ * {@link LevelResolver}, and real callers use {@code defaultLevel()}. Unlike
+ * {@link CachedLevelResolver} this does not cache successful lookups (the global resolver
+ * never has), only failed ones, purely so a bad property alerts once per logger name
+ * instead of on every call.
+ * <p>
+ * Special-cased outside the normal {@code LevelResolver.Builder.build()} ->
+ * {@code LogProvider<LevelResolver>} path since the global resolver is built before a
+ * {@link LogConfig} exists to pull {@link LogAlerts} from - see where this is constructed
+ * for why {@link LogAlerts} (and {@link LogMetrics}, via alerts' own listener wiring) are
+ * built and handed in directly instead.
+ */
+final class AlertingLevelConfig implements LevelConfig {
+
+	private final LevelConfig levelConfig;
+
+	private final LogAlerts alerts;
+
+	private final ConcurrentHashMap<String, Level> failedNames = new ConcurrentHashMap<>();
+
+	AlertingLevelConfig(LevelConfig levelConfig, LogAlerts alerts) {
+		this.levelConfig = levelConfig;
+		this.alerts = alerts;
+	}
+
+	@Override
+	public @Nullable Level levelOrNull(String name) {
+		var fallback = failedNames.get(name);
+		if (fallback != null) {
+			return fallback;
+		}
+		try {
+			return levelConfig.levelOrNull(name);
+		}
+		catch (Exception e) {
+			alerts.error(AlertingLevelConfig.class,
+					"Failed to resolve level for logger '" + name + "', falling back to " + Level.INFO, e);
+			failedNames.putIfAbsent(name, Level.INFO);
+			return Level.INFO;
+		}
+	}
+
+	@Override
+	public void clear() {
+		failedNames.clear();
+		levelConfig.clear();
+	}
+
+	@Override
+	public String toString() {
+		return "AlertingLevelConfig[" + levelConfig + "]";
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -305,26 +305,47 @@ public sealed interface LogConfig extends LogProperty.PropertySupport {
 				logProperties = LogProperties.of(props, LogProperties.StandardProperties.SYSTEM_PROPERTIES);
 
 			}
-			var levelResolver = this.buildGlobalResolver(logProperties);
-			var config = new DefaultLogConfig(serviceRegistry, logProperties, levelResolver);
+			/*
+			 * Built before DefaultLogConfig itself (rather than left for
+			 * DefaultLogConfig's constructor to create, as before) specifically so
+			 * buildGlobalResolver below can hand LogAlerts to the global level resolver's
+			 * alerting wrapper - the global resolver is built before a full LogConfig
+			 * exists to pull config.alerts() from, so alerts (and metrics, via alerts'
+			 * own listener wiring) are constructed directly here instead.
+			 */
+			LogAlerts alerts = new DefaultLogAlerts(LogAlerts.DEFAULT_CAPACITY);
+			LogMetrics metrics = new DefaultLogMetrics();
+			var levelResolver = this.buildGlobalResolver(logProperties, alerts);
+			var config = new DefaultLogConfig(serviceRegistry, logProperties, levelResolver, alerts, metrics);
 			if (serviceLoader != null) {
 				configurators = new ArrayList<>(configurators);
 				findProviders(serviceLoader, Configurator.class).forEach(configurators::add);
 			}
 			if (!configurators.isEmpty()) {
+				/*
+				 * TODO two-pass config: configurators run after config (and therefore the
+				 * global level resolver above) already exists, so a configurator that
+				 * contributes additional property sources or otherwise changes what the
+				 * level resolver should have seen is invisible to it - the resolver was
+				 * already built from logProperties as it stood before any configurator
+				 * ran. A more correct design would run configurators first, then rebuild
+				 * whatever is purely derived from properties (starting with the level
+				 * resolver) a second time against the now-fully-configured LogConfig. Not
+				 * done here - see todo.md.
+				 */
 				RainbowGumServiceProvider.Configurator.runConfigurators(configurators.stream(), config);
 			}
 			return config;
 		}
 
-		LevelConfig buildGlobalResolver(LogProperties logProperties) {
+		LevelConfig buildGlobalResolver(LogProperties logProperties, LogAlerts alerts) {
 			LevelConfig levelResolver = LevelConfig
 				.of(List.of(ConfigLevelResolver.of(logProperties), GroupLevelResolver.of(logProperties)));
 			var config = buildLevelConfigOrNull();
 			if (config != null) {
-				return LevelConfig.of(List.<LevelConfig>of(config, levelResolver));
+				levelResolver = LevelConfig.of(List.<LevelConfig>of(config, levelResolver));
 			}
-			return levelResolver;
+			return new AlertingLevelConfig(levelResolver, alerts);
 		}
 
 		private static List<LogProperties> provideProperties(ServiceRegistry registry,
@@ -432,19 +453,20 @@ final class DefaultLogConfig implements LogConfig {
 
 	private final LogMetrics metrics;
 
-	DefaultLogConfig(ServiceRegistry registry, LogProperties properties, LevelConfig levelResolver) {
+	DefaultLogConfig(ServiceRegistry registry, LogProperties properties, LevelConfig levelResolver, LogAlerts alerts,
+			LogMetrics metrics) {
 		super();
 		this.registry = registry;
 		this.properties = properties;
 		this.levelResolver = levelResolver;
+		this.alerts = alerts;
+		this.metrics = metrics;
 		boolean changeable = properties.forKey(LogProperties.GLOBAL_CHANGE_PROPERTY).ofBoolean().or(false).value();
 		this.changePublisher = changeable ? new DefaultChangePublisher() : IgnoreChangePublisher.INSTANT;
 		applyGlobalAppenderReentrantLockProperty(properties);
 		this.outputRegistry = DefaultOutputRegistry.of(registry);
 		this.encoderRegistry = DefaultEncoderRegistry.of();
 		this.publisherRegistry = DefaultPublisherRegistry.of();
-		this.alerts = new DefaultLogAlerts(LogAlerts.DEFAULT_CAPACITY);
-		this.metrics = new DefaultLogMetrics();
 		this.alerts.addListener(event -> this.metrics.errorCounter(event.loggerName(), 1));
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -379,7 +379,7 @@ public sealed interface LogRouter extends LogLifecycle {
 				if (!flags.contains(RouteFlag.IGNORE_GLOBAL_LEVEL_RESOLVER)) {
 					routeLevelResolverBuilder.fallback(config.levelResolver());
 				}
-				var levelResolver = routeLevelResolverBuilder.build();
+				var levelResolver = routeLevelResolverBuilder.build().provide(name, config);
 
 				if (currentConfig == null) {
 					/*
@@ -397,7 +397,8 @@ public sealed interface LogRouter extends LogLifecycle {
 						levelResolver = LevelResolver.builder()
 							.resolver(levelResolver)
 							.fallback(StaticLevelResolver.INFO)
-							.build();
+							.build()
+							.provide(name, config);
 						// throw new IllegalStateException("Global Level Resolver should
 						// not resolve to Level.ALL");
 					}
@@ -599,7 +600,7 @@ sealed interface InternalRootRouter extends RootRouter {
 		routes = sorted;
 		LevelResolver.Builder resolverBuilder = LevelResolver.builder();
 		routes.stream().map(Router::levelResolver).forEach(resolverBuilder::resolver);
-		var globalLevelResolver = resolverBuilder.build();
+		var globalLevelResolver = resolverBuilder.build().provide("", config);
 
 		Router[] array = routes.toArray(new Router[] {});
 

--- a/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LevelResolverTest.java
@@ -82,19 +82,21 @@ class LevelResolverTest {
 												]
 											]
 										],
-										CompositeLevelConfig[
-											ConfigLevelResolver[
-												prefix=logging.level,
-												properties=MapLogProperties[
-													description='test_props',
-													order=0
-												]
-											],
-											GroupLevelResolver[
-												groupLevelPrefix=logging.level,
-												properties=MapLogProperties[
-													description='test_props',
-													order=0
+										AlertingLevelConfig[
+											CompositeLevelConfig[
+												ConfigLevelResolver[
+													prefix=logging.level,
+													properties=MapLogProperties[
+														description='test_props',
+														order=0
+													]
+												],
+												GroupLevelResolver[
+													groupLevelPrefix=logging.level,
+													properties=MapLogProperties[
+														description='test_props',
+														order=0
+													]
 												]
 											]
 										]
@@ -206,19 +208,21 @@ class LevelResolverTest {
 														]
 													]
 												],
-												CompositeLevelConfig[
-													ConfigLevelResolver[
-														prefix=logging.level,
-														properties=MapLogProperties[
-															description='test_props',
-															order=0
-														]
-													],
-													GroupLevelResolver[
-														groupLevelPrefix=logging.level,
-														properties=MapLogProperties[
-															description='test_props',
-															order=0
+												AlertingLevelConfig[
+													CompositeLevelConfig[
+														ConfigLevelResolver[
+															prefix=logging.level,
+															properties=MapLogProperties[
+																description='test_props',
+																order=0
+															]
+														],
+														GroupLevelResolver[
+															groupLevelPrefix=logging.level,
+															properties=MapLogProperties[
+																description='test_props',
+																order=0
+															]
 														]
 													]
 												]

--- a/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/RouterTest.java
@@ -20,7 +20,12 @@ class RouterTest {
 
 		// LevelResolver resolver = InternalLevelResolver.of(Map.of("stuff", Level.INFO,
 		// "", Level.DEBUG));
-		LevelResolver resolver = LevelResolver.builder().level(Level.DEBUG).level(Level.INFO, "stuff").build();
+		var config = LogConfig.builder().build();
+		LevelResolver resolver = LevelResolver.builder()
+			.level(Level.DEBUG)
+			.level(Level.INFO, "stuff")
+			.build()
+			.provide("test", config);
 		assertEquals(Level.INFO, resolver.resolveLevel("stuff.crap"));
 		var publisher = new TestSyncPublisher();
 		@SuppressWarnings("resource")
@@ -34,20 +39,29 @@ class RouterTest {
 	@Test
 	void testCompositeRouter() throws Exception {
 
+		var config = LogConfig.builder().build();
+
 		// LevelResolver resolver1 = InternalLevelResolver.of(Map.of("stuff", Level.INFO,
 		// "", Level.DEBUG));
-		LevelResolver resolver1 = LevelResolver.builder().level(Level.DEBUG).level(Level.INFO, "stuff").build();
+		LevelResolver resolver1 = LevelResolver.builder()
+			.level(Level.DEBUG)
+			.level(Level.INFO, "stuff")
+			.build()
+			.provide("1", config);
 		var publisher1 = new TestSyncPublisher();
 		var router1 = new SimpleRouter("1", publisher1, resolver1);
 
 		// LevelResolver resolver2 = InternalLevelResolver.of(Map.of("stuff", Level.DEBUG,
 		// "", Level.WARNING));
-		LevelResolver resolver2 = LevelResolver.builder().level(Level.DEBUG, "stuff").level(Level.WARNING).build();
+		LevelResolver resolver2 = LevelResolver.builder()
+			.level(Level.DEBUG, "stuff")
+			.level(Level.WARNING)
+			.build()
+			.provide("2", config);
 
 		var publisher2 = new TestSyncPublisher();
 		var router2 = new SimpleRouter("2", publisher2, resolver2);
 
-		var config = LogConfig.builder().build();
 		var root = InternalRootRouter.of(List.of(router1, router2), config);
 
 		var route = root.route("stuff", Level.DEBUG);
@@ -76,7 +90,8 @@ class RouterTest {
 		 * mutation of the live key values. Freezing (and therefore defensively copying)
 		 * would just be wasted allocation here.
 		 */
-		var resolver = LevelResolver.builder().level(Level.DEBUG).build();
+		var config = LogConfig.builder().build();
+		var resolver = LevelResolver.builder().level(Level.DEBUG).build().provide("test", config);
 		var publisher = new TestSyncPublisher();
 		@SuppressWarnings("resource")
 		var router = new SimpleRouter("1", publisher, resolver);
@@ -98,7 +113,8 @@ class RouterTest {
 		 * the event) before the worker gets around to it. The router must freeze
 		 * (defensively copy) the event before publishing it asynchronously.
 		 */
-		var resolver = LevelResolver.builder().level(Level.DEBUG).build();
+		var config = LogConfig.builder().build();
+		var resolver = LevelResolver.builder().level(Level.DEBUG).build().provide("test", config);
 		var publisher = new TestAsyncPublisher();
 		@SuppressWarnings("resource")
 		var router = new SimpleRouter("1", publisher, resolver);

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.System.Logger.Level;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -23,11 +24,11 @@ import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
  * {@link FakeEncoderConfigurator} (host/label/port/endpoint/tags/headers, i.e.
  * String/Integer/URI/List/Map) is registered by default for every case, exercising a
  * component with a spread of property types failing conversion/validation through a
- * builder+{@link LogProperty.Validator} - the built-in scenarios (unregistered scheme,
- * bad level) need no such fixture, but registering it is harmless for them since none of
- * their properties overlap with FakeEncoderBuilder's. {@link FakeGlobalConfigurator}
- * (opted into per-case via {@link ConfigFailure#configurators()}) is the contrasting
- * case: a direct property read with no builder/Validator in between.
+ * builder+{@link LogProperty.Validator} - the built-in scenarios (unregistered scheme)
+ * need no such fixture, but registering it is harmless for them since none of their
+ * properties overlap with FakeEncoderBuilder's. {@link FakeGlobalConfigurator} (opted
+ * into per-case via {@link ConfigFailure#configurators()}) is the contrasting case: a
+ * direct property read with no builder/Validator in between.
  */
 class ConfigFailureTest {
 
@@ -44,28 +45,33 @@ class ConfigFailureTest {
 	}
 
 	/*
-	 * Not a ConfigFailure case: a bad per-logger level mapping does NOT make
-	 * RainbowGum.builder(config).build().start() fail at all - per-logger level
-	 * properties (as opposed to the bare "logging.level" root default, see
-	 * ConfigFailure.badLevelValue above) are resolved lazily, only when a logger by that
-	 * exact name is actually looked up (ConfigLevelResolver.levelOrNull(name), called
-	 * from LevelResolver.resolveLevel(name)) - so a typo like this can sit in config for
-	 * the whole life of the process without ever surfacing, until/unless something
-	 * actually logs through "com.blah".
+	 * Not a ConfigFailure case, and no longer a "throws lazily" case either (see git
+	 * history for that older version of this test - and the now-removed
+	 * ConfigFailure.badLevelValue, which used to make a bad root "logging.level" fail
+	 * RainbowGum...start() itself). Both were made obsolete by the same fix: a level
+	 * property that fails to parse - root or per-logger - no longer throws anywhere.
+	 * CachedLevelResolver/AlertingLevelConfig catch it, fall back to Level.INFO, and
+	 * report exactly one alert per distinct logger name (not one per resolveLevel(name)
+	 * call - resolution for a hot logger happens constantly, and ConcurrentHashMap's
+	 * computeIfAbsent would otherwise leave a throwing lookup uncached, re-parsing and
+	 * re-alerting every single time).
 	 */
 	@Test
-	void testBadPerLoggerLevelMappingOnlyFailsWhenThatLoggerIsResolved() {
+	void testBadLevelMappingAlertsOnceAndFallsBackToInfoInsteadOfThrowing() {
 		var props = LogProperties.builder().fromProperties("""
 				logging.level.com.blah=BLAH
 				""").build();
 		var config = LogConfig.builder().properties(props).build();
 		try (var gum = RainbowGum.builder(config).build().start()) {
-			var e = assertThrows(RuntimeException.class, () -> gum.router().levelResolver().resolveLevel("com.blah"));
-			assertEquals(
-					"""
-							Error for property. key: 'logging.level.com.blah' from PROPERTIES_STRING[logging.level.com.blah], java.lang.IllegalArgumentException Cannot parse Level from input. input='BLAH'
-							Tried: 'logging.level.com.blah' from PROPERTIES_STRING[logging.level.com.blah]""",
-					e.getMessage());
+			var alerts = gum.config().alerts();
+			assertEquals(0, alerts.stats().total());
+
+			assertEquals(Level.INFO, gum.router().levelResolver().resolveLevel("com.blah"));
+			assertEquals(1, alerts.stats().total());
+
+			// resolving the same bad name again must not alert a second time.
+			assertEquals(Level.INFO, gum.router().levelResolver().resolveLevel("com.blah"));
+			assertEquals(1, alerts.stats().total());
 		}
 	}
 
@@ -80,13 +86,6 @@ class ConfigFailureTest {
 						Failure providing Appender: 'myapp' from property: Property[logging.appenders]=[myapp]. cause:
 						Error for property. key: 'logging.appender.myapp.output' from PROPERTIES_STRING[logging.appender.myapp.output], NotFoundException No output found. Scheme not registered. scheme: 'bogus', URI: 'bogus:///'
 						Tried: 'logging.appender.myapp.output' from PROPERTIES_STRING[logging.appender.myapp.output]"""),
-
-		badLevelValue("""
-				logging.level=NOTALEVEL
-				""",
-				"""
-						Error for property. key: 'logging.level' from PROPERTIES_STRING[logging.level], java.lang.IllegalArgumentException Cannot parse Level from input. input='NOTALEVEL'
-						Tried: 'logging.level' from PROPERTIES_STRING[logging.level]"""),
 
 		unregisteredPublisherScheme("""
 				logging.route.default.publisher=bogus:///

--- a/todo.md
+++ b/todo.md
@@ -65,6 +65,30 @@ To land before 1.0:
       resize/soft-limit-hit counter (see the soft-limiting `maxBufferSize` work on
       `LogEncoder`/`JsonBuffer`) was floated as the first real candidate, once WARN/INFO
       widening (above) makes a non-error signal like that appropriate.
+- [x] `LevelResolver`/`LevelConfig` now alert instead of throwing: a level property that
+      fails to parse (root `logging.level` or a per-logger `logging.level.X`) used to
+      throw `PropertyConvertException` right out of `resolveLevel`/`levelOrNull` -
+      possibly on every single call for a hot logger name, since a
+      `ConcurrentHashMap#computeIfAbsent` mapping function that throws leaves nothing
+      cached. `CachedLevelResolver` (per-route) and the new `AlertingLevelConfig`
+      (global, package-private, `LevelResolver.java`) now catch that, alert exactly once
+      per logger name via `LogAlerts`, and fall back to `Level.INFO`. `DefaultLogConfig`
+      now takes `LogAlerts`/`LogMetrics` in its constructor (built by `LogConfig.Builder`
+      before `DefaultLogConfig` itself) instead of constructing them internally, since
+      the global resolver needs `LogAlerts` before a full `LogConfig` exists to pull
+      `config.alerts()` from - see the two-pass item just below for the one remaining
+      rough edge this didn't fix.
+- [ ] **Two-pass config**: `LogConfig.Builder.build()` builds the global level resolver
+      from `logProperties` as it stood *before* any `Configurator` runs, then only
+      afterward calls `RainbowGumServiceProvider.Configurator.runConfigurators(...)` - so
+      a configurator that contributes additional property sources (or otherwise changes
+      what the level resolver should have seen) is invisible to it. Flagged inline where
+      `runConfigurators` is called in `LogConfig.java`. Proper fix: run configurators
+      first, then rebuild whatever is purely derived from properties (starting with the
+      level resolver) a second time against the now-fully-configured `LogConfig`, rather
+      than building it once, early, and never revisiting it. Deliberately not done as
+      part of the `LevelResolver` alerting work above - a bigger change to `LogConfig`'s
+      build lifecycle than that warranted on its own.
 - [ ] A third, still-unaddressed facet the old `status()` API used to partly cover:
       a **static configuration report** - not alerts (event-driven) or metrics
       (gauges), just "what actually got wired up." With `REUSE_BUFFER`/


### PR DESCRIPTION
A level property that fails to parse (root logging.level or a per-logger logging.level.X) used to throw PropertyConvertException right out of resolveLevel/levelOrNull - possibly on every single call for a hot logger name, since ConcurrentHashMap#computeIfAbsent leaves nothing cached when its mapping function throws. Level resolution sits on the hot path of every isEnabled() check, so this could break application logging at an arbitrary, unpredictable time and place, repeatedly.

- CachedLevelResolver (per-route) now takes LogAlerts, catches resolveLevel() failures, alerts exactly once per logger name, and caches Level.INFO as the fallback (fixing the repeat-throw and the alert-spam in one change, since they were the same root cause: nothing was being cached).
- New AlertingLevelConfig (LevelResolver.java) does the same for the global resolver at the levelOrNull() level specifically (not resolveLevel()) so LevelConfig#defaultLevel() - which real callers use - keeps working; it doesn't cache successful lookups (the global resolver never has), only failed ones.
- LevelResolver.Builder.build() now returns LogProvider<LevelResolver> instead of LevelResolver directly, deferred so the per-route cache can reach config.alerts() - matching the LogProvider<T> pattern already used throughout the codebase for config-derived dependencies. Only this one builder (where caching already happened) and the global resolver need alerts; every other LevelResolver/LevelConfig primitive (ConfigLevelResolver, GroupLevelResolver, MapLevelResolver, PriorityLevelResolver, StaticLevelResolver) is untouched.
- DefaultLogConfig now takes LogAlerts/LogMetrics in its constructor (built by LogConfig.Builder before DefaultLogConfig itself) instead of constructing them internally, since the global resolver needs LogAlerts before a full LogConfig exists to pull config.alerts() from.
- Default fallback level is Level.INFO, matching LogProperties' own documented root default - i.e. "behave as if this property weren't set."

Known remaining gap, flagged inline in LogConfig.java and in todo.md rather than fixed here: the global level resolver is still built once, early, from whatever logProperties looked like before any Configurator ran - a configurator contributing more property sources afterward is invisible to it. A proper fix needs a second config-build pass; out of scope for this change.

ConfigFailureTest's badLevelValue case is removed (a bad root logging.level no longer fails RainbowGum...start() at all, so it no longer belongs in a "must fail" harness) and its bad-per-logger-level test is rewritten to assert the new alert-once/fallback-to-INFO behavior instead of a thrown exception. LevelResolverTest's two toString()-structure golden strings gained the new AlertingLevelConfig[...] wrapper around the global resolver. RouterTest/LogRouter.java call sites updated for LevelResolver.Builder.build()'s new LogProvider<LevelResolver> return type.