### PR TITLE
Give Result.map() failures the same rich error message as convert()

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -815,7 +815,7 @@ final class GroupLevelResolver implements LevelConfig {
 			String group = e.getKey();
 			properties.forKey(LogProperties.concatKey(groupLevelPrefix, group))
 				.ofString()
-				.convert(LevelResolver::parseLevel)
+				.map(LevelResolver::parseLevel)
 				.optional() //
 				.ifPresent(level -> groupToLevels.put(group, level));
 		}
@@ -866,7 +866,7 @@ final class ConfigLevelResolver implements LevelConfig {
 	public @Nullable Level levelOrNull(String name) {
 		return properties.forKey(LogProperties.concatKey(prefix, name))
 			.ofString()
-			.convert(LevelResolver::parseLevel)
+			.map(LevelResolver::parseLevel)
 			.valueOrNull();
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LevelResolver.java
@@ -815,7 +815,7 @@ final class GroupLevelResolver implements LevelConfig {
 			String group = e.getKey();
 			properties.forKey(LogProperties.concatKey(groupLevelPrefix, group))
 				.ofString()
-				.convert(properties, LevelResolver::parseLevel)
+				.convert(LevelResolver::parseLevel)
 				.optional() //
 				.ifPresent(level -> groupToLevels.put(group, level));
 		}
@@ -866,7 +866,7 @@ final class ConfigLevelResolver implements LevelConfig {
 	public @Nullable Level levelOrNull(String name) {
 		return properties.forKey(LogProperties.concatKey(prefix, name))
 			.ofString()
-			.convert(properties, LevelResolver::parseLevel)
+			.convert(LevelResolver::parseLevel)
 			.valueOrNull();
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -148,7 +148,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			case Result.Missing<URI> m -> m.convert();
 			case Result.Error<URI> e -> e.convert();
 		};
-		Result<LogOutput> fileProperty = refResult.convert(LogOutput::of).convert(p -> p.provide(name, config));
+		Result<LogOutput> fileProperty = refResult.map(LogOutput::of).map(p -> p.provide(name, config));
 		var encoderProperty = encoderProperty(LogAppender.APPENDER_ENCODER_PROPERTY, name, config);
 		return appender(name, config, fileProperty, encoderProperty);
 	}
@@ -235,13 +235,13 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 	private static Result<LogOutput> outputProperty(String propertyKey, String name, LogConfig config) {
 		var properties = config.properties();
 		var provider = properties.forKey(propertyKey, name).ofProvider(LogOutput::of);
-		return provider.convert(p -> p.provide(name, config));
+		return provider.map(p -> p.provide(name, config));
 	}
 
 	private static Result<LogEncoder> encoderProperty(String propertyKey, String name, LogConfig config) {
 		var properties = config.properties();
 		var provider = properties.forKey(propertyKey, name).ofProvider(LogEncoder::of);
-		return provider.convert(p -> p.provide(name, config));
+		return provider.map(p -> p.provide(name, config));
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogAppenderRegistry.java
@@ -148,9 +148,7 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 			case Result.Missing<URI> m -> m.convert();
 			case Result.Error<URI> e -> e.convert();
 		};
-		var properties = config.properties();
-		Result<LogOutput> fileProperty = refResult.convert(properties, LogOutput::of)
-			.convert(properties, p -> p.provide(name, config));
+		Result<LogOutput> fileProperty = refResult.convert(LogOutput::of).convert(p -> p.provide(name, config));
 		var encoderProperty = encoderProperty(LogAppender.APPENDER_ENCODER_PROPERTY, name, config);
 		return appender(name, config, fileProperty, encoderProperty);
 	}
@@ -237,13 +235,13 @@ final class DefaultAppenderRegistry implements LogAppenderRegistry {
 	private static Result<LogOutput> outputProperty(String propertyKey, String name, LogConfig config) {
 		var properties = config.properties();
 		var provider = properties.forKey(propertyKey, name).ofProvider(LogOutput::of);
-		return provider.convert(properties, p -> p.provide(name, config));
+		return provider.convert(p -> p.provide(name, config));
 	}
 
 	private static Result<LogEncoder> encoderProperty(String propertyKey, String name, LogConfig config) {
 		var properties = config.properties();
 		var provider = properties.forKey(propertyKey, name).ofProvider(LogEncoder::of);
-		return provider.convert(properties, p -> p.provide(name, config));
+		return provider.convert(p -> p.provide(name, config));
 	}
 
 }

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -70,7 +70,7 @@ public interface LogProperty {
 	 * @return result.
 	 */
 	default Result<Integer> ofInt() {
-		return ofString().convert(properties(), Integer::parseInt);
+		return ofString().convert(Integer::parseInt);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public interface LogProperty {
 	 * @return result.
 	 */
 	default Result<Boolean> ofBoolean() {
-		return ofString().convert(properties(), Boolean::parseBoolean);
+		return ofString().convert(Boolean::parseBoolean);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public interface LogProperty {
 	 * @return result.
 	 */
 	default Result<URI> ofURI() {
-		return ofString().convert(properties(), URI::new);
+		return ofString().convert(URI::new);
 	}
 
 	/**
@@ -112,16 +112,16 @@ public interface LogProperty {
 	 */
 	default <U> Result<LogProvider<U>> ofProvider(
 			PropertyFunction<LogProviderRef, LogProvider<U>, ? super Exception> mapper) {
-		return ofProviderRef().convert(properties(), mapper);
+		return ofProviderRef().convert(mapper);
 	}
 
 	/**
 	 * Rewraps a value that was already derived from success's value, keeping the
-	 * {@link Result.Success.PropertySuccess}'s origin (properties/key/rawValue/kind)
-	 * intact - useful for a conversion step that cannot itself throw, so
-	 * {@link Result#convert(LogProperties, PropertyFunction)} would be overkill, but that
-	 * still needs to keep the result's origin intact for a later conversion step's error
-	 * message.
+	 * {@link Result.Success.PropertySuccess}'s origin
+	 * (topProperties/properties/key/rawValue/kind) intact - useful for a conversion step
+	 * that cannot itself throw, so {@link Result#convert(PropertyFunction)} would be
+	 * overkill, but that still needs to keep the result's origin intact for a later
+	 * conversion step's error message.
 	 * @param <T> success's value type.
 	 * @param <U> new value type.
 	 * @param success success to take the origin from.
@@ -130,19 +130,18 @@ public interface LogProperty {
 	 */
 	static <T, U> Result.Success<U> mapValue(Result.Success<T> success, U value) {
 		return switch (success) {
-			case Result.Success.PropertySuccess<T> ps ->
-				new Result.Success.PropertySuccess<>(ps.properties(), ps.key(), ps.rawValue(), ps.kind(), value);
+			case Result.Success.PropertySuccess<T> ps -> new Result.Success.PropertySuccess<>(ps.topProperties(),
+					ps.properties(), ps.key(), ps.rawValue(), ps.kind(), value);
 		};
 	}
 
-	private static <U> Result.Error<U> richError(LogProperties properties, Result.Success<?> previousResult,
-			Exception e) {
+	private static <U> Result.Error<U> richError(Result.Success<?> previousResult, Exception e) {
 		String fqk = previousResult.key();
 		Result.Success.PropertySuccess<?> ps = switch (previousResult) {
 			case Result.Success.PropertySuccess<?> p -> p;
 		};
 		if (ps.kind() == Result.Success.PropertySuccess.Kind.VALUE) {
-			String resolvedKey = properties.description(fqk);
+			String resolvedKey = ps.topProperties().description(fqk);
 			String message = "Error for property. key: " + resolvedKey + ", " + e.getMessage();
 			return new Result.Error<>(resolvedKey, message, e);
 		}
@@ -156,7 +155,7 @@ public interface LogProperty {
 		else {
 			message = "Error for property. key: " + resolvedKey + ", " + errorName(e) + " " + e.getMessage();
 		}
-		message += "\nTried: '" + fqk + "' from " + properties.description(fqk);
+		message += "\nTried: '" + fqk + "' from " + ps.topProperties().description(fqk);
 		return new Result.Error<>(resolvedKey, message, e);
 	}
 
@@ -704,14 +703,19 @@ public interface LogProperty {
 
 		/**
 		 * Maps this result's value through {@code mapper}. On success, keeps the origin
-		 * (properties/key/rawValue/kind, see {@link Success.PropertySuccess}) so a later
-		 * conversion step's error message can still point back to it. On failure, builds
-		 * the same rich error message {@link #convert(LogProperties, PropertyFunction)}
-		 * does - which key it came from, where that key was found, and (for
+		 * ({@link Success.PropertySuccess#topProperties() topProperties}/properties/key/
+		 * rawValue/kind, see {@link Success.PropertySuccess}) so a later conversion
+		 * step's error message can still point back to it. On failure, builds a rich
+		 * error message - which key it came from, where that key was found, and (for
 		 * {@link PropertyConvertException}/{@link ValidationException} causes) the
-		 * original raw value - except the "Tried:" line can only ever be that same exact
-		 * source, since (unlike {@code convert()}) there is no separate, possibly
-		 * broader/aggregate {@link LogProperties} parameter to search for that line.
+		 * original raw value - with a "Tried:" line searching {@code topProperties}: the
+		 * {@link LogProperties} the very first {@link LogProperties#forKey(String)} in
+		 * this chain was looked up against, which for a chained/composite
+		 * {@code LogProperties.of(a, b)} can be broader than the exact source the value
+		 * was actually found at. Same message {@link #convert(PropertyFunction)} builds -
+		 * the two are equivalent, {@code convert} is just the conventional name to reach
+		 * for when the mapper is doing type conversion rather than an arbitrary value
+		 * transform.
 		 * @param <U> result type
 		 * @param mapper mapping function.
 		 * @return mapped result.
@@ -720,28 +724,25 @@ public interface LogProperty {
 		public <U> Result<U> map(PropertyFunction<T, U, ? super Exception> mapper);
 
 		/**
-		 * Like {@link #map(PropertyFunction)} but additionally accepts the
-		 * {@link LogProperties} the original lookup was made against, used for the
-		 * "Tried:" line of a failure's error message - so that line can show a broader
-		 * search (for example every member of a chained/composite
-		 * {@code LogProperties.of(a, b)}) than just the exact source the value was found
-		 * at. Usable at any point in a chain, not just directly off a
-		 * {@link LogProperty}, since a {@link Success} keeps pointing back to the
-		 * property it originally came from no matter how many conversions have run since.
+		 * Equivalent to {@link #map(PropertyFunction)} - see its documentation for what
+		 * the failure message looks like - kept as a separate, identically-named method
+		 * only so a conversion step (parsing a {@code String} into some other type) reads
+		 * distinctly from a plain value transform at the call site. Usable at any point
+		 * in a chain, not just directly off a {@link LogProperty}, since a
+		 * {@link Success} keeps pointing back to the property it originally came from no
+		 * matter how many conversions have run since.
 		 * @param <U> output value type.
-		 * @param properties the properties the original lookup was made against, used
-		 * only for the "Tried:" line of the error message.
 		 * @param converter conversion function.
 		 * @return converted result.
 		 */
-		default <U> Result<U> convert(LogProperties properties, PropertyFunction<T, U, ? super Exception> converter) {
+		default <U> Result<U> convert(PropertyFunction<T, U, ? super Exception> converter) {
 			return switch (this) {
 				case Success<T> s -> {
 					try {
 						yield mapValue(s, converter._apply(s.value()));
 					}
 					catch (Exception e) {
-						yield richError(properties, s, e);
+						yield richError(s, e);
 					}
 				}
 				case Missing<T> m -> m.convert();
@@ -802,14 +803,20 @@ public interface LogProperty {
 			/**
 			 * A property that is present, either because it was actually found in
 			 * properties, or (when {@code kind} is {@link Kind#VALUE}) because it was
-			 * missing there and a fallback value was supplied instead - either way,
-			 * properties is the properties it was (or would have been) searched against,
-			 * for a later conversion step's error message.
+			 * missing there and a fallback value was supplied instead.
 			 *
 			 * @param <T> property type.
+			 * @param topProperties the {@link LogProperties} the very first
+			 * {@link LogProperties#forKey(String)} in this chain was looked up against -
+			 * for a chained/composite {@code LogProperties.of(a, b)} this is the whole
+			 * composite, not just whichever member the value ended up found in. Used for
+			 * a failure message's "Tried:" line, which can therefore search more broadly
+			 * than {@code properties}.
 			 * @param properties the properties searched; for {@link Kind#STRING}/
 			 * {@link Kind#LIST}/{@link Kind#MAP} the <strong>exact</strong> properties
-			 * where the value was found.
+			 * where the value was found - for a chained/composite search this can be
+			 * narrower than {@code topProperties}, naming just the one member the value
+			 * was actually found in. Used for a failure message's "key: ... from X" line.
 			 * @param key property key.
 			 * @param rawValue value as originally found (or the fallback, for
 			 * {@link Kind#VALUE}), before any conversion - a {@link String}, {@link List
@@ -825,8 +832,8 @@ public interface LogProperty {
 			 * {@code Integer}) so error messages can still describe the original value -
 			 * value's type and rawValue's kind are not always in sync.
 			 */
-			public record PropertySuccess<T>(LogProperties properties, String key, Object rawValue, Kind kind,
-					T value) implements Success<T> {
+			public record PropertySuccess<T>(LogProperties topProperties, LogProperties properties, String key,
+					Object rawValue, Kind kind, T value) implements Success<T> {
 
 				/**
 				 * Which of {@link LogProperty}'s typed accessors a
@@ -861,6 +868,7 @@ public interface LogProperty {
 
 				/**
 				 * Successfully found property value.
+				 * @param topProperties the properties the original lookup started from.
 				 * @param properties the properties searched.
 				 * @param key property key.
 				 * @param rawValue value as originally found (or the fallback), before any
@@ -878,10 +886,10 @@ public interface LogProperty {
 				public <U> Result<U> map(PropertyFunction<T, U, ? super Exception> mapper) {
 					try {
 						U u = mapper._apply(value);
-						return new PropertySuccess<>(properties, key, rawValue, kind, u);
+						return new PropertySuccess<>(topProperties, properties, key, rawValue, kind, u);
 					}
 					catch (Exception e) {
-						return richError(properties, this, e);
+						return richError(this, e);
 					}
 				}
 
@@ -955,7 +963,7 @@ public interface LogProperty {
 			@Override
 			public Result<T> or(@Nullable T fallback) {
 				if (fallback != null) {
-					return new Success.PropertySuccess<>(properties, keys.get(0), fallback,
+					return new Success.PropertySuccess<>(properties, properties, keys.get(0), fallback,
 							Success.PropertySuccess.Kind.VALUE, fallback);
 				}
 				return this;
@@ -1089,8 +1097,8 @@ final class DefaultLogProperty implements LogProperty {
 	public Result<String> ofString() {
 		return resolve(k -> properties.visit(k, (p, kk) -> {
 			var v = p.valueOrNull(kk);
-			return v == null ? null
-					: new Result.Success.PropertySuccess<>(p, kk, v, Result.Success.PropertySuccess.Kind.STRING, v);
+			return v == null ? null : new Result.Success.PropertySuccess<>(properties, p, kk, v,
+					Result.Success.PropertySuccess.Kind.STRING, v);
 		}));
 	}
 
@@ -1098,8 +1106,8 @@ final class DefaultLogProperty implements LogProperty {
 	public Result<List<String>> ofList() {
 		return resolve(k -> properties.visit(k, (p, kk) -> {
 			var v = p.listOrNull(kk);
-			return v == null ? null
-					: new Result.Success.PropertySuccess<>(p, kk, v, Result.Success.PropertySuccess.Kind.LIST, v);
+			return v == null ? null : new Result.Success.PropertySuccess<>(properties, p, kk, v,
+					Result.Success.PropertySuccess.Kind.LIST, v);
 		}));
 	}
 
@@ -1107,8 +1115,8 @@ final class DefaultLogProperty implements LogProperty {
 	public Result<Map<String, String>> ofMap() {
 		return resolve(k -> properties.visit(k, (p, kk) -> {
 			var v = p.mapOrNull(kk);
-			return v == null ? null
-					: new Result.Success.PropertySuccess<>(p, kk, v, Result.Success.PropertySuccess.Kind.MAP, v);
+			return v == null ? null : new Result.Success.PropertySuccess<>(properties, p, kk, v,
+					Result.Success.PropertySuccess.Kind.MAP, v);
 		}));
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -703,7 +703,15 @@ public interface LogProperty {
 		public Result<T> or(Supplier<T> fallback);
 
 		/**
-		 * Map a result
+		 * Maps this result's value through {@code mapper}. On success, keeps the origin
+		 * (properties/key/rawValue/kind, see {@link Success.PropertySuccess}) so a later
+		 * conversion step's error message can still point back to it. On failure, builds
+		 * the same rich error message {@link #convert(LogProperties, PropertyFunction)}
+		 * does - which key it came from, where that key was found, and (for
+		 * {@link PropertyConvertException}/{@link ValidationException} causes) the
+		 * original raw value - except the "Tried:" line can only ever be that same exact
+		 * source, since (unlike {@code convert()}) there is no separate, possibly
+		 * broader/aggregate {@link LogProperties} parameter to search for that line.
 		 * @param <U> result type
 		 * @param mapper mapping function.
 		 * @return mapped result.
@@ -712,13 +720,14 @@ public interface LogProperty {
 		public <U> Result<U> map(PropertyFunction<T, U, ? super Exception> mapper);
 
 		/**
-		 * Like {@link #map(PropertyFunction)} but on conversion failure builds a richer
-		 * error message - which key it came from, where that key was found, and (for
-		 * {@link PropertyConvertException}/{@link ValidationException} causes) the
-		 * original raw value - instead of {@code map}'s terser one line message. Usable
-		 * at any point in a chain, not just directly off a {@link LogProperty}, since a
-		 * {@link Success} keeps pointing back to the property it originally came from no
-		 * matter how many conversions have run since.
+		 * Like {@link #map(PropertyFunction)} but additionally accepts the
+		 * {@link LogProperties} the original lookup was made against, used for the
+		 * "Tried:" line of a failure's error message - so that line can show a broader
+		 * search (for example every member of a chained/composite
+		 * {@code LogProperties.of(a, b)}) than just the exact source the value was found
+		 * at. Usable at any point in a chain, not just directly off a
+		 * {@link LogProperty}, since a {@link Success} keeps pointing back to the
+		 * property it originally came from no matter how many conversions have run since.
 		 * @param <U> output value type.
 		 * @param properties the properties the original lookup was made against, used
 		 * only for the "Tried:" line of the error message.
@@ -872,7 +881,7 @@ public interface LogProperty {
 						return new PropertySuccess<>(properties, key, rawValue, kind, u);
 					}
 					catch (Exception e) {
-						return Error.of(key, e);
+						return richError(properties, this, e);
 					}
 				}
 
@@ -1025,11 +1034,6 @@ public interface LogProperty {
 			@Override
 			public <U> Error<U> map(PropertyFunction<T, U, ? super Exception> mapper) {
 				return convert();
-			}
-
-			static <U> Error<U> of(String resolvedKey, Exception cause) {
-				String message = "Error for property. key: " + resolvedKey + ", " + cause.getMessage();
-				return new Error<U>(resolvedKey, message, cause);
 			}
 
 			@Override

--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -70,7 +70,7 @@ public interface LogProperty {
 	 * @return result.
 	 */
 	default Result<Integer> ofInt() {
-		return ofString().convert(Integer::parseInt);
+		return ofString().map(Integer::parseInt);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public interface LogProperty {
 	 * @return result.
 	 */
 	default Result<Boolean> ofBoolean() {
-		return ofString().convert(Boolean::parseBoolean);
+		return ofString().map(Boolean::parseBoolean);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public interface LogProperty {
 	 * @return result.
 	 */
 	default Result<URI> ofURI() {
-		return ofString().convert(URI::new);
+		return ofString().map(URI::new);
 	}
 
 	/**
@@ -112,14 +112,14 @@ public interface LogProperty {
 	 */
 	default <U> Result<LogProvider<U>> ofProvider(
 			PropertyFunction<LogProviderRef, LogProvider<U>, ? super Exception> mapper) {
-		return ofProviderRef().convert(mapper);
+		return ofProviderRef().map(mapper);
 	}
 
 	/**
 	 * Rewraps a value that was already derived from success's value, keeping the
 	 * {@link Result.Success.PropertySuccess}'s origin
 	 * (topProperties/properties/key/rawValue/kind) intact - useful for a conversion step
-	 * that cannot itself throw, so {@link Result#convert(PropertyFunction)} would be
+	 * that cannot itself throw, so {@link Result#map(PropertyFunction)} would be
 	 * overkill, but that still needs to keep the result's origin intact for a later
 	 * conversion step's error message.
 	 * @param <T> success's value type.
@@ -712,43 +712,15 @@ public interface LogProperty {
 		 * {@link LogProperties} the very first {@link LogProperties#forKey(String)} in
 		 * this chain was looked up against, which for a chained/composite
 		 * {@code LogProperties.of(a, b)} can be broader than the exact source the value
-		 * was actually found at. Same message {@link #convert(PropertyFunction)} builds -
-		 * the two are equivalent, {@code convert} is just the conventional name to reach
-		 * for when the mapper is doing type conversion rather than an arbitrary value
-		 * transform.
+		 * was actually found at. Usable at any point in a chain, not just directly off a
+		 * {@link LogProperty}, since a {@link Success} keeps pointing back to the
+		 * property it originally came from no matter how many conversions have run since.
 		 * @param <U> result type
 		 * @param mapper mapping function.
 		 * @return mapped result.
 		 */
 		@Override
 		public <U> Result<U> map(PropertyFunction<T, U, ? super Exception> mapper);
-
-		/**
-		 * Equivalent to {@link #map(PropertyFunction)} - see its documentation for what
-		 * the failure message looks like - kept as a separate, identically-named method
-		 * only so a conversion step (parsing a {@code String} into some other type) reads
-		 * distinctly from a plain value transform at the call site. Usable at any point
-		 * in a chain, not just directly off a {@link LogProperty}, since a
-		 * {@link Success} keeps pointing back to the property it originally came from no
-		 * matter how many conversions have run since.
-		 * @param <U> output value type.
-		 * @param converter conversion function.
-		 * @return converted result.
-		 */
-		default <U> Result<U> convert(PropertyFunction<T, U, ? super Exception> converter) {
-			return switch (this) {
-				case Success<T> s -> {
-					try {
-						yield mapValue(s, converter._apply(s.value()));
-					}
-					catch (Exception e) {
-						yield richError(s, e);
-					}
-				}
-				case Missing<T> m -> m.convert();
-				case Error<T> e -> e.convert();
-			};
-		}
 
 		/**
 		 * Convenience that turns a value into an optional.

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -424,7 +424,7 @@ public sealed interface LogRouter extends LogLifecycle {
 					var properties = config.properties();
 					publisher = properties.forKey(LogProperties.ROUTE_PUBLISHER_PROPERTY, name)
 						.ofProviderRef()
-						.convert(properties, r -> config.publisherRegistry().provide(r))
+						.convert(r -> config.publisherRegistry().provide(r))
 						.or(() -> LogPublisher.SyncLogPublisher.builder().build())
 						.value();
 				}
@@ -789,7 +789,7 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 		var properties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 		return properties.forKey(LogProperties.GLOBAL_QUEUE_LEVEL_PROPERTY)
 			.ofString()
-			.convert(properties, LevelResolver::parseLevel)
+			.convert(LevelResolver::parseLevel)
 			.or(Level.INFO)
 			.value();
 	}
@@ -798,7 +798,7 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 		var properties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 		return properties.forKey(LogProperties.GLOBAL_QUEUE_ERROR_PROPERTY)
 			.ofString()
-			.convert(properties, LevelResolver::parseLevel)
+			.convert(LevelResolver::parseLevel)
 			.or(Level.ERROR)
 			.value();
 	}

--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -424,7 +424,7 @@ public sealed interface LogRouter extends LogLifecycle {
 					var properties = config.properties();
 					publisher = properties.forKey(LogProperties.ROUTE_PUBLISHER_PROPERTY, name)
 						.ofProviderRef()
-						.convert(r -> config.publisherRegistry().provide(r))
+						.map(r -> config.publisherRegistry().provide(r))
 						.or(() -> LogPublisher.SyncLogPublisher.builder().build())
 						.value();
 				}
@@ -789,7 +789,7 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 		var properties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 		return properties.forKey(LogProperties.GLOBAL_QUEUE_LEVEL_PROPERTY)
 			.ofString()
-			.convert(LevelResolver::parseLevel)
+			.map(LevelResolver::parseLevel)
 			.or(Level.INFO)
 			.value();
 	}
@@ -798,7 +798,7 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 		var properties = LogProperties.StandardProperties.SYSTEM_PROPERTIES;
 		return properties.forKey(LogProperties.GLOBAL_QUEUE_ERROR_PROPERTY)
 			.ofString()
-			.convert(LevelResolver::parseLevel)
+			.map(LevelResolver::parseLevel)
 			.or(Level.ERROR)
 			.value();
 	}

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -60,9 +60,9 @@ class LogPropertyTest {
 	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testValueKindPropertySuccessRejectsNullValueAndMap() {
 		var properties = LogProperties.StandardProperties.EMPTY;
-		assertThrows(NullPointerException.class,
-				() -> new PropertySuccess<String>(properties, "key", "5", PropertySuccess.Kind.VALUE, null));
-		var success = new PropertySuccess<>(properties, "key", "5", PropertySuccess.Kind.VALUE, "5");
+		assertThrows(NullPointerException.class, () -> new PropertySuccess<String>(properties, properties, "key", "5",
+				PropertySuccess.Kind.VALUE, null));
+		var success = new PropertySuccess<>(properties, properties, "key", "5", PropertySuccess.Kind.VALUE, "5");
 		assertEquals("key", success.key());
 		assertEquals("Fallback[key]=5", success.describe());
 		Result<Integer> mapped = success.map(Integer::parseInt);
@@ -78,9 +78,10 @@ class LogPropertyTest {
 	@SuppressWarnings({ "null", "nullness", "NullAway" })
 	void testPropertySuccessRejectsNullValueAndMap() {
 		LogProperties properties = LogProperties.MutableLogProperties.builder().build().put("logging.p1", "5");
-		assertThrows(NullPointerException.class,
-				() -> new PropertySuccess<String>(properties, "logging.p1", "5", PropertySuccess.Kind.STRING, null));
-		var success = new PropertySuccess<>(properties, "logging.p1", "5", PropertySuccess.Kind.STRING, "5");
+		assertThrows(NullPointerException.class, () -> new PropertySuccess<String>(properties, properties, "logging.p1",
+				"5", PropertySuccess.Kind.STRING, null));
+		var success = new PropertySuccess<>(properties, properties, "logging.p1", "5", PropertySuccess.Kind.STRING,
+				"5");
 		assertEquals("logging.p1", success.key());
 		assertEquals("Property[logging.p1]=5", success.describe());
 		Result<Integer> mapped = success.map(Integer::parseInt);
@@ -133,8 +134,8 @@ class LogPropertyTest {
 
 	@Test
 	void testResultValueOrNullWithFallback() {
-		Result<String> success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY, "key", "actual",
-				PropertySuccess.Kind.VALUE, "actual");
+		Result<String> success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY,
+				LogProperties.StandardProperties.EMPTY, "key", "actual", PropertySuccess.Kind.VALUE, "actual");
 		assertEquals("actual", success.valueOrNull("fallback"));
 		Result<String> missing = new Missing<>(LogProperties.StandardProperties.EMPTY, List.of("key"), "missing");
 		assertEquals("fallback", missing.valueOrNull("fallback"));
@@ -149,8 +150,8 @@ class LogPropertyTest {
 
 	@Test
 	void testResultOptional() {
-		Result<String> success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY, "key", "actual",
-				PropertySuccess.Kind.VALUE, "actual");
+		Result<String> success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY,
+				LogProperties.StandardProperties.EMPTY, "key", "actual", PropertySuccess.Kind.VALUE, "actual");
 		assertEquals(Optional.of("actual"), success.optional());
 		Result<String> missing = new Missing<>(LogProperties.StandardProperties.EMPTY, List.of("key"), "missing");
 		assertEquals(Optional.empty(), missing.optional());
@@ -158,8 +159,8 @@ class LogPropertyTest {
 
 	@Test
 	void testResultGetReturnsItself() {
-		Result<String> success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY, "key", "value",
-				PropertySuccess.Kind.VALUE, "value");
+		Result<String> success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY,
+				LogProperties.StandardProperties.EMPTY, "key", "value", PropertySuccess.Kind.VALUE, "value");
 		assertSame(success, success.get());
 	}
 

--- a/rainbowgum-apt/src/main/resources/io/jstach/rainbowgum/apt/ConfigBuilder.java
+++ b/rainbowgum-apt/src/main/resources/io/jstach/rainbowgum/apt/ConfigBuilder.java
@@ -148,7 +148,7 @@ public final class $$builderName$$ implements io.jstach.rainbowgum.LogBuilder<$$
 		var __v = LogProperty.Validator.of(this.getClass());
 		$$#properties$$
 		$$#normal$$
-		var _$$name$$ = $$#hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$().convert(_v -> $$converterMethodName$$(_v))$$/hasConverter$$$$^hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$()$$/hasConverter$$.or(this.$$name$$).$$validateMethod$$(__v);
+		var _$$name$$ = $$#hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$().map(_v -> $$converterMethodName$$(_v))$$/hasConverter$$$$^hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$()$$/hasConverter$$.or(this.$$name$$).$$validateMethod$$(__v);
 		$$/normal$$
 		$$/properties$$
 		__v.validate();

--- a/rainbowgum-apt/src/main/resources/io/jstach/rainbowgum/apt/ConfigBuilder.java
+++ b/rainbowgum-apt/src/main/resources/io/jstach/rainbowgum/apt/ConfigBuilder.java
@@ -148,7 +148,7 @@ public final class $$builderName$$ implements io.jstach.rainbowgum.LogBuilder<$$
 		var __v = LogProperty.Validator.of(this.getClass());
 		$$#properties$$
 		$$#normal$$
-		var _$$name$$ = $$#hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$().convert(properties, _v -> $$converterMethodName$$(_v))$$/hasConverter$$$$^hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$()$$/hasConverter$$.or(this.$$name$$).$$validateMethod$$(__v);
+		var _$$name$$ = $$#hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$().convert(_v -> $$converterMethodName$$(_v))$$/hasConverter$$$$^hasConverter$$properties.forKey($$propertyVar$$).$$baseAccessor$$()$$/hasConverter$$.or(this.$$name$$).$$validateMethod$$(__v);
 		$$/normal$$
 		$$/properties$$
 		__v.validate();

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
@@ -128,7 +128,7 @@ public abstract class RainbowGumSystemLoggerFinder extends System.LoggerFinder {
 		var v = LogProperty.Validator.of(RainbowGumSystemLoggerFinder.class);
 		var result = properties.forKey(INITIALIZE_RAINBOW_GUM_PROPERTY)
 			.ofString()
-			.convert(properties, InitOption::parse)
+			.convert(InitOption::parse)
 			.or(InitOption.CHECK)
 			.validate(v);
 		v.validate();

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
@@ -128,7 +128,7 @@ public abstract class RainbowGumSystemLoggerFinder extends System.LoggerFinder {
 		var v = LogProperty.Validator.of(RainbowGumSystemLoggerFinder.class);
 		var result = properties.forKey(INITIALIZE_RAINBOW_GUM_PROPERTY)
 			.ofString()
-			.convert(InitOption::parse)
+			.map(InitOption::parse)
 			.or(InitOption.CHECK)
 			.validate(v);
 		v.validate();

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
@@ -154,12 +154,13 @@ class ConfigFailureTest {
 		 * Hits Result.map() at the end of the fluent chain (FakeEncoderBuilder's "label"
 		 * field: properties.forKey(...).ofString().map(...)) instead of
 		 * LogProperty.ofXxx()/Result.convert() - see the comment on FakeEncoderBuilder's
-		 * _label. map() builds the same rich error message convert()'s richError() does
-		 * (quoted key, "from X", exception class name, "Tried:" line), except its
-		 * "Tried:" line can only ever be that same exact source - map() has no separate
-		 * outer/aggregate LogProperties parameter the way convert() does, so unlike
-		 * unregisteredOutputSchemeAcrossChainedProperties below there is no broader
-		 * search to report.
+		 * _label. map() builds the exact same rich error message convert()'s richError()
+		 * does, including the "Tried:" line: since the "properties" this builder was
+		 * given is itself a composite (PROPERTIES_STRING plus the
+		 * [logging.appender.myapp.encoder]->URI(fake:///) query-parameter layer), the
+		 * first "Tried:" line names both, same as any convert()-based property here would
+		 * (see encoderMalformedIntProperty above). The second "Tried:" line is the outer
+		 * encoder-URI-to-builder conversion's own richError(), nested via "cause:".
 		 */
 		encoderCustomStringValidationFailure("""
 				logging.appenders=myapp
@@ -174,7 +175,7 @@ class ConfigFailureTest {
 						Error converting property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], value: 'fake:///' cause:
 						Validation failed for io.jstach.rainbowgum.FakeEncoderBuilder:
 						Error for property. key: 'logging.encoder.myapp.label' from PROPERTIES_STRING[logging.encoder.myapp.label], java.lang.IllegalArgumentException label must not be 'bad'
-						Tried: 'logging.encoder.myapp.label' from PROPERTIES_STRING[logging.encoder.myapp.label]
+						Tried: 'logging.encoder.myapp.label' from PROPERTIES_STRING[logging.encoder.myapp.label], [logging.appender.myapp.encoder]->URI(fake:///)[label]
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
 		// same Result.map() (not convert()) path as encoderCustomStringValidationFailure
@@ -192,7 +193,7 @@ class ConfigFailureTest {
 						Error converting property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], value: 'fake:///' cause:
 						Validation failed for io.jstach.rainbowgum.FakeEncoderBuilder:
 						Error for property. key: 'logging.encoder.myapp.tags' from PROPERTIES_STRING[logging.encoder.myapp.tags], java.lang.IllegalArgumentException tags must not contain 'bad'
-						Tried: 'logging.encoder.myapp.tags' from PROPERTIES_STRING[logging.encoder.myapp.tags]
+						Tried: 'logging.encoder.myapp.tags' from PROPERTIES_STRING[logging.encoder.myapp.tags], [logging.appender.myapp.encoder]->URI(fake:///)[tags]
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
 		// same Result.map() (not convert()) path as encoderCustomStringValidationFailure
@@ -210,7 +211,7 @@ class ConfigFailureTest {
 						Error converting property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], value: 'fake:///' cause:
 						Validation failed for io.jstach.rainbowgum.FakeEncoderBuilder:
 						Error for property. key: 'logging.encoder.myapp.headers' from PROPERTIES_STRING[logging.encoder.myapp.headers], java.lang.IllegalArgumentException headers must not contain key 'bad'
-						Tried: 'logging.encoder.myapp.headers' from PROPERTIES_STRING[logging.encoder.myapp.headers]
+						Tried: 'logging.encoder.myapp.headers' from PROPERTIES_STRING[logging.encoder.myapp.headers], [logging.appender.myapp.encoder]->URI(fake:///)[headers]
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
 		/*
@@ -324,11 +325,10 @@ class ConfigFailureTest {
 		 * The genuine-error counterpart to globalFlagReadWithoutValidatorThrowsDirectly
 		 * above: mode itself fails its map() check, going through the same richError()
 		 * formatting convert() uses (quoted key, "from X", exception class name, "Tried:"
-		 * line) - see the comment on encoderCustomStringValidationFailure above. Since
-		 * map() has no separate outer/aggregate LogProperties parameter, "Tried:" here
-		 * can only ever repeat the same exact source as "from X" - contrast with
-		 * globalConvertValueErrorAcrossChainedProperties above, where convert()'s
-		 * "Tried:" aggregates every chained member.
+		 * line) - see the comment on encoderCustomStringValidationFailure above. Not
+		 * chained, so "from X" and "Tried:" both just name PROPERTIES_STRING here; see
+		 * globalFlagValueErrorAcrossChainedProperties below for the chained case, where
+		 * they differ.
 		 */
 		globalFlagValueError("""
 				logging.fakeGlobal.mode=bad
@@ -480,19 +480,21 @@ class ConfigFailureTest {
 		 * mode (the plain, no-Validator "value" property, see
 		 * globalFlagReadWithoutValidatorThrowsDirectlyAcrossChainedProperties above)
 		 * genuinely failing to convert (not just being absent), inside a chained
-		 * composite. mode is read via Result.map() (not convert()), which builds the same
-		 * richError() message convert() does - since mode3 is Kind.STRING (found, not a
-		 * fallback), "from X"/"Tried:" name the exact chained member it was found in
-		 * ("b"/B_PROPS below), same exact-source precision
-		 * globalConvertValueErrorAcrossChainedProperties above shows for "from X" - but
-		 * unlike that convert() case, map() has no separate outer/aggregate LogProperties
-		 * parameter, so "Tried:" here stays just B_PROPS too, never aggregating in
-		 * A_PROPS.
+		 * composite. mode is read via Result.map() (not convert()), which builds the
+		 * exact same richError() message convert() does, including the "Tried:" line:
+		 * "key: ... from X" stays exact (only "b"/B_PROPS, not doubled) since it comes
+		 * from PropertySuccess.properties() (the exact source the value was found at),
+		 * while "Tried: ... from X" is the full aggregate (both members, doubled) since
+		 * it now comes from PropertySuccess.topProperties() - the composite the very
+		 * first forKey() lookup in this chain was made against, carried on the result
+		 * itself rather than passed in by the caller. Same exact-vs-aggregate split
+		 * globalConvertValueErrorAcrossChainedProperties above shows for convert() - the
+		 * two are indistinguishable now.
 		 */
 		globalFlagValueErrorAcrossChainedProperties("",
 				"""
 						Error for property. key: 'logging.fakeGlobal.mode' from B_PROPS[logging.fakeGlobal.mode], java.lang.IllegalArgumentException mode must not be 'bad'
-						Tried: 'logging.fakeGlobal.mode' from B_PROPS[logging.fakeGlobal.mode]""") {
+						Tried: 'logging.fakeGlobal.mode' from A_PROPS[logging.fakeGlobal.mode], B_PROPS[logging.fakeGlobal.mode]""") {
 			@Override
 			LogProperties properties() {
 				var a = LogProperties.builder().description("A_PROPS").fromProperties("").build();
@@ -514,14 +516,14 @@ class ConfigFailureTest {
 		 * Chained-composite variant of globalValidateError above: mode2 (in "b") fails
 		 * its map() check while mode (in "a") is valid, so the Validator collects the
 		 * same richError() message globalValidateError does, naming B_PROPS as the exact
-		 * (and, for the same reason as globalFlagValueErrorAcrossChainedProperties above,
-		 * only) source in both "from X" and "Tried:".
+		 * source in "from X" and the full A_PROPS+B_PROPS aggregate in "Tried:" - same as
+		 * globalFlagValueErrorAcrossChainedProperties above.
 		 */
 		globalValidateErrorAcrossChainedProperties("",
 				"""
 						Validation failed for io.jstach.rainbowgum.FakeGlobalConfigurator:
 						Error for property. key: 'logging.fakeGlobal.mode2' from B_PROPS[logging.fakeGlobal.mode2], java.lang.IllegalArgumentException mode2 must not be 'bad'
-						Tried: 'logging.fakeGlobal.mode2' from B_PROPS[logging.fakeGlobal.mode2]""") {
+						Tried: 'logging.fakeGlobal.mode2' from A_PROPS[logging.fakeGlobal.mode2], B_PROPS[logging.fakeGlobal.mode2]""") {
 			@Override
 			LogProperties properties() {
 				var a = LogProperties.builder().description("A_PROPS").fromProperties("""

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
@@ -154,9 +154,12 @@ class ConfigFailureTest {
 		 * Hits Result.map() at the end of the fluent chain (FakeEncoderBuilder's "label"
 		 * field: properties.forKey(...).ofString().map(...)) instead of
 		 * LogProperty.ofXxx()/Result.convert() - see the comment on FakeEncoderBuilder's
-		 * _label. The terser "Error for property. key: <plain key>, <message>" (no "from
-		 * ..."/no "Tried:" line) is exactly the message shape Success.map()'s
-		 * Error.of(key, e) produces, distinct from convert()'s richError().
+		 * _label. map() builds the same rich error message convert()'s richError() does
+		 * (quoted key, "from X", exception class name, "Tried:" line), except its
+		 * "Tried:" line can only ever be that same exact source - map() has no separate
+		 * outer/aggregate LogProperties parameter the way convert() does, so unlike
+		 * unregisteredOutputSchemeAcrossChainedProperties below there is no broader
+		 * search to report.
 		 */
 		encoderCustomStringValidationFailure("""
 				logging.appenders=myapp
@@ -170,7 +173,8 @@ class ConfigFailureTest {
 						Failure providing Appender: 'myapp' from property: Property[logging.appenders]=[myapp]. cause:
 						Error converting property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], value: 'fake:///' cause:
 						Validation failed for io.jstach.rainbowgum.FakeEncoderBuilder:
-						Error for property. key: logging.encoder.myapp.label, label must not be 'bad'
+						Error for property. key: 'logging.encoder.myapp.label' from PROPERTIES_STRING[logging.encoder.myapp.label], java.lang.IllegalArgumentException label must not be 'bad'
+						Tried: 'logging.encoder.myapp.label' from PROPERTIES_STRING[logging.encoder.myapp.label]
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
 		// same Result.map() (not convert()) path as encoderCustomStringValidationFailure
@@ -187,7 +191,8 @@ class ConfigFailureTest {
 						Failure providing Appender: 'myapp' from property: Property[logging.appenders]=[myapp]. cause:
 						Error converting property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], value: 'fake:///' cause:
 						Validation failed for io.jstach.rainbowgum.FakeEncoderBuilder:
-						Error for property. key: logging.encoder.myapp.tags, tags must not contain 'bad'
+						Error for property. key: 'logging.encoder.myapp.tags' from PROPERTIES_STRING[logging.encoder.myapp.tags], java.lang.IllegalArgumentException tags must not contain 'bad'
+						Tried: 'logging.encoder.myapp.tags' from PROPERTIES_STRING[logging.encoder.myapp.tags]
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
 		// same Result.map() (not convert()) path as encoderCustomStringValidationFailure
@@ -204,7 +209,8 @@ class ConfigFailureTest {
 						Failure providing Appender: 'myapp' from property: Property[logging.appenders]=[myapp]. cause:
 						Error converting property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], value: 'fake:///' cause:
 						Validation failed for io.jstach.rainbowgum.FakeEncoderBuilder:
-						Error for property. key: logging.encoder.myapp.headers, headers must not contain key 'bad'
+						Error for property. key: 'logging.encoder.myapp.headers' from PROPERTIES_STRING[logging.encoder.myapp.headers], java.lang.IllegalArgumentException headers must not contain key 'bad'
+						Tried: 'logging.encoder.myapp.headers' from PROPERTIES_STRING[logging.encoder.myapp.headers]
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
 		/*
@@ -316,16 +322,20 @@ class ConfigFailureTest {
 		 * permutation: not chained,error,value
 		 *
 		 * The genuine-error counterpart to globalFlagReadWithoutValidatorThrowsDirectly
-		 * above: mode itself fails its map() check. Same terse Error.of(key, e) path
-		 * FakeEncoderBuilder's label uses (see encoderCustomStringValidationFailure
-		 * above) - no "from X"/"Tried:" provenance at all - which is why this message is
-		 * identical to globalFlagValueErrorAcrossChainedProperties below regardless of
-		 * chaining.
+		 * above: mode itself fails its map() check, going through the same richError()
+		 * formatting convert() uses (quoted key, "from X", exception class name, "Tried:"
+		 * line) - see the comment on encoderCustomStringValidationFailure above. Since
+		 * map() has no separate outer/aggregate LogProperties parameter, "Tried:" here
+		 * can only ever repeat the same exact source as "from X" - contrast with
+		 * globalConvertValueErrorAcrossChainedProperties above, where convert()'s
+		 * "Tried:" aggregates every chained member.
 		 */
 		globalFlagValueError("""
 				logging.fakeGlobal.mode=bad
-				""", """
-				Error for property. key: logging.fakeGlobal.mode, mode must not be 'bad'""") {
+				""",
+				"""
+						Error for property. key: 'logging.fakeGlobal.mode' from PROPERTIES_STRING[logging.fakeGlobal.mode], java.lang.IllegalArgumentException mode must not be 'bad'
+						Tried: 'logging.fakeGlobal.mode' from PROPERTIES_STRING[logging.fakeGlobal.mode]""") {
 			@Override
 			List<Configurator> configurators() {
 				return List.of(new FakeGlobalConfigurator());
@@ -339,15 +349,18 @@ class ConfigFailureTest {
 		 * globalFlagReadWithValidateBuildsRicherMissingMessage above: mode2 fails its
 		 * map() check instead of being absent, so the Validator collects a Result.Error
 		 * (via Validator#add, same as Missing) instead of a Result.Missing - same
-		 * "Validation failed for X:" wrapper, but the inner line is mode2's terse
-		 * Error.of(key, e) message instead of "Property missing. keys: [...]".
+		 * "Validation failed for X:" wrapper, but the inner line is mode2's richError()
+		 * message (see globalFlagValueError above) instead of
+		 * "Property missing. keys: [...]".
 		 */
 		globalValidateError("""
 				logging.fakeGlobal.mode=x
 				logging.fakeGlobal.mode2=bad
-				""", """
-				Validation failed for io.jstach.rainbowgum.FakeGlobalConfigurator:
-				Error for property. key: logging.fakeGlobal.mode2, mode2 must not be 'bad'""") {
+				""",
+				"""
+						Validation failed for io.jstach.rainbowgum.FakeGlobalConfigurator:
+						Error for property. key: 'logging.fakeGlobal.mode2' from PROPERTIES_STRING[logging.fakeGlobal.mode2], java.lang.IllegalArgumentException mode2 must not be 'bad'
+						Tried: 'logging.fakeGlobal.mode2' from PROPERTIES_STRING[logging.fakeGlobal.mode2]""") {
 			@Override
 			List<Configurator> configurators() {
 				return List.of(new FakeGlobalConfigurator());
@@ -467,16 +480,19 @@ class ConfigFailureTest {
 		 * mode (the plain, no-Validator "value" property, see
 		 * globalFlagReadWithoutValidatorThrowsDirectlyAcrossChainedProperties above)
 		 * genuinely failing to convert (not just being absent), inside a chained
-		 * composite. mode is read via Result.map() (not convert()), the same terse
-		 * Error.of(key, e) path FakeEncoderBuilder's label uses - see
-		 * encoderCustomStringValidationFailure above - which has no "from X"/"Tried:"
-		 * provenance at all, so unlike globalConvertValueErrorAcrossChainedProperties
-		 * (the convert() equivalent) this message is identical to globalFlagValueError
-		 * above, whether mode lives in a single LogProperties or a chained one; kept here
-		 * anyway for completeness of the matrix.
+		 * composite. mode is read via Result.map() (not convert()), which builds the same
+		 * richError() message convert() does - since mode3 is Kind.STRING (found, not a
+		 * fallback), "from X"/"Tried:" name the exact chained member it was found in
+		 * ("b"/B_PROPS below), same exact-source precision
+		 * globalConvertValueErrorAcrossChainedProperties above shows for "from X" - but
+		 * unlike that convert() case, map() has no separate outer/aggregate LogProperties
+		 * parameter, so "Tried:" here stays just B_PROPS too, never aggregating in
+		 * A_PROPS.
 		 */
-		globalFlagValueErrorAcrossChainedProperties("", """
-				Error for property. key: logging.fakeGlobal.mode, mode must not be 'bad'""") {
+		globalFlagValueErrorAcrossChainedProperties("",
+				"""
+						Error for property. key: 'logging.fakeGlobal.mode' from B_PROPS[logging.fakeGlobal.mode], java.lang.IllegalArgumentException mode must not be 'bad'
+						Tried: 'logging.fakeGlobal.mode' from B_PROPS[logging.fakeGlobal.mode]""") {
 			@Override
 			LogProperties properties() {
 				var a = LogProperties.builder().description("A_PROPS").fromProperties("").build();
@@ -497,13 +513,15 @@ class ConfigFailureTest {
 		 *
 		 * Chained-composite variant of globalValidateError above: mode2 (in "b") fails
 		 * its map() check while mode (in "a") is valid, so the Validator collects the
-		 * same terse Error.of(key, e) message globalValidateError does - no "from
-		 * X"/"Tried:" provenance, so this message is identical to the non-chained
-		 * version; kept here anyway for completeness of the matrix.
+		 * same richError() message globalValidateError does, naming B_PROPS as the exact
+		 * (and, for the same reason as globalFlagValueErrorAcrossChainedProperties above,
+		 * only) source in both "from X" and "Tried:".
 		 */
-		globalValidateErrorAcrossChainedProperties("", """
-				Validation failed for io.jstach.rainbowgum.FakeGlobalConfigurator:
-				Error for property. key: logging.fakeGlobal.mode2, mode2 must not be 'bad'""") {
+		globalValidateErrorAcrossChainedProperties("",
+				"""
+						Validation failed for io.jstach.rainbowgum.FakeGlobalConfigurator:
+						Error for property. key: 'logging.fakeGlobal.mode2' from B_PROPS[logging.fakeGlobal.mode2], java.lang.IllegalArgumentException mode2 must not be 'bad'
+						Tried: 'logging.fakeGlobal.mode2' from B_PROPS[logging.fakeGlobal.mode2]""") {
 			@Override
 			LogProperties properties() {
 				var a = LogProperties.builder().description("A_PROPS").fromProperties("""

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeEncoderConfigurator.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeEncoderConfigurator.java
@@ -147,9 +147,11 @@ final class FakeEncoderBuilder implements LogBuilder<FakeEncoderBuilder, LogEnco
 		var _host = properties.forKey(property_host).ofString().or(this.host).validate(__v);
 		/*
 		 * Deliberately Result.map() here, not LogProperty.ofXxx()/Result.convert() -
-		 * exercises the plain end-of-fluent-chain mapping path (Success.map() ->
-		 * Error.of(key, e), a terser message with no "from ..."/"Tried:" provenance)
-		 * rather than convert()'s richer richError() path. See
+		 * exercises the plain end-of-fluent-chain mapping path (Success.map(), which
+		 * builds the same richError() message convert() does, except its "Tried:" line
+		 * can only ever be the exact source the value was found at - map() has no
+		 * separate outer/aggregate LogProperties parameter to search more broadly for
+		 * that line the way convert() does). See
 		 * ConfigFailureTest.encoderCustomStringValidationFailure().
 		 */
 		var _label = properties.forKey(property_label).ofString().map(l -> {

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeEncoderConfigurator.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeEncoderConfigurator.java
@@ -148,10 +148,9 @@ final class FakeEncoderBuilder implements LogBuilder<FakeEncoderBuilder, LogEnco
 		/*
 		 * Deliberately Result.map() here, not LogProperty.ofXxx()/Result.convert() -
 		 * exercises the plain end-of-fluent-chain mapping path (Success.map(), which
-		 * builds the same richError() message convert() does, except its "Tried:" line
-		 * can only ever be the exact source the value was found at - map() has no
-		 * separate outer/aggregate LogProperties parameter to search more broadly for
-		 * that line the way convert() does). See
+		 * builds the exact same richError() message convert() does - both read the
+		 * broader/aggregate LogProperties for the "Tried:" line off the result's own
+		 * PropertySuccess.topProperties(), not a parameter either method is given). See
 		 * ConfigFailureTest.encoderCustomStringValidationFailure().
 		 */
 		var _label = properties.forKey(property_label).ofString().map(l -> {

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeGlobalConfigurator.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeGlobalConfigurator.java
@@ -14,10 +14,9 @@ import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
  * properties, each demonstrating a different way a direct (no builder) read can fail:
  * <ul>
  * <li>{@value #MODE_PROPERTY} via plain {@link LogProperty.Result#value()} (with a
- * {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()} check, same terse
- * {@code Error.of(key, e)} path as {@code FakeEncoderBuilder}'s {@code label}), so a
- * missing/bad value throws immediately and unwrapped - no "Validation failed for ...:"
- * collection in between.</li>
+ * {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()} check, same as
+ * {@code FakeEncoderBuilder}'s {@code label}), so a missing/bad value throws immediately
+ * and unwrapped - no "Validation failed for ...:" collection in between.</li>
  * <li>{@value #MODE2_PROPERTY} via a hand-built
  * {@link LogProperty.Validator}/{@link LogProperty.Result#validate(LogProperty.Validator)
  * validate(Validator)} (with the same kind of {@code map()} check as
@@ -27,9 +26,11 @@ import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
  * <li>{@value #MODE3_PROPERTY} via
  * {@link LogProperty.Result#convert(LogProperties, LogProperty.PropertyFunction)
  * convert()} (not {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()}, see
- * {@code FakeEncoderBuilder}'s {@code label}) so the failure goes through
- * {@code richError()}'s richer path instead of {@code map()}'s terse
- * {@code Error.of(key, e)}.</li>
+ * {@code FakeEncoderBuilder}'s {@code label}) - both build the same rich
+ * {@code richError()} message on failure, but only {@code convert()} takes a separate
+ * outer/aggregate {@link LogProperties} so its "Tried:" line can search more broadly than
+ * the exact source the value was found at; {@code map()}'s "Tried:" line is always that
+ * same exact source.</li>
  * </ul>
  * See {@link ConfigFailureTest.ConfigFailure} for exactly how these compare, including
  * chained/{@code ListLogProperties} variants.

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeGlobalConfigurator.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeGlobalConfigurator.java
@@ -11,25 +11,22 @@ import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
  * for its global on/off switches. Unlike those switches (always {@code Boolean}, which
  * can never itself fail to parse - {@link Boolean#parseBoolean(String)} just returns
  * {@code false} for anything unrecognized), this fake also has three required companion
- * properties, each demonstrating a different way a direct (no builder) read can fail:
+ * properties, each read via {@link LogProperty.Result#map(LogProperty.PropertyFunction)
+ * map()} (same as {@code FakeEncoderBuilder}'s {@code label}) but wired up differently so
+ * each demonstrates a different way a direct (no builder) read can fail:
  * <ul>
- * <li>{@value #MODE_PROPERTY} via plain {@link LogProperty.Result#value()} (with a
- * {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()} check, same as
- * {@code FakeEncoderBuilder}'s {@code label}), so a missing/bad value throws immediately
- * and unwrapped - no "Validation failed for ...:" collection in between.</li>
- * <li>{@value #MODE2_PROPERTY} via a hand-built
+ * <li>{@value #MODE_PROPERTY} - plain {@link LogProperty.Result#value()} after the
+ * {@code map()} check, so a missing/bad value throws immediately and unwrapped - no
+ * "Validation failed for ...:" collection in between.</li>
+ * <li>{@value #MODE2_PROPERTY} - a hand-built
  * {@link LogProperty.Validator}/{@link LogProperty.Result#validate(LogProperty.Validator)
- * validate(Validator)} (with the same kind of {@code map()} check as
- * {@value #MODE_PROPERTY}), which gets that richer "Validation failed for X:" message
- * (naming this class) the same way a generated builder's own {@code Validator}
- * would.</li>
- * <li>{@value #MODE3_PROPERTY} via
- * {@link LogProperty.Result#convert(LogProperty.PropertyFunction) convert()} - the
- * conventional name for a conversion step, but otherwise identical to
- * {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()}: both build the same
- * rich {@code richError()} message on failure, reading a possibly-broader/ aggregate
- * {@link LogProperties} for the "Tried:" line off the result's own
- * {@code PropertySuccess.topProperties()}.</li>
+ * validate(Validator)} after the same kind of {@code map()} check, which gets that richer
+ * "Validation failed for X:" message (naming this class) the same way a generated
+ * builder's own {@code Validator} would.</li>
+ * <li>{@value #MODE3_PROPERTY} - kept as a third, separately-named property purely so
+ * {@link ConfigFailureTest.ConfigFailure}'s permutation matrix has a case per read style
+ * to point at; its own {@code map()} check ({@link #checkMode3(String)}) is otherwise
+ * identical in mechanism to {@value #MODE_PROPERTY}'s.</li>
  * </ul>
  * See {@link ConfigFailureTest.ConfigFailure} for exactly how these compare, including
  * chained/{@code ListLogProperties} variants.
@@ -56,7 +53,7 @@ final class FakeGlobalConfigurator implements Configurator {
 		var mode2 = properties.forKey(MODE2_PROPERTY).ofString().map(FakeGlobalConfigurator::checkMode2).validate(v);
 		v.validate();
 		mode2.value();
-		properties.forKey(MODE3_PROPERTY).ofString().convert(FakeGlobalConfigurator::checkMode3).value();
+		properties.forKey(MODE3_PROPERTY).ofString().map(FakeGlobalConfigurator::checkMode3).value();
 		return true;
 	}
 

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeGlobalConfigurator.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/FakeGlobalConfigurator.java
@@ -24,13 +24,12 @@ import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
  * (naming this class) the same way a generated builder's own {@code Validator}
  * would.</li>
  * <li>{@value #MODE3_PROPERTY} via
- * {@link LogProperty.Result#convert(LogProperties, LogProperty.PropertyFunction)
- * convert()} (not {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()}, see
- * {@code FakeEncoderBuilder}'s {@code label}) - both build the same rich
- * {@code richError()} message on failure, but only {@code convert()} takes a separate
- * outer/aggregate {@link LogProperties} so its "Tried:" line can search more broadly than
- * the exact source the value was found at; {@code map()}'s "Tried:" line is always that
- * same exact source.</li>
+ * {@link LogProperty.Result#convert(LogProperty.PropertyFunction) convert()} - the
+ * conventional name for a conversion step, but otherwise identical to
+ * {@link LogProperty.Result#map(LogProperty.PropertyFunction) map()}: both build the same
+ * rich {@code richError()} message on failure, reading a possibly-broader/ aggregate
+ * {@link LogProperties} for the "Tried:" line off the result's own
+ * {@code PropertySuccess.topProperties()}.</li>
  * </ul>
  * See {@link ConfigFailureTest.ConfigFailure} for exactly how these compare, including
  * chained/{@code ListLogProperties} variants.
@@ -57,7 +56,7 @@ final class FakeGlobalConfigurator implements Configurator {
 		var mode2 = properties.forKey(MODE2_PROPERTY).ofString().map(FakeGlobalConfigurator::checkMode2).validate(v);
 		v.validate();
 		mode2.value();
-		properties.forKey(MODE3_PROPERTY).ofString().convert(properties, FakeGlobalConfigurator::checkMode3).value();
+		properties.forKey(MODE3_PROPERTY).ofString().convert(FakeGlobalConfigurator::checkMode3).value();
 		return true;
 	}
 


### PR DESCRIPTION
PropertySuccess.map() used to report a mapper's exception via the terse Error.of(key, e) - just the key and the exception message, no "from X"/ "Tried:" provenance or exception class name. Route it through the same richError() helper convert() uses instead, so a map()-based failure (FakeEncoderBuilder's label/tags/headers, FakeGlobalConfigurator's mode/mode2) is exactly as informative as a convert()-based one; the only remaining difference is that map() has no separate outer/aggregate LogProperties parameter, so its "Tried:" line can only ever repeat the exact source, never search more broadly across a chained composite the way convert()'s can. Error.of() is now unused and removed.
