### PR TITLE
Replace "opinionated" tagline with "Secure, GraalVM native and jlink …

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -75,8 +75,8 @@ a service loader aware jar.
 
 <h2 id="description">Description</h2>
 
-Rainbow Gum is a JDK 21+ opinionated SLF4J implementation that aims to be easier to use
-while leveraging newer JDK technology.
+Rainbow Gum is a secure, GraalVM native and jlink friendly, modular JDK 21+ SLF4J
+implementation that aims to be easier to use while leveraging newer JDK technology.
 
 Rainbow Gum unlike Logback or Log4J (2) does not offer as much flexibility but is simpler
 and has less overhead.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <packaging>pom</packaging>
   <version>0.11.0-SNAPSHOT</version>
   <url>https://github.com/jstachio/rainbowgum</url>
-  <description>Minimum Opinionated Logging</description>
+  <description>Secure, GraalVM native and jlink friendly modular logging</description>
   <organization>
     <name>rainbowgum</name>
     <url>https://jstach.io/rainbowgum</url>


### PR DESCRIPTION
…friendly modular logging"

Updates pom.xml's <description> (indexed by Maven Central) and the matching sentence in doc/overview.html's Description section. Leaves the two other "opinionated" mentions alone - overview.html's reference to the README's design/philosophy discussion and the unrelated "Logback's own opinionated JSON encoder" - since those describe an actual ongoing design characteristic and a different project's encoder, not this tagline.