### PR TITLE
Hint at the missing module when a known-but-unregistered scheme is used

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogEncoderRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogEncoderRegistry.java
@@ -69,7 +69,7 @@ final class DefaultEncoderRegistry implements LogEncoderRegistry {
 
 		var provider = providers.get(scheme);
 		if (provider == null) {
-			throw LogProviderRef.NotFoundException.of("encoder", scheme, uri);
+			throw LogProviderRef.NotFoundException.of(ProviderModule.ComponentType.ENCODER, scheme, uri);
 		}
 
 		return provider.provide(_ref);

--- a/core/src/main/java/io/jstach/rainbowgum/LogOutputRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogOutputRegistry.java
@@ -165,7 +165,7 @@ final class DefaultOutputRegistry implements LogOutputRegistry {
 		String scheme = Objects.requireNonNull(uri.getScheme());
 		OutputProvider customProvider = providers.get(scheme);
 		if (customProvider == null) {
-			throw LogProviderRef.NotFoundException.of("output", scheme, uri);
+			throw LogProviderRef.NotFoundException.of(ProviderModule.ComponentType.OUTPUT, scheme, uri);
 		}
 		var _ref = ref;
 		return (name, config) -> {

--- a/core/src/main/java/io/jstach/rainbowgum/LogProviderRef.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProviderRef.java
@@ -74,16 +74,24 @@ public sealed interface LogProviderRef {
 		/**
 		 * Builds a {@link NotFoundException} for an unregistered scheme, with a message
 		 * consistent across every kind of provider registry (output/publisher/encoder/
-		 * etc).
-		 * @param component the kind of thing not found (e.g. "output", "publisher",
-		 * "encoder").
+		 * etc). If the scheme happens to be one known to be provided by an optional
+		 * module not currently on the classpath (see {@link ProviderModule}), the message
+		 * is extended to say which dependency to add.
+		 * @param component the kind of thing not found.
 		 * @param scheme the URI scheme that had no provider registered for it.
 		 * @param uri the full URI that was being resolved.
 		 * @return exception, not thrown.
 		 */
-		static NotFoundException of(String component, String scheme, URI uri) {
-			return new NotFoundException(
-					"No " + component + " found. Scheme not registered. scheme: '" + scheme + "', URI: '" + uri + "'");
+		static NotFoundException of(ProviderModule.ComponentType component, String scheme, URI uri) {
+			String message = "No " + component.label() + " found. Scheme not registered. scheme: '" + scheme
+					+ "', URI: '" + uri + "'";
+			var module = ProviderModule.find(component, scheme);
+			if (module.isPresent()) {
+				var m = module.get();
+				message += ". Scheme '" + scheme + "' is provided by module '" + m.moduleName() + "' (Maven: '"
+						+ m.mavenGav() + "') - add that dependency.";
+			}
+			return new NotFoundException(message);
 		}
 
 	}

--- a/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogPublisherRegistry.java
@@ -92,7 +92,7 @@ final class DefaultPublisherRegistry implements LogPublisherRegistry {
 		}
 		var provider = providers.get(scheme);
 		if (provider == null) {
-			throw LogProviderRef.NotFoundException.of("publisher", scheme, uri);
+			throw LogProviderRef.NotFoundException.of(ProviderModule.ComponentType.PUBLISHER, scheme, uri);
 		}
 		return provider.provide(ref);
 	}

--- a/core/src/main/java/io/jstach/rainbowgum/ProviderModule.java
+++ b/core/src/main/java/io/jstach/rainbowgum/ProviderModule.java
@@ -1,0 +1,127 @@
+package io.jstach.rainbowgum;
+
+import java.util.Optional;
+
+/**
+ * Catalogs the optional modules (not bundled in {@code rainbowgum-core}) that are known
+ * to register a particular URI scheme for a particular kind of provider registry
+ * (output/publisher/encoder). This is not a service discovery mechanism - it is a fixed,
+ * hand maintained list used purely to make {@link LogProviderRef.NotFoundException}
+ * messages more actionable: if a scheme is not registered <em>and</em> it happens to be
+ * one we know is provided by an optional module, the message can say which dependency to
+ * add instead of just "not found".
+ */
+enum ProviderModule {
+
+	FILE_OUTPUT(ComponentType.OUTPUT, "file", "io.jstach.rainbowgum.file", "io.jstach.rainbowgum:rainbowgum-file"),
+	ROLLING_OUTPUT(ComponentType.OUTPUT, "rolling", "io.jstach.rainbowgum.file",
+			"io.jstach.rainbowgum:rainbowgum-file"),
+	GELF_ENCODER(ComponentType.ENCODER, "gelf", "io.jstach.rainbowgum.json", "io.jstach.rainbowgum:rainbowgum-json"),
+	ECS_ENCODER(ComponentType.ENCODER, "ecs", "io.jstach.rainbowgum.json", "io.jstach.rainbowgum:rainbowgum-json"),
+	LOGSTASH_ENCODER(ComponentType.ENCODER, "logstash", "io.jstach.rainbowgum.json",
+			"io.jstach.rainbowgum:rainbowgum-json"),
+	LOGBACK_JSON_ENCODER(ComponentType.ENCODER, "logback", "io.jstach.rainbowgum.json",
+			"io.jstach.rainbowgum:rainbowgum-json"),
+	PATTERN_ENCODER(ComponentType.ENCODER, "pattern", "io.jstach.rainbowgum.pattern",
+			"io.jstach.rainbowgum:rainbowgum-pattern"),
+	DISRUPTOR_PUBLISHER(ComponentType.PUBLISHER, "disruptor", "io.jstach.rainbowgum.disruptor",
+			"io.jstach.rainbowgum:rainbowgum-disruptor");
+
+	private final ComponentType componentType;
+
+	private final String scheme;
+
+	private final String moduleName;
+
+	private final String mavenGav;
+
+	private ProviderModule(ComponentType componentType, String scheme, String moduleName, String mavenGav) {
+		this.componentType = componentType;
+		this.scheme = scheme;
+		this.moduleName = moduleName;
+		this.mavenGav = mavenGav;
+	}
+
+	/**
+	 * The kind of provider registry this scheme is registered with.
+	 * @return component type.
+	 */
+	ComponentType componentType() {
+		return componentType;
+	}
+
+	/**
+	 * The URI scheme the module registers.
+	 * @return scheme.
+	 */
+	String scheme() {
+		return scheme;
+	}
+
+	/**
+	 * The Java module ({@code module-info.java}) name the scheme is registered from.
+	 * @return module name.
+	 */
+	String moduleName() {
+		return moduleName;
+	}
+
+	/**
+	 * The Maven {@code groupId:artifactId} that provides {@link #moduleName()}.
+	 * @return maven GAV (without version).
+	 */
+	String mavenGav() {
+		return mavenGav;
+	}
+
+	/**
+	 * Finds a known module by component type and scheme.
+	 * @param componentType kind of provider registry.
+	 * @param scheme URI scheme that was not found.
+	 * @return module if the combination of type and scheme is known, empty otherwise.
+	 */
+	static Optional<ProviderModule> find(ComponentType componentType, String scheme) {
+		for (var m : values()) {
+			if (m.componentType == componentType && m.scheme.equals(scheme)) {
+				return Optional.of(m);
+			}
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * The different kinds of provider registries that resolve components by URI scheme.
+	 */
+	enum ComponentType {
+
+		/**
+		 * {@link LogOutputRegistry}.
+		 */
+		OUTPUT("output"),
+		/**
+		 * {@link LogPublisherRegistry}.
+		 */
+		PUBLISHER("publisher"),
+		/**
+		 * {@link LogEncoderRegistry}.
+		 */
+		ENCODER("encoder");
+
+		private final String label;
+
+		private ComponentType(String label) {
+			this.label = label;
+		}
+
+		/**
+		 * The label used in {@link LogProviderRef.NotFoundException} messages, e.g.
+		 * "output"/"publisher"/"encoder".
+		 * @return label.
+		 */
+		String label() {
+			return label;
+		}
+
+	}
+
+}

--- a/core/src/test/java/io/jstach/rainbowgum/LogProviderRefTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogProviderRefTest.java
@@ -47,6 +47,30 @@ class LogProviderRefTest {
 	}
 
 	@Test
+	void testNotFoundExceptionOfUnknownSchemeHasNoModuleHint() {
+		var e = LogProviderRef.NotFoundException.of(ProviderModule.ComponentType.OUTPUT, "bogus",
+				URI.create("bogus:///"));
+		assertEquals("No output found. Scheme not registered. scheme: 'bogus', URI: 'bogus:///'", e.getMessage());
+	}
+
+	@Test
+	void testNotFoundExceptionOfKnownSchemeButWrongComponentTypeHasNoModuleHint() {
+		// "gelf" is only registered as an encoder scheme, not an output scheme.
+		var e = LogProviderRef.NotFoundException.of(ProviderModule.ComponentType.OUTPUT, "gelf",
+				URI.create("gelf:///"));
+		assertEquals("No output found. Scheme not registered. scheme: 'gelf', URI: 'gelf:///'", e.getMessage());
+	}
+
+	@Test
+	void testNotFoundExceptionOfKnownSchemeHasModuleHint() {
+		var e = LogProviderRef.NotFoundException.of(ProviderModule.ComponentType.ENCODER, "gelf",
+				URI.create("gelf:///"));
+		assertEquals("No encoder found. Scheme not registered. scheme: 'gelf', URI: 'gelf:///'. "
+				+ "Scheme 'gelf' is provided by module 'io.jstach.rainbowgum.json' "
+				+ "(Maven: 'io.jstach.rainbowgum:rainbowgum-json') - add that dependency.", e.getMessage());
+	}
+
+	@Test
 	void testNormalizeUriPassesThroughWhenSchemeAlreadyPresent() {
 		var uri = URI.create("console:///?a=b");
 		assertEquals(uri, DefaultLogProviderRef.normalize(uri));

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/ConfigFailureTest.java
@@ -101,6 +101,17 @@ class ConfigFailureTest {
 						Error for property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], NotFoundException No encoder found. Scheme not registered. scheme: 'bogus', URI: 'bogus:///'
 						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
 
+		unregisteredEncoderSchemeFromKnownModuleHintsDependency("""
+				logging.appenders=myapp
+				logging.appender.myapp.output=list:///
+				logging.appender.myapp.encoder=gelf:///
+				""",
+				"""
+						Failure providing Appenders for route: 'default'. cause:
+						Failure providing Appender: 'myapp' from property: Property[logging.appenders]=[myapp]. cause:
+						Error for property. key: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder], NotFoundException No encoder found. Scheme not registered. scheme: 'gelf', URI: 'gelf:///'. Scheme 'gelf' is provided by module 'io.jstach.rainbowgum.json' (Maven: 'io.jstach.rainbowgum:rainbowgum-json') - add that dependency.
+						Tried: 'logging.appender.myapp.encoder' from PROPERTIES_STRING[logging.appender.myapp.encoder]"""),
+
 		encoderMissingRequiredStringProperty("""
 				logging.appenders=myapp
 				logging.appender.myapp.output=list:///


### PR DESCRIPTION
ProviderModule (sibling to LogProviderRef) catalogs the URI schemes that optional modules (rainbowgum-file, rainbowgum-json, rainbowgum-pattern, rainbowgum-disruptor) register with the output/publisher/encoder registries, along with the Java module name and Maven groupId:artifactId that provides each. LogProviderRef.NotFoundException.of now looks a scheme up there and, when found, appends which dependency to add - otherwise the message is unchanged, so existing "genuinely unknown scheme" golden-string tests still pass byte for byte.