### PR TITLE
Split Rolling Files doc section into Built-in Rolling vs External Too…

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1034,6 +1034,8 @@ their defaults.
 
 <h3 id="rolling">Rolling Files</h3>
 
+<h4 id="rolling_builtin">Built-in Rolling</h4>
+
 The same <code>rainbowgum-file</code> module additionally provides a deliberately basic,
 size based rolling file output under the "rolling" URI scheme,
 {@link io.jstach.rainbowgum.rolling.RollingFileOutput}:
@@ -1059,6 +1061,9 @@ below instead (typically
 <a href="https://manpages.debian.org/latest/logrotate/logrotate.8.en.html">logrotate</a>)
 - it remains the recommended approach for anything beyond preventing a disk from
 filling up, and does not depend on the <code>rainbowgum-file</code> module at all.
+
+<h4 id="rolling_external">External Tool Support (logrotate)</h4>
+
 How this typically works:
 
 <ol>


### PR DESCRIPTION
…l Support

Adds h4 subsections so the size-based rolling:// scheme and the logrotate/reopen-on-signal approach read as two distinct options instead of one continuous block.