### PR TITLE
Add rainbowgum-signal: Unix signal based reopen for log rotation

### DIFF
--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1118,6 +1118,16 @@ We might have a logrotate script that looks like:
 }
 }
 
+<p>
+The example above assumes a fixed, known port. For Spring Boot applications where the port
+is not fixed (e.g. a random port for tests, or unknown until the web server actually starts),
+Spring Boot's own
+<a href="https://docs.spring.io/spring-boot/reference/actuator/process-monitoring.html">process
+monitoring support</a> includes <code>WebServerPortFileWriter</code>, which writes the actual
+bound port to a file (<code>application.port</code> by default) that the <code>postrotate</code>
+script can read instead of hardcoding one.
+</p>
+
 <h5 id="rolling_external_signal">Unix Signal based reopen (recommended for Linux/Docker)</h5>
 
 On Linux - and in most container/Docker deployments - a Unix signal is a simpler alternative
@@ -1167,6 +1177,15 @@ assuming the application writes its own pid to a file, e.g. <code>/var/run/app.p
   endscript
 }
 }
+
+<p>
+For Spring Boot applications, the pid file itself does not need to be written by hand: the
+same
+<a href="https://docs.spring.io/spring-boot/reference/actuator/process-monitoring.html">process
+monitoring support</a> mentioned above also includes <code>ApplicationPidFileWriter</code>,
+which writes the running application's pid to a file (<code>application.pid</code> by default,
+customizable via its constructor) for exactly this purpose.
+</p>
 
 <p>
 <strong>This module is not usable on Windows</strong> (there are no POSIX signals) - it

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1118,6 +1118,63 @@ We might have a logrotate script that looks like:
 }
 }
 
+<h5 id="rolling_external_signal">Unix Signal based reopen (recommended for Linux/Docker)</h5>
+
+On Linux - and in most container/Docker deployments - a Unix signal is a simpler alternative
+to the HTTP endpoint above: no port needs to be opened or secured, and no application code
+has to be written at all. The optional <code>rainbowgum-signal</code> module (not included by
+default) provides {@link io.jstach.rainbowgum.signal.SignalConfigurator}, which listens for a
+configurable signal and calls {@link io.jstach.rainbowgum.LogOutputRegistry#reopen()} - the
+exact same call the HTTP example above makes - whenever it is received.
+
+<p>
+<strong>Merely depending on this module does not activate it</strong> - installing a live
+signal handler is an ambient capability change (any process with permission to signal this
+one could trigger it), so it is deliberately disabled by default. Activate it with:
+</p>
+
+{@snippet lang=properties :
+logging.signal.enable=true
+}
+
+or, if configuring Rainbow Gum programmatically instead of via properties, by calling
+{@link io.jstach.rainbowgum.signal.SignalConfigurator#enabled(boolean)} explicitly - passing
+<code>new SignalConfigurator().enabled(true)</code> to
+{@link io.jstach.rainbowgum.LogConfig.Builder#configurator(io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator)}
+is itself the opt-in, independent of the property above.
+
+<p>
+The signal name defaults to {@value io.jstach.rainbowgum.signal.SignalConfigurator#DEFAULT_SIGNAL_NAME}
+and can be changed with {@value io.jstach.rainbowgum.signal.SignalConfigurator#SIGNAL_NAME}
+(or the equivalent {@link io.jstach.rainbowgum.signal.SignalConfigurator#signalName(String)}
+method). Given the same logging configuration as above, the logrotate <code>postrotate</code>
+script simply sends the signal to the running process instead of calling out over HTTP -
+assuming the application writes its own pid to a file, e.g. <code>/var/run/app.pid</code>:
+
+{@snippet :
+/var/log/app.log
+{
+  rotate 4
+  weekly
+  missingok
+  notifempty
+  compress
+  delaycompress
+  sharedscripts
+  nocreate
+  postrotate
+    kill -USR1 $(cat /var/run/app.pid) 2>/dev/null || true
+  endscript
+}
+}
+
+<p>
+<strong>This module is not usable on Windows</strong> (there are no POSIX signals) - it
+detects this and safely becomes a no-op rather than failing to start, so it is safe to leave
+on the classpath of a cross platform application; use the HTTP based approach above there
+instead.
+</p>
+
 <h2 id="filter">Filtering</h2>
 
 Like logback Rainbow Gum provides two types of filtering through functional composition:

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>rainbowgum-signal</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>rainbowgum-json</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1235,6 +1240,7 @@
     <module>rainbowgum</module>
     <module>rainbowgum-disruptor</module>
     <module>rainbowgum-jansi</module>
+    <module>rainbowgum-signal</module>
     <module>benchmark</module>
     <module>rainbowgum-avaje-config</module>
     <module>test</module>

--- a/rainbowgum-signal/pom.xml
+++ b/rainbowgum-signal/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach.rainbowgum</groupId>
+    <artifactId>rainbowgum-maven-parent</artifactId>
+    <version>0.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>rainbowgum-signal</artifactId>
+  <name>rainbowgum-signal</name>
+  <properties>
+    <doc.resources>../</doc.resources>
+    <parent.root>${basedir}/..</parent.root>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach.pistachio</groupId>
+      <artifactId>pistachio-svc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach.pistachio</groupId>
+      <artifactId>pistachio-svc-apt</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!--
+            javac unconditionally warns "X is internal proprietary API and may be
+            removed in a future release" on every sun.misc.Signal/SignalHandler
+            reference, even when the module properly declares `requires jdk.unsupported`
+            - confirmed neither -nowarn, -Xlint:-removal, nor -XDignore.symbol.file
+            suppress it (tested directly with javac 26 both on the classpath and as a
+            proper module). This is that module's entire purpose (legacy/unsupported
+            API kept alive on purpose) so the warning is expected and unavoidable here;
+            failOnWarning is relaxed for this module only rather than repo wide.
+          -->
+          <failOnWarning>false</failOnWarning>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/rainbowgum-signal/src/main/java/io/jstach/rainbowgum/signal/SignalConfigurator.java
+++ b/rainbowgum-signal/src/main/java/io/jstach/rainbowgum/signal/SignalConfigurator.java
@@ -1,0 +1,170 @@
+package io.jstach.rainbowgum.signal;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
+import io.jstach.rainbowgum.spi.RainbowGumServiceProvider.Configurator;
+import io.jstach.svc.ServiceProvider;
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
+/**
+ * Installs a {@code sun.misc.Signal} handler that calls
+ * {@link io.jstach.rainbowgum.LogOutputRegistry#reopen()} - the same call the HTTP based
+ * reopen example in {@code doc/overview.html} makes - when the configured signal (default
+ * {@value #DEFAULT_SIGNAL_NAME}) is received. Intended to be triggered from a logrotate
+ * {@code postrotate} script with e.g. <code>kill -USR1 $(cat app.pid)</code> instead of
+ * an HTTP callback.
+ * <p>
+ * <strong>Disabled by default</strong>, even with this module on the classpath -
+ * installing a live signal handler is an ambient capability change (any process with
+ * permission to signal this one could trigger it), so activation requires either
+ * {@value #SIGNAL_ENABLE} set to <code>true</code>, or calling {@link #enabled(boolean)}
+ * explicitly in code - constructing and configuring this class directly is itself the
+ * opt-in.
+ * <p>
+ * Any previously installed handler for the same signal is chained (called after this
+ * handler runs), not discarded, so this composes with other signal handlers in the same
+ * process; {@link #close()} restores it.
+ * <p>
+ * Becomes a safe no-op - rather than failing Rainbow Gum startup - if the platform has no
+ * such signal (e.g. Windows) or if the optional {@code jdk.unsupported} module is not
+ * present (e.g. a trimmed jlink runtime image).
+ *
+ * @apiNote {@code sun.misc.Signal} dispatches handlers from native code; this has not
+ * been verified under GraalVM native-image and this module does not currently ship a
+ * {@code reflect-config.json}. Applications building a native-image should test this
+ * specifically.
+ */
+@ServiceProvider(RainbowGumServiceProvider.class)
+public final class SignalConfigurator implements Configurator, AutoCloseable {
+
+	/**
+	 * If <code>true</code> will install the signal handler when relying on auto-discovery
+	 * (service loader) alone. Disabled by default since installing a signal handler is an
+	 * ambient capability change - see this class's javadoc. Ignored if
+	 * {@link #enabled(boolean)} was called explicitly, which always wins.
+	 */
+	public static final String SIGNAL_ENABLE = LogProperties.ROOT_PREFIX + "signal.enable";
+
+	/**
+	 * The signal name (without the <code>SIG</code> prefix, e.g. <code>USR1</code>,
+	 * <code>HUP</code>) to listen on if not set explicitly with
+	 * {@link #signalName(String)}. Defaults to {@value #DEFAULT_SIGNAL_NAME}.
+	 */
+	public static final String SIGNAL_NAME = LogProperties.ROOT_PREFIX + "signal.name";
+
+	/**
+	 * Default signal name: {@value}.
+	 */
+	public static final String DEFAULT_SIGNAL_NAME = "USR1";
+
+	private volatile @Nullable Boolean enabled;
+
+	private volatile @Nullable String signalName;
+
+	private volatile @Nullable Signal signal;
+
+	private volatile @Nullable SignalHandler previousHandler;
+
+	/**
+	 * No arg for service loader. Disabled by default - see {@link #SIGNAL_ENABLE}.
+	 */
+	public SignalConfigurator() {
+	}
+
+	/**
+	 * Explicitly enables or disables installing the signal handler, overriding
+	 * {@value #SIGNAL_ENABLE} regardless of its value. Calling this with
+	 * <code>true</code> is itself an explicit opt-in.
+	 * @param enabled <code>true</code> to install the handler.
+	 * @return this.
+	 */
+	public SignalConfigurator enabled(boolean enabled) {
+		this.enabled = enabled;
+		return this;
+	}
+
+	/**
+	 * Explicitly sets the signal name to listen on, overriding {@value #SIGNAL_NAME}.
+	 * @param signalName signal name without the <code>SIG</code> prefix, e.g.
+	 * <code>USR1</code>.
+	 * @return this.
+	 */
+	public SignalConfigurator signalName(String signalName) {
+		this.signalName = Objects.requireNonNull(signalName);
+		return this;
+	}
+
+	@Override
+	public boolean configure(LogConfig config, Pass pass) {
+		boolean resolvedEnabled = enabled != null ? enabled
+				: config.properties().forKey(SIGNAL_ENABLE).ofBoolean().or(false).value();
+		if (!resolvedEnabled) {
+			return true;
+		}
+		if (!isUnsupportedModuleAvailable()) {
+			/*
+			 * A trimmed jlink runtime image without jdk.unsupported - safe no-op rather
+			 * than failing startup, same as JULConfigurator does for java.logging.
+			 */
+			return true;
+		}
+		String name = signalName != null ? signalName
+				: config.properties().forKey(SIGNAL_NAME).ofString().or(DEFAULT_SIGNAL_NAME).value();
+		install(config, name);
+		return true;
+	}
+
+	private void install(LogConfig config, String name) {
+		var outputRegistry = config.outputRegistry();
+		var alerts = config.alerts();
+		SignalHandler handler = raisedSignal -> {
+			try {
+				outputRegistry.reopen();
+			}
+			catch (RuntimeException e) {
+				alerts.error(SignalConfigurator.class, e);
+			}
+			var previous = previousHandler;
+			if (previous != null && previous != SignalHandler.SIG_DFL && previous != SignalHandler.SIG_IGN) {
+				try {
+					previous.handle(raisedSignal);
+				}
+				catch (RuntimeException e) {
+					alerts.error(SignalConfigurator.class, e);
+				}
+			}
+		};
+		try {
+			Signal sig = new Signal(name);
+			this.previousHandler = Signal.handle(sig, handler);
+			this.signal = sig;
+		}
+		catch (IllegalArgumentException e) {
+			/*
+			 * Platform does not support this signal (e.g. Windows) or the name is not
+			 * recognized - safe no-op rather than failing startup.
+			 */
+			alerts.error(SignalConfigurator.class, e);
+		}
+	}
+
+	private static boolean isUnsupportedModuleAvailable() {
+		return ModuleLayer.boot().findModule("jdk.unsupported").isPresent();
+	}
+
+	@Override
+	public void close() {
+		var sig = signal;
+		if (sig != null) {
+			var previous = previousHandler;
+			Signal.handle(sig, previous != null ? previous : SignalHandler.SIG_DFL);
+		}
+	}
+
+}

--- a/rainbowgum-signal/src/main/java/io/jstach/rainbowgum/signal/package-info.java
+++ b/rainbowgum-signal/src/main/java/io/jstach/rainbowgum/signal/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Unix signal based reopen for log rotation.
+ */
+@org.eclipse.jdt.annotation.NonNullByDefault
+package io.jstach.rainbowgum.signal;

--- a/rainbowgum-signal/src/main/java/module-info.java
+++ b/rainbowgum-signal/src/main/java/module-info.java
@@ -1,0 +1,37 @@
+/**
+ * Rainbow Gum Unix signal integration. Installs a {@code sun.misc.Signal} handler that
+ * calls {@link io.jstach.rainbowgum.LogOutputRegistry#reopen()} - the same call the HTTP
+ * based reopen example in {@code doc/overview.html} makes - when a configurable signal
+ * (default {@code SIGUSR1}) is received. Intended for a logrotate {@code postrotate}
+ * script to use (e.g. <code>kill -USR1 $(cat app.pid)</code>) instead of an HTTP
+ * callback, on Linux/Docker deployments.
+ * <p>
+ * <strong>Disabled by default</strong> even when this module is on the classpath -
+ * installing a live signal handler is an ambient capability change, so activating it
+ * requires either the property
+ * {@value io.jstach.rainbowgum.signal.SignalConfigurator#SIGNAL_ENABLE} set to
+ * <code>true</code>, or explicit programmatic configuration (constructing a
+ * {@link io.jstach.rainbowgum.signal.SignalConfigurator} and enabling it in code is
+ * itself the opt-in).
+ * <p>
+ * This module is not usable on Windows (there are no POSIX signals) or on a custom
+ * jlink runtime image that excludes the optional <code>jdk.unsupported</code> module -
+ * in both cases it detects this and safely becomes a no-op rather than failing to
+ * start. <strong>The module <code>jdk.unsupported</code> is not required and thus
+ * jlink might not automatically include it as it is <code>requires static</code>.</strong>
+ *
+ * @provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider
+ */
+module io.jstach.rainbowgum.signal {
+
+	exports io.jstach.rainbowgum.signal;
+
+	requires io.jstach.rainbowgum;
+
+	requires static jdk.unsupported;
+	requires static org.eclipse.jdt.annotation;
+	requires static io.jstach.svc;
+
+	provides io.jstach.rainbowgum.spi.RainbowGumServiceProvider with io.jstach.rainbowgum.signal.SignalConfigurator;
+
+}

--- a/rainbowgum-signal/src/test/java/io/jstach/rainbowgum/signal/SignalConfiguratorTest.java
+++ b/rainbowgum-signal/src/test/java/io/jstach/rainbowgum/signal/SignalConfiguratorTest.java
@@ -1,0 +1,134 @@
+package io.jstach.rainbowgum.signal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogResponse;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+import sun.misc.Signal;
+import sun.misc.SignalHandler;
+
+@DisabledOnOs(OS.WINDOWS)
+class SignalConfiguratorTest {
+
+	@Test
+	void testDisabledByDefaultDoesNotInstallHandler() {
+		var output = countingOutput(new CountDownLatch(1), new AtomicInteger());
+
+		var config = LogConfig.builder().configurator(new SignalConfigurator()).build();
+		var gum = RainbowGum.builder(config).route(r -> r.appender("app", a -> a.output(output))).build();
+
+		try (var g = gum.start()) {
+			/*
+			 * sun.misc.Signal.raise() throws IllegalArgumentException("Unhandled signal")
+			 * rather than delivering anything at the OS level when the JVM has no
+			 * internal dispatch trap registered for that signal at all - confirmed via a
+			 * scratch test that this is also exactly the state Signal.handle(sig,
+			 * SIG_DFL) restores things to, so this assertion is safe/deterministic
+			 * regardless of what earlier tests in this class did.
+			 */
+			assertThrows(IllegalArgumentException.class,
+					() -> Signal.raise(new Signal(SignalConfigurator.DEFAULT_SIGNAL_NAME)),
+					"handler must not be installed by default");
+		}
+	}
+
+	@Test
+	void testSignalEnablePropertyInstallsHandler() throws InterruptedException {
+		var reopenCount = new AtomicInteger();
+		var latch = new CountDownLatch(1);
+		var output = countingOutput(latch, reopenCount);
+
+		var properties = LogProperties.builder().fromProperties(SignalConfigurator.SIGNAL_ENABLE + "=true").build();
+		var config = LogConfig.builder().properties(properties).configurator(new SignalConfigurator()).build();
+		var gum = RainbowGum.builder(config).route(r -> r.appender("app", a -> a.output(output))).build();
+
+		try (var g = gum.start()) {
+			/*
+			 * Signal.raise dispatches to the JVM's signal handler thread asynchronously -
+			 * raise() returning does NOT mean the handler ran yet.
+			 */
+			Signal.raise(new Signal(SignalConfigurator.DEFAULT_SIGNAL_NAME));
+			assertTrue(latch.await(5, TimeUnit.SECONDS), "signal handler should have run within 5s");
+			assertEquals(1, reopenCount.get());
+		}
+	}
+
+	@Test
+	void testProgrammaticEnabledInstallsHandlerWithoutProperty() throws InterruptedException {
+		var reopenCount = new AtomicInteger();
+		var latch = new CountDownLatch(1);
+		var output = countingOutput(latch, reopenCount);
+
+		var config = LogConfig.builder().configurator(new SignalConfigurator().enabled(true)).build();
+		var gum = RainbowGum.builder(config).route(r -> r.appender("app", a -> a.output(output))).build();
+
+		try (var g = gum.start()) {
+			Signal.raise(new Signal(SignalConfigurator.DEFAULT_SIGNAL_NAME));
+			assertTrue(latch.await(5, TimeUnit.SECONDS), "signal handler should have run within 5s");
+			assertEquals(1, reopenCount.get());
+		}
+	}
+
+	@Test
+	void testProgrammaticDisabledOverridesEnabledProperty() {
+		var output = countingOutput(new CountDownLatch(1), new AtomicInteger());
+
+		var properties = LogProperties.builder().fromProperties(SignalConfigurator.SIGNAL_ENABLE + "=true").build();
+		var config = LogConfig.builder()
+			.properties(properties)
+			.configurator(new SignalConfigurator().enabled(false))
+			.build();
+		var gum = RainbowGum.builder(config).route(r -> r.appender("app", a -> a.output(output))).build();
+
+		try (var g = gum.start()) {
+			assertThrows(IllegalArgumentException.class,
+					() -> Signal.raise(new Signal(SignalConfigurator.DEFAULT_SIGNAL_NAME)),
+					"explicit enabled(false) must override the property");
+		}
+	}
+
+	@Test
+	void testCloseRestoresPreviousHandler() {
+		var config = LogConfig.builder().configurator(new SignalConfigurator().enabled(true)).build();
+		var gum = RainbowGum.builder(config).build();
+
+		try (var g = gum.start()) {
+			// configurator now owns the signal handler.
+		}
+		// close() -> serviceRegistry().close() -> configurator.close() -> restore.
+
+		Signal sig = new Signal(SignalConfigurator.DEFAULT_SIGNAL_NAME);
+		SignalHandler probe = s -> {
+		};
+		SignalHandler restored = Signal.handle(sig, probe);
+		assertEquals(SignalHandler.SIG_DFL, restored);
+		Signal.handle(sig, SignalHandler.SIG_DFL); // avoid leaking `probe` across tests
+													// in this JVM
+	}
+
+	private static ListLogOutput countingOutput(CountDownLatch latch, AtomicInteger reopenCount) {
+		return new ListLogOutput() {
+			@Override
+			public LogResponse.Status reopen() {
+				reopenCount.incrementAndGet();
+				latch.countDown();
+				return LogResponse.Status.StandardStatus.OK;
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
An alternative to the existing HTTP reopen example for logrotate postrotate scripts (kill -USR1 $PID instead of an HTTP callback) - no open port, no application code required, for Linux/Docker deployments. Uses sun.misc.Signal, guarded by a jdk.unsupported module-presence check (mirroring rainbowgum-jul's java.logging guard) so a trimmed jlink image or Windows safely no-ops instead of failing startup.

Disabled by default even with the module on the classpath - installing a signal handler is an ambient capability change, so activation needs either logging.signal.enable=true or explicit programmatic SignalConfigurator.enabled(true), which always wins over the property.