### PR TITLE
Add LogRouter.eventLogger(name): a sink with no level-based gating

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogRouter.java
@@ -40,6 +40,19 @@ public sealed interface LogRouter extends LogLifecycle {
 	public Route route(String loggerName, java.lang.System.Logger.Level level);
 
 	/**
+	 * The sink to dispatch events to for a logger name, with <strong>no level based
+	 * gating</strong> - unlike {@link #route(String, java.lang.System.Logger.Level)}, the
+	 * returned {@link LogEventLogger} always accepts {@link LogEventLogger#log(LogEvent)}
+	 * regardless of what level is currently enabled. Use this when level gating is
+	 * already handled independently (e.g. a logger facade caching its own resolved level
+	 * and re-checking it on every call) and a level would otherwise have to be made up
+	 * just to obtain a working sink.
+	 * @param loggerName topic.
+	 * @return event logger, never <code>null</code>.
+	 */
+	public LogEventLogger eventLogger(String loggerName);
+
+	/**
 	 * Global router which is always available.
 	 * @return global root router.
 	 */
@@ -195,6 +208,17 @@ public sealed interface LogRouter extends LogLifecycle {
 				event = event.freeze();
 			}
 			publisher().log(event);
+		}
+
+		@Override
+		default LogEventLogger eventLogger(String loggerName) {
+			/*
+			 * A leaf Router does not route to a different Router by name (that only
+			 * happens at the RootRouter level, e.g. CompositeLogRouter fanning out to
+			 * multiple child Routers) - it always dispatches to its own publisher, so it
+			 * is already its own sink.
+			 */
+			return this;
 		}
 
 		/**
@@ -687,6 +711,11 @@ record SingleSyncRootRouter(Router router, RouteChangePublisher changePublisher)
 		return router.route(loggerName, level);
 	}
 
+	@Override
+	public LogEventLogger eventLogger(String loggerName) {
+		return router.eventLogger(loggerName);
+	}
+
 }
 
 record SingleAsyncRootRouter(Router router, RouteChangePublisher changePublisher) implements InternalRootRouter {
@@ -711,6 +740,11 @@ record SingleAsyncRootRouter(Router router, RouteChangePublisher changePublisher
 		return router.route(loggerName, level);
 	}
 
+	@Override
+	public LogEventLogger eventLogger(String loggerName) {
+		return router.eventLogger(loggerName);
+	}
+
 }
 
 @SuppressWarnings("ArrayRecordComponent") // TODO revisit perf
@@ -727,6 +761,16 @@ record CompositeLogRouter(Router[] routers, LevelResolver levelResolver,
 			return this;
 		}
 		return Routes.NotFound;
+	}
+
+	@Override
+	public LogEventLogger eventLogger(String loggerName) {
+		/*
+		 * log(LogEvent) below already fans out to every child router regardless of how it
+		 * was reached, so this composite is already its own sink - no per-child selection
+		 * happens until log() actually runs.
+		 */
+		return this;
 	}
 
 	@Override
@@ -823,6 +867,11 @@ final class QueueEventsRouter implements InternalRootRouter, Route {
 	}
 
 	@Override
+	public LogEventLogger eventLogger(String loggerName) {
+		return this;
+	}
+
+	@Override
 	public void start(LogConfig config) {
 	}
 
@@ -895,6 +944,11 @@ enum GlobalLogRouter implements InternalRootRouter, Route {
 	@Override
 	public Route route(String loggerName, Level level) {
 		return this.delegate.route(loggerName, level);
+	}
+
+	@Override
+	public LogEventLogger eventLogger(String loggerName) {
+		return this.delegate.eventLogger(loggerName);
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>rainbowgum-jcl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>rainbowgum-file</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -1245,6 +1250,7 @@
     <module>rainbowgum-pattern</module>
     <module>rainbowgum-systemlogger</module>
     <module>rainbowgum-tomcat</module>
+    <module>rainbowgum-jcl</module>
     <module>rainbowgum-file</module>
     <module>spring</module>
     <module>rainbowgum-maven-last</module>

--- a/rainbowgum-jcl/pom.xml
+++ b/rainbowgum-jcl/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach.rainbowgum</groupId>
+    <artifactId>rainbowgum-maven-parent</artifactId>
+    <version>0.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>rainbowgum-jcl</artifactId>
+  <name>rainbowgum-jcl</name>
+  <properties>
+    <doc.resources>../</doc.resources>
+    <parent.root>${basedir}/..</parent.root>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.3.6</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach.pistachio</groupId>
+      <artifactId>pistachio-svc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jstach.pistachio</groupId>
+      <artifactId>pistachio-svc-apt</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/ChangeableRainbowGumLog.java
+++ b/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/ChangeableRainbowGumLog.java
@@ -1,0 +1,149 @@
+package io.jstach.rainbowgum.jcl;
+
+import java.lang.System.Logger.Level;
+import java.time.Instant;
+
+import org.apache.commons.logging.Log;
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.LevelResolver;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogRouter;
+
+/**
+ * Re-resolves the level and re-fetches the sink fresh on every call instead of caching
+ * either - simpler than {@code io.jstach.rainbowgum.slf4j}'s
+ * {@code ReplaceableLogger}/subscription approach, and correctly current by construction
+ * rather than needing an explicit invalidation path. Worth the extra per-call lookup here
+ * since a changeable logger name is, by definition, not the common case.
+ */
+final class ChangeableRainbowGumLog implements Log {
+
+	private final String loggerName;
+
+	private final LogRouter router;
+
+	ChangeableRainbowGumLog(String loggerName, LogRouter router) {
+		super();
+		this.loggerName = loggerName;
+		this.router = router;
+	}
+
+	boolean isLoggable(Level level) {
+		return router.route(loggerName, LevelResolver.normalizeLevel(level)).isEnabled();
+	}
+
+	void log(Level level, Object obj) {
+		log(level, obj, null);
+	}
+
+	void log(Level level, Object obj, @Nullable Throwable t) {
+		level = LevelResolver.normalizeLevel(level);
+		var route = router.route(loggerName, level);
+		if (route.isEnabled()) {
+			@Nullable
+			String formattedMessage = obj == null ? null : obj.toString();
+			var currentThread = Thread.currentThread();
+			LogEvent event = LogEvent.of(Instant.now(), currentThread.getName(), currentThread.threadId(), level,
+					loggerName, formattedMessage, KeyValues.of(), t);
+			route.log(event);
+		}
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return isLoggable(Level.DEBUG);
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return isLoggable(Level.ERROR);
+
+	}
+
+	@Override
+	public boolean isFatalEnabled() {
+		return isLoggable(Level.ERROR);
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return isLoggable(Level.INFO);
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return isLoggable(Level.TRACE);
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return isLoggable(Level.WARNING);
+	}
+
+	@Override
+	public void trace(Object message) {
+		log(Level.TRACE, message);
+	}
+
+	@Override
+	public void trace(Object message, Throwable t) {
+		log(Level.TRACE, message, t);
+
+	}
+
+	@Override
+	public void debug(Object message) {
+		log(Level.DEBUG, message);
+	}
+
+	@Override
+	public void debug(Object message, Throwable t) {
+		log(Level.DEBUG, message, t);
+	}
+
+	@Override
+	public void info(Object message) {
+		log(Level.INFO, message);
+	}
+
+	@Override
+	public void info(Object message, Throwable t) {
+		log(Level.INFO, message, t);
+
+	}
+
+	@Override
+	public void warn(Object message) {
+		log(Level.WARNING, message);
+	}
+
+	@Override
+	public void warn(Object message, Throwable t) {
+		log(Level.WARNING, message, t);
+	}
+
+	@Override
+	public void error(Object message) {
+		log(Level.ERROR, message);
+
+	}
+
+	@Override
+	public void error(Object message, Throwable t) {
+		log(Level.ERROR, message, t);
+	}
+
+	@Override
+	public void fatal(Object message) {
+		log(Level.ERROR, message);
+	}
+
+	@Override
+	public void fatal(Object message, Throwable t) {
+		log(Level.ERROR, message, t);
+
+	}
+
+}

--- a/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/ForwardingLog.java
+++ b/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/ForwardingLog.java
@@ -1,0 +1,81 @@
+package io.jstach.rainbowgum.jcl;
+
+import org.apache.commons.logging.Log;
+
+interface ForwardingLog extends Log {
+
+	public Log delegate();
+
+	default boolean isDebugEnabled() {
+		return delegate().isDebugEnabled();
+	}
+
+	default boolean isErrorEnabled() {
+		return delegate().isErrorEnabled();
+	}
+
+	default boolean isFatalEnabled() {
+		return delegate().isFatalEnabled();
+	}
+
+	default boolean isInfoEnabled() {
+		return delegate().isInfoEnabled();
+	}
+
+	default boolean isTraceEnabled() {
+		return delegate().isTraceEnabled();
+	}
+
+	default boolean isWarnEnabled() {
+		return delegate().isWarnEnabled();
+	}
+
+	default void trace(Object message) {
+		delegate().trace(message);
+	}
+
+	default void trace(Object message, Throwable t) {
+		delegate().trace(message, t);
+	}
+
+	default void debug(Object message) {
+		delegate().debug(message);
+	}
+
+	default void debug(Object message, Throwable t) {
+		delegate().debug(message, t);
+	}
+
+	default void info(Object message) {
+		delegate().info(message);
+	}
+
+	default void info(Object message, Throwable t) {
+		delegate().info(message, t);
+	}
+
+	default void warn(Object message) {
+		delegate().warn(message);
+	}
+
+	default void warn(Object message, Throwable t) {
+		delegate().warn(message, t);
+	}
+
+	default void error(Object message) {
+		delegate().error(message);
+	}
+
+	default void error(Object message, Throwable t) {
+		delegate().error(message, t);
+	}
+
+	default void fatal(Object message) {
+		delegate().fatal(message);
+	}
+
+	default void fatal(Object message, Throwable t) {
+		delegate().fatal(message, t);
+	}
+
+}

--- a/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/LevelLog.java
+++ b/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/LevelLog.java
@@ -1,0 +1,568 @@
+package io.jstach.rainbowgum.jcl;
+
+import java.lang.System.Logger.Level;
+import java.time.Instant;
+
+import org.apache.commons.logging.Log;
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.rainbowgum.KeyValues;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogEventLogger;
+
+interface LevelLog extends Log {
+
+	String loggerName();
+
+	LogEventLogger eventLogger();
+
+	default void log(Level level, @Nullable Object obj) {
+		log(level, obj, null);
+	}
+
+	default void log(Level level, @Nullable Object obj, @Nullable Throwable t) {
+		// We do not need to check if the route is enabled.
+		// We are assuming level logging mode.
+		@Nullable
+		String formattedMessage = obj == null ? null : obj.toString();
+		var currentThread = Thread.currentThread();
+		LogEvent event = LogEvent.of(Instant.now(), currentThread.getName(), currentThread.threadId(), level,
+				loggerName(), formattedMessage, KeyValues.of(), t);
+		eventLogger().log(event);
+	}
+
+	record TraceLevelLog(String loggerName, LogEventLogger eventLogger) implements LevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+			log(Level.TRACE, message);
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.TRACE, message, throwable);
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+			log(Level.DEBUG, message);
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.DEBUG, message, throwable);
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.INFO, message, throwable);
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message, throwable);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message, throwable);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record DebugLevelLog(String loggerName, LogEventLogger eventLogger) implements LevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+			log(Level.DEBUG, message);
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.DEBUG, message, throwable);
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.INFO, message, throwable);
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message, throwable);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message, throwable);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record InfoLevelLog(String loggerName, LogEventLogger eventLogger) implements LevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+			log(Level.INFO, message);
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.INFO, message, throwable);
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message, throwable);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message, throwable);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record WarnLevelLog(String loggerName, LogEventLogger eventLogger) implements LevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+			log(Level.WARNING, message);
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.WARNING, message, throwable);
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message, throwable);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record ErrorLevelLog(String loggerName, LogEventLogger eventLogger) implements LevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return true;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+			log(Level.ERROR, message);
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+			log(Level.ERROR, message, throwable);
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+	record OffLevelLog(String loggerName, LogEventLogger eventLogger) implements LevelLog {
+		@Override
+		public boolean isTraceEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDebugEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isInfoEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isWarnEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isErrorEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isFatalEnabled() {
+			return isErrorEnabled();
+		}
+
+		@Override
+		public void trace(@Nullable Object message) {
+		}
+
+		@Override
+		public void trace(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message) {
+		}
+
+		@Override
+		public void debug(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void info(@Nullable Object message) {
+		}
+
+		@Override
+		public void info(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message) {
+		}
+
+		@Override
+		public void warn(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void error(@Nullable Object message) {
+		}
+
+		@Override
+		public void error(@Nullable Object message, @Nullable Throwable throwable) {
+		}
+
+		@Override
+		public void fatal(Object message) {
+			error(message);
+		}
+
+		@Override
+		public void fatal(Object message, Throwable t) {
+			error(message, t);
+
+		}
+
+	}
+
+}

--- a/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/RainbowGumLog.java
+++ b/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/RainbowGumLog.java
@@ -1,0 +1,51 @@
+package io.jstach.rainbowgum.jcl;
+
+import org.apache.commons.logging.Log;
+
+import io.jstach.rainbowgum.LogRouter;
+
+/**
+ * Rainbow Gum's {@link Log} implementation, created by {@link RainbowGumLogFactory}.
+ */
+final class RainbowGumLog implements ForwardingLog {
+
+	private final Log delegate;
+
+	RainbowGumLog(String loggerName) {
+		this(loggerName, LogRouter.global());
+	}
+
+	/**
+	 * Allows a specific router to be used instead of the {@linkplain LogRouter#global()
+	 * global router} - mainly so tests are not coupled to (and do not have to synchronize
+	 * around) the global router's static, JVM-wide state.
+	 * @param loggerName logger name.
+	 * @param router router to use instead of the global router.
+	 */
+	RainbowGumLog(String loggerName, LogRouter.RootRouter router) {
+		var level = router.levelResolver().resolveLevel(loggerName);
+		boolean changeable = router.isChangeable(loggerName);
+		if (changeable) {
+			this.delegate = new ChangeableRainbowGumLog(loggerName, router);
+		}
+		else {
+			var eventLogger = router.eventLogger(loggerName);
+			Log delegate = switch (level) {
+				case ALL -> new LevelLog.TraceLevelLog(loggerName, eventLogger);
+				case TRACE -> new LevelLog.TraceLevelLog(loggerName, eventLogger);
+				case DEBUG -> new LevelLog.DebugLevelLog(loggerName, eventLogger);
+				case INFO -> new LevelLog.InfoLevelLog(loggerName, eventLogger);
+				case WARNING -> new LevelLog.WarnLevelLog(loggerName, eventLogger);
+				case ERROR -> new LevelLog.ErrorLevelLog(loggerName, eventLogger);
+				case OFF -> new LevelLog.OffLevelLog(loggerName, eventLogger);
+			};
+			this.delegate = delegate;
+		}
+	}
+
+	@Override
+	public Log delegate() {
+		return this.delegate;
+	}
+
+}

--- a/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/RainbowGumLogFactory.java
+++ b/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/RainbowGumLogFactory.java
@@ -1,0 +1,70 @@
+package io.jstach.rainbowgum.jcl;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.jstach.svc.ServiceProvider;
+
+/**
+ * Discovered by {@link LogFactory#getFactory()} via {@link java.util.ServiceLoader}
+ * (Commons Logging's own {@code module-info.java} declares
+ * {@code uses org.apache.commons.logging.LogFactory}) or, on the classpath, via the
+ * generated {@code META-INF/services/org.apache.commons.logging.LogFactory} entry.
+ * Creates {@link RainbowGumLog} instances - see that class and
+ * {@link ChangeableRainbowGumLog}/{@link LevelLog} for how logging is actually
+ * dispatched.
+ */
+@ServiceProvider(LogFactory.class)
+public final class RainbowGumLogFactory extends LogFactory {
+
+	private final ConcurrentHashMap<String, Object> attributes = new ConcurrentHashMap<>();
+
+	/**
+	 * For {@link java.util.ServiceLoader}.
+	 */
+	public RainbowGumLogFactory() {
+	}
+
+	@Override
+	public Log getInstance(Class<?> clazz) {
+		return getInstance(clazz.getName());
+	}
+
+	@Override
+	public Log getInstance(String name) {
+		return new RainbowGumLog(name);
+	}
+
+	@Override
+	public void release() {
+	}
+
+	@Override
+	public @Nullable Object getAttribute(String name) {
+		return attributes.get(name);
+	}
+
+	@Override
+	public String[] getAttributeNames() {
+		return attributes.keySet().toArray(new String[0]);
+	}
+
+	@Override
+	public void removeAttribute(String name) {
+		attributes.remove(name);
+	}
+
+	@Override
+	public void setAttribute(String name, @Nullable Object value) {
+		if (value == null) {
+			attributes.remove(name);
+		}
+		else {
+			attributes.put(name, value);
+		}
+	}
+
+}

--- a/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/package-info.java
+++ b/rainbowgum-jcl/src/main/java/io/jstach/rainbowgum/jcl/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Commons Logging (JCL) implementation.
+ */
+@org.eclipse.jdt.annotation.NonNullByDefault
+package io.jstach.rainbowgum.jcl;

--- a/rainbowgum-jcl/src/main/java/module-info.java
+++ b/rainbowgum-jcl/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/**
+ * Rainbow Gum Apache Commons Logging (JCL) implementation - a native
+ * {@code org.apache.commons.logging.LogFactory}/{@code Log}, not a bridge through
+ * {@code jcl-over-slf4j}/{@code spring-jcl}.
+ * <p>
+ * Commons Logging's {@code Log} interface is method-for-method identical to
+ * {@code org.apache.juli.logging.Log} (Tomcat's own logging facade, confirmed by
+ * decompiling both), so this module mirrors {@code rainbowgum-tomcat}'s implementation
+ * shape directly: a non-changeable path with a per-level specialized {@code Log}
+ * (avoiding a level check on every call, same rationale as
+ * {@code io.jstach.rainbowgum.slf4j}'s {@code LevelLogger}, just without needing to be
+ * mustache-generated given how much smaller this facade's surface is), and a
+ * changeable path that re-resolves the level and re-fetches the sink fresh on every
+ * call instead - deliberately not the more complex mutable-state-plus-subscription
+ * approach {@code io.jstach.rainbowgum.slf4j}'s {@code ReplaceableLogger} uses, since
+ * that complexity is only earned by SLF4J's much hotter, more heavily wrapped call
+ * path.
+ *
+ * @provides org.apache.commons.logging.LogFactory
+ */
+module io.jstach.rainbowgum.jcl {
+
+	requires io.jstach.rainbowgum;
+	requires static org.apache.commons.logging;
+	requires static org.eclipse.jdt.annotation;
+	requires static io.jstach.svc;
+
+	provides org.apache.commons.logging.LogFactory with io.jstach.rainbowgum.jcl.RainbowGumLogFactory;
+
+}

--- a/rainbowgum-jcl/src/test/java/io/jstach/rainbowgum/jcl/RainbowGumLogFactoryTest.java
+++ b/rainbowgum-jcl/src/test/java/io/jstach/rainbowgum/jcl/RainbowGumLogFactoryTest.java
@@ -1,0 +1,36 @@
+package io.jstach.rainbowgum.jcl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class RainbowGumLogFactoryTest {
+
+	@Test
+	void testGetInstanceReturnsRainbowGumLog() {
+		var factory = new RainbowGumLogFactory();
+		assertInstanceOf(RainbowGumLog.class, factory.getInstance("some.logger.name"));
+		assertInstanceOf(RainbowGumLog.class, factory.getInstance(RainbowGumLogFactoryTest.class));
+	}
+
+	@Test
+	void testAttributesRoundTrip() {
+		var factory = new RainbowGumLogFactory();
+		assertNull(factory.getAttribute("missing"));
+		assertArrayEquals(new String[0], factory.getAttributeNames());
+
+		factory.setAttribute("a", "b");
+		assertArrayEquals(new String[] { "a" }, factory.getAttributeNames());
+		assertNull(factory.getAttribute("missing"));
+
+		factory.setAttribute("a", null);
+		assertArrayEquals(new String[0], factory.getAttributeNames());
+
+		factory.setAttribute("a", "b");
+		factory.removeAttribute("a");
+		assertArrayEquals(new String[0], factory.getAttributeNames());
+	}
+
+}

--- a/rainbowgum-jcl/src/test/java/io/jstach/rainbowgum/jcl/RainbowGumLogTest.java
+++ b/rainbowgum-jcl/src/test/java/io/jstach/rainbowgum/jcl/RainbowGumLogTest.java
@@ -1,0 +1,132 @@
+package io.jstach.rainbowgum.jcl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.System.Logger.Level;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogEvent;
+import io.jstach.rainbowgum.LogProperties;
+import io.jstach.rainbowgum.LogRouter.RootRouter;
+import io.jstach.rainbowgum.RainbowGum;
+import io.jstach.rainbowgum.output.ListLogOutput;
+
+/**
+ * Covers both dispatch paths {@link RainbowGumLog} picks between: the fixed-level fast
+ * path ({@link LevelLog}, used when the router reports the logger's level as not
+ * changeable) and {@link ChangeableRainbowGumLog} (used when it is). Uses the
+ * {@code RainbowGumLog(String, LogRouter.RootRouter)} constructor added specifically so
+ * these tests don't have to touch (or lock around) the {@code global()} static singleton.
+ */
+class RainbowGumLogTest {
+
+	private static final String LOGGER_NAME = "org.apache.commons.logging.TestComponent";
+
+	private record Fixture(RainbowGum gum, ListLogOutput output, RootRouter router) implements AutoCloseable {
+		@Override
+		public void close() {
+			gum.close();
+		}
+	}
+
+	private static Fixture fixture(Level configuredLevel, boolean changeable) {
+		var propsBuilder = LogProperties.MutableLogProperties.builder()
+			.description("test_props")
+			.build()
+			.put("logging.level." + LOGGER_NAME, configuredLevel.toString());
+		if (changeable) {
+			propsBuilder.put("logging.global.change", "true").put("logging.change", "level");
+		}
+		LogConfig config = LogConfig.builder().properties(propsBuilder).build();
+		ListLogOutput output = new ListLogOutput();
+		var gum = RainbowGum.builder(config).route(r -> r.appender("list", a -> a.output(output))).build().start();
+		var router = gum.router();
+		assertEquals(changeable, router.isChangeable(LOGGER_NAME),
+				"test setup should have produced a router.isChangeable() of " + changeable);
+		return new Fixture(gum, output, router);
+	}
+
+	private static Stream<Arguments> levelsAndChangeable() {
+		return Stream.of(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARNING, Level.ERROR, Level.OFF)
+			.flatMap(level -> Stream.of(Arguments.of(level, true), Arguments.of(level, false)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("levelsAndChangeable")
+	void testEnabledChecksAndLogging(Level configuredLevel, boolean changeable) {
+		try (var fx = fixture(configuredLevel, changeable)) {
+			var log = new RainbowGumLog(LOGGER_NAME, fx.router());
+
+			assertEquals(enabledFor(Level.TRACE, configuredLevel), log.isTraceEnabled(), "isTraceEnabled");
+			assertEquals(enabledFor(Level.DEBUG, configuredLevel), log.isDebugEnabled(), "isDebugEnabled");
+			assertEquals(enabledFor(Level.INFO, configuredLevel), log.isInfoEnabled(), "isInfoEnabled");
+			assertEquals(enabledFor(Level.WARNING, configuredLevel), log.isWarnEnabled(), "isWarnEnabled");
+			assertEquals(enabledFor(Level.ERROR, configuredLevel), log.isErrorEnabled(), "isErrorEnabled");
+			assertEquals(enabledFor(Level.ERROR, configuredLevel), log.isFatalEnabled(), "isFatalEnabled");
+
+			assertLogged(fx, () -> log.trace("hello", new RuntimeException("trace boom")), Level.TRACE,
+					enabledFor(Level.TRACE, configuredLevel), "hello", "trace boom");
+			assertLogged(fx, () -> log.debug("hello", new RuntimeException("debug boom")), Level.DEBUG,
+					enabledFor(Level.DEBUG, configuredLevel), "hello", "debug boom");
+			assertLogged(fx, () -> log.info("hello", new RuntimeException("info boom")), Level.INFO,
+					enabledFor(Level.INFO, configuredLevel), "hello", "info boom");
+			assertLogged(fx, () -> log.warn("hello", new RuntimeException("warn boom")), Level.WARNING,
+					enabledFor(Level.WARNING, configuredLevel), "hello", "warn boom");
+			assertLogged(fx, () -> log.error("hello", new RuntimeException("error boom")), Level.ERROR,
+					enabledFor(Level.ERROR, configuredLevel), "hello", "error boom");
+			assertLogged(fx, () -> log.fatal("hello", new RuntimeException("fatal boom")), Level.ERROR,
+					enabledFor(Level.ERROR, configuredLevel), "hello", "fatal boom");
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("levelsAndChangeable")
+	void testNullMessageIsNotEmptyString(Level configuredLevel, boolean changeable) {
+		try (var fx = fixture(configuredLevel, changeable)) {
+			var log = new RainbowGumLog(LOGGER_NAME, fx.router());
+			fx.output().clear();
+			log.error(null);
+			if (enabledFor(Level.ERROR, configuredLevel)) {
+				List<Entry<LogEvent, String>> events = fx.output().events();
+				assertEquals(1, events.size());
+				assertNull(events.get(0).getKey().messageOrNull(), "a null message should stay null, not \"\"");
+			}
+			else {
+				assertTrue(fx.output().events().isEmpty());
+			}
+		}
+	}
+
+	private static boolean enabledFor(Level methodLevel, Level configuredLevel) {
+		return methodLevel.compareTo(configuredLevel) >= 0;
+	}
+
+	private static void assertLogged(Fixture fx, Runnable call, Level expectedLevel, boolean expectedEnabled,
+			String expectedMessage, String expectedThrowableMessage) {
+		fx.output().clear();
+		call.run();
+		List<Entry<LogEvent, String>> events = fx.output().events();
+		if (!expectedEnabled) {
+			assertTrue(events.isEmpty(), "expected no event for a disabled level but got: " + events);
+			return;
+		}
+		assertEquals(1, events.size());
+		LogEvent event = events.get(0).getKey();
+		assertEquals(expectedLevel, event.level());
+		assertEquals(LOGGER_NAME, event.loggerName());
+		assertEquals(expectedMessage, event.messageOrNull());
+		var throwable = event.throwableOrNull();
+		assertEquals(expectedThrowableMessage, throwable == null ? null : throwable.getMessage(),
+				"throwable should have been passed through, not dropped");
+	}
+
+}

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
@@ -74,9 +74,13 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 			var allowedChanges = changePublisher.allowedChanges(name);
 			if (allowedChanges.contains(ChangeType.LEVEL)) {
 				/*
-				 * We get a logger that can log everything.
+				 * The level can change after this logger is created (that is the whole
+				 * point of it being replaceable), so the sink must not be bound based on
+				 * a level snapshot at creation time - level gating for this logger
+				 * happens entirely inside ReplaceableLogger/LevelLogger instead, via
+				 * setLevel().
 				 */
-				LogEventLogger logger = router.route(name, System.Logger.Level.ERROR);
+				LogEventLogger logger = router.eventLogger(name);
 				var handler = maybeAddCallerInfo(name, allowedChanges, logger, 1);
 				var changeable = ReplaceableLogger.of(Levels.toSlf4jLevel(level), handler);
 				subscribe(name, router, changeable, allowedChanges);
@@ -106,9 +110,11 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 	 * RouteChangePublisher that GlobalLogRouter transfers its queued subscribers into
 	 * once a real router replaces the placeholder queue (see
 	 * InternalRootRouter.setRouter/GlobalLogRouter._drain). r (below) is that replacement
-	 * router - re-resolving the route against it, not just the level, is what stops an
+	 * router - re-fetching the sink from it, not just the level, is what stops an
 	 * already-created ReplaceableLogger from continuing to dispatch into the
-	 * now-abandoned queue after the swap.
+	 * now-abandoned queue after the swap. eventLogger(name), not route(name, level), is
+	 * used deliberately: the level is applied via setLevel() on the line above instead,
+	 * so gating it a second time at the sink would be redundant.
 	 */
 	private void subscribe(String name, RootRouter router, ReplaceableLogger changeable,
 			Set<ChangeType> allowedChanges) {
@@ -118,7 +124,7 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 			public void accept(RootRouter r) {
 				var level = r.levelResolver().resolveLevel(name);
 				changeable.setLevel(Levels.toSlf4jLevel(level));
-				var logger = r.route(name, level);
+				var logger = r.eventLogger(name);
 				var handler = maybeAddCallerInfo(name, allowedChanges, logger, 1);
 				changeable.setEventHandler(handler);
 			}

--- a/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
+++ b/rainbowgum-tomcat/src/main/java/io/jstach/rainbowgum/tomcat/RainbowGumTomcatLog.java
@@ -1,7 +1,5 @@
 package io.jstach.rainbowgum.tomcat;
 
-import java.lang.System.Logger.Level;
-
 import org.apache.juli.logging.Log;
 
 import io.jstach.rainbowgum.LogRouter;
@@ -49,10 +47,7 @@ public final class RainbowGumTomcatLog implements ForwardingTomcatLog {
 			this.delegate = new ChangeableRainbowGumTomcatLog(loggerName, router);
 		}
 		else {
-			// We want a logger that can handle all events.
-			// TODO this is a common need and perhaps a method on LogRouter like
-			// "eventLogger"
-			var eventLogger = router.route(loggerName, Level.ERROR);
+			var eventLogger = router.eventLogger(loggerName);
 			Log delegate = switch (level) {
 				case ALL -> new TomcatLevelLog.TraceLevelLog(loggerName, eventLogger);
 				case TRACE -> new TomcatLevelLog.TraceLevelLog(loggerName, eventLogger);

--- a/todo.md
+++ b/todo.md
@@ -264,20 +264,34 @@ unifying.
       that holds up on a closer look, `write(LogEvent, String)` (and the `STRING` write
       method) may be dead API surface worth removing rather than keeping "just in case" -
       not investigated further or acted on yet.
-- [ ] **Commons Logging (jcl) probably needs its own native Rainbow Gum
-      implementation, the same way `rainbowgum-tomcat` replaced bridging through
-      JUL**: currently the only path is `jcl-over-slf4j`/`spring-jcl`, both of which
-      are someone else's bridge rather than a Rainbow Gum-native `LogFactory`/`Log`.
-      The blocker is that depth-aware (caller info) and runtime-changeable (level,
-      event handler) logger facades are genuinely fiddly to get right - see
-      `rainbowgum-slf4j`'s `ReplaceableLogger`
-      (`LevelChangeable`/`LogEventHandler.EventHandlerChangeable`/
-      `LoggerDecoratorService.DepthAwareLogger`), `CallerInfoEventDecorator`, and
-      `AbstractFilteringLogger`. That logic is currently written once, coupled to
-      SLF4J's `Logger` shape. Before a `rainbowgum-jcl` module (or similar) is worth
-      starting, this shared depth/changeable-logger machinery should be extracted out
-      of `rainbowgum-slf4j` into something a second facade implementation (JCL, and
-      potentially others down the line) can reuse instead of re-deriving it.
+- [x] **Commons Logging (jcl) native Rainbow Gum implementation**: landed as
+      `rainbowgum-jcl` on `feature/router-event-logger`. The premise of this item's
+      original draft was wrong - it assumed `rainbowgum-slf4j`'s
+      `ReplaceableLogger`/`CallerInfoEventDecorator`/`AbstractFilteringLogger` machinery
+      would need extracting out first, but that machinery is specifically earned by
+      SLF4J's own hot, heavily-wrapped call path (caller info, markers, the fluent
+      builder API) - none of which Commons Logging's `Log` interface has. Decompiling
+      both confirmed `org.apache.commons.logging.Log` and `org.apache.juli.logging.Log`
+      (Tomcat's own facade) are method-for-method identical (18 methods, same
+      signatures, just declared in a different order), so `rainbowgum-jcl` is instead a
+      near-direct port of `rainbowgum-tomcat`'s much simpler pattern:
+      `RainbowGumLog`/`ForwardingLog` picks between `LevelLog` (fixed-level, no
+      per-call check - the non-changeable fast path) and `ChangeableRainbowGumLog`
+      (re-resolves the level and re-fetches the sink fresh on every call instead of
+      caching + subscribing to change events - simpler than `ReplaceableLogger`, and
+      correctly current by construction). The one new piece Tomcat's SPI (reflection
+      based, per its own constructor comment) didn't need: `RainbowGumLogFactory
+      extends org.apache.commons.logging.LogFactory`, discovered via
+      `java.util.ServiceLoader` - confirmed Commons Logging 1.3.x's own
+      `module-info.java` declares `uses org.apache.commons.logging.LogFactory`, so a
+      plain `@ServiceProvider(LogFactory.class)`-generated
+      `META-INF/services/org.apache.commons.logging.LogFactory` entry is sufficient on
+      both the module path and the classpath - verified end-to-end with a live
+      `LogFactory.getLog(...)` smoke test outside the reactor, not just a compile check.
+      Takeaway for any future facade (JMX, whatever else): default to the Tomcat/JCL
+      "re-resolve every call" shape, only reach for SLF4J's
+      cache-plus-subscription machinery if the facade's own call path is hot enough to
+      justify it.
 - [x] **No message size limiting - `LogEvent#formattedMessage(StringBuilder)` appends
       unbounded**: every `LogEvent` implementation (`OneArgLogEvent`, `TwoArgLogEvent`,
       `ArrayArgLogEvent`, etc. in `LogEvent.java`) writes into the passed `StringBuilder`


### PR DESCRIPTION
Replaces the router.route(name, Level.ERROR) trick both RainbowGumLoggerFactory (for replaceable loggers) and RainbowGumTomcatLog already used to get a working dispatcher without actually wanting route()'s level check - ERROR was picked only because it's virtually always enabled, which is exactly the kind of tribal knowledge the tomcat module's own pre-existing TODO ("perhaps a method on LogRouter like eventLogger") already called out.

route(name, level) still exists unchanged for the common combined check-and-fetch case (e.g. RainbowGumSystemLogger, RainbowGum.log()). eventLogger(name) is for callers that already gate level themselves (ReplaceableLogger/LevelLogger via setLevel()) and were only calling route() to get a dispatcher, never for its level check.