### PR TITLE
Add golden-string tests proving QueueEventsRouter swallows validation

### DIFF
--- a/test/rainbowgum-test-core/pom.xml
+++ b/test/rainbowgum-test-core/pom.xml
@@ -12,4 +12,47 @@
       <artifactId>rainbowgum-core</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <!--
+            QueueRouter*InvalidTest touch GlobalLogRouter, a JVM-wide singleton that
+            self-initializes exactly once (on first LogRouter.global() call) and
+            permanently poisons itself if that first attempt fails - every later touch
+            throws NoClassDefFoundError instead of re-running init. Surefire's default
+            reuseForks=true shares one JVM across every test class in this module, so
+            these two need excluding from the default execution and re-running in their
+            own execution with reuseForks=false, which forks a fresh JVM per test class
+            instead of reusing one - see QueueRouterLevelPropertyInvalidTest's javadoc.
+          -->
+          <execution>
+            <id>default-test</id>
+            <configuration>
+              <excludes>
+                <exclude>**/QueueRouterLevelPropertyInvalidTest.java</exclude>
+                <exclude>**/QueueRouterBothPropertiesInvalidTest.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>queue-router-validation-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <reuseForks>false</reuseForks>
+              <includes>
+                <include>**/QueueRouterLevelPropertyInvalidTest.java</include>
+                <include>**/QueueRouterBothPropertiesInvalidTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/QueueRouterBothPropertiesInvalidTest.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/QueueRouterBothPropertiesInvalidTest.java
@@ -1,0 +1,48 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.jstach.rainbowgum.LogProperty.ValidationException;
+
+/**
+ * The actual bug this exists to catch: with the old (unvalidated) {@code queueLevel()}/
+ * {@code errorLevel()} implementation, {@code QueueEventsRouter.of()} calls
+ * {@code queueLevel().value()} as the first constructor argument and
+ * {@code errorLevel().value()} as the second - Java evaluates constructor arguments left
+ * to right, so if {@code logging.global.queue.level} is malformed,
+ * {@code queueLevel().value()} throws immediately and {@code errorLevel()} is never even
+ * called, silently never checking whether {@code logging.global.queue.error} is malformed
+ * too. Using a shared {@link io.jstach.rainbowgum.LogProperty.Validator} instead means
+ * both properties are read and registered before either is asked for its value, so a
+ * failure in one no longer hides a failure in the other - both are reported together in
+ * one exception.
+ * <p>
+ * See {@link QueueRouterLevelPropertyInvalidTest} for why this needs its own dedicated,
+ * non-reused-fork JVM (this module's {@code pom.xml}) and {@code @Isolated}.
+ */
+@Isolated
+class QueueRouterBothPropertiesInvalidTest {
+
+	@Test
+	void testBothQueuePropertiesInvalidAreReportedTogether() {
+		System.setProperty(LogProperties.GLOBAL_QUEUE_LEVEL_PROPERTY, "BOGUS1");
+		System.setProperty(LogProperties.GLOBAL_QUEUE_ERROR_PROPERTY, "BOGUS2");
+
+		var error = assertThrows(ExceptionInInitializerError.class, LogRouter::global);
+		var cause = assertInstanceOf(ValidationException.class, error.getCause());
+		assertEquals(
+				"""
+						Validation failed for io.jstach.rainbowgum.QueueEventsRouter:
+						Error for property. key: 'logging.global.queue.level' from SYSTEM_PROPERTIES[logging.global.queue.level], java.lang.IllegalArgumentException Cannot parse Level from input. input='BOGUS1'
+						Tried: 'logging.global.queue.level' from SYSTEM_PROPERTIES[logging.global.queue.level]
+						Error for property. key: 'logging.global.queue.error' from SYSTEM_PROPERTIES[logging.global.queue.error], java.lang.IllegalArgumentException Cannot parse Level from input. input='BOGUS2'
+						Tried: 'logging.global.queue.error' from SYSTEM_PROPERTIES[logging.global.queue.error]""",
+				cause.getMessage());
+	}
+
+}

--- a/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/QueueRouterLevelPropertyInvalidTest.java
+++ b/test/rainbowgum-test-core/src/test/java/io/jstach/rainbowgum/QueueRouterLevelPropertyInvalidTest.java
@@ -1,0 +1,45 @@
+package io.jstach.rainbowgum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.jstach.rainbowgum.LogProperty.ValidationException;
+
+/**
+ * {@code QueueEventsRouter.of()} runs exactly once per JVM, inside
+ * {@code GlobalLogRouter}'s own enum {@code <clinit>}, triggered by the first touch of
+ * {@link LogRouter#global()} anywhere in that JVM's lifetime. A failure there permanently
+ * poisons the class for the rest of the JVM - every later touch throws
+ * {@code NoClassDefFoundError} instead of the real cause, not
+ * {@code ExceptionInInitializerError} again - so this test (and its sibling,
+ * {@link QueueRouterBothPropertiesInvalidTest}) must be the only thing that ever touches
+ * {@link LogRouter#global()}/{@code GlobalLogRouter} in whatever JVM they run in. See
+ * this module's {@code pom.xml} for the dedicated, non-reused-fork Surefire execution
+ * both are scoped to (Surefire's default {@code reuseForks=true} would otherwise share
+ * one JVM with every other test class in this module, some of which may have already
+ * touched {@code GlobalLogRouter} with real system properties before this test ever
+ * runs). {@code @Isolated} is a second guard against the same problem under the
+ * (currently opt-in, {@code -Pfast}) JUnit5 class-concurrency profile.
+ */
+@Isolated
+class QueueRouterLevelPropertyInvalidTest {
+
+	@Test
+	void testQueueLevelPropertyInvalidThrowsValidationException() {
+		System.setProperty(LogProperties.GLOBAL_QUEUE_LEVEL_PROPERTY, "BOGUS_LEVEL");
+
+		var error = assertThrows(ExceptionInInitializerError.class, LogRouter::global);
+		var cause = assertInstanceOf(ValidationException.class, error.getCause());
+		assertEquals(
+				"""
+						Validation failed for io.jstach.rainbowgum.QueueEventsRouter:
+						Error for property. key: 'logging.global.queue.level' from SYSTEM_PROPERTIES[logging.global.queue.level], java.lang.IllegalArgumentException Cannot parse Level from input. input='BOGUS_LEVEL'
+						Tried: 'logging.global.queue.level' from SYSTEM_PROPERTIES[logging.global.queue.level]""",
+				cause.getMessage());
+	}
+
+}


### PR DESCRIPTION
Currently (unfixed) fails against main by design, both for the same underlying reason - a malformed logging.global.queue.level/.error system property is supposed to fail QueueEventsRouter.of() with LogProperty.ValidationException, aggregating every bad property into one message, but today it throws PropertyConvertException instead and
- worse, per QueueRouterBothPropertiesInvalidTest - only reports whichever of the two properties happens to be read first as a constructor argument, silently never even checking the second if the first already failed.

Verified both tests pass once refactor/logrouter's "Fix Queue Router to use validator" (6184792f) is applied - confirmed directly by temporarily overlaying that commit's LogRouter.java, rebuilding, and reverting before this commit.

Needs its own Surefire execution (reuseForks=false, excluded from the module's default execution) because QueueEventsRouter.of() only runs once per JVM, inside GlobalLogRouter's enum <clinit> on first LogRouter.global() touch - a failed first attempt permanently poisons the class (later touches throw NoClassDefFoundError, not the real cause again), so each scenario needs a JVM that has never touched GlobalLogRouter before, which Surefire's default reuseForks=true sharing one JVM across this module's other test classes can't guarantee.