### PR TITLE
Replace the hidden mobile TOC with a working hamburger drawer

### DIFF
--- a/doc/jstachio.css
+++ b/doc/jstachio.css
@@ -113,16 +113,71 @@ body.module-index-page main {
   margin-left: 300px;
 }
 
+#toc-toggle {
+  display: none;
+}
+#toc-backdrop {
+  display: none;
+}
+
 @media screen and (max-width: 800px) {
 
+/*
+  Below 800px the desktop sidebar (fixed, 300px, shifted on screen via
+  margin-left) has no room - "left: 0" alone (the old mobile rule) combined
+  with the desktop-wide "margin-left: -300px" actually pushed the whole nav
+  entirely off screen (its right edge lands exactly at the viewport's left
+  edge), making the TOC completely inaccessible on a phone, not just
+  cramped. Replaced with a slide-in drawer toggled by #toc-toggle instead:
+  closed by default (transform pushes it fully off screen, same as before),
+  opened by adding .toc-open (via jstachio.js), which both the nav and a
+  dimming backdrop respond to.
+*/
 body.module-index-page nav.js-toc {
   left: 0;
+  margin-left: 0;
+  width: 85vw;
+  max-width: 320px;
+  max-height: 100vh;
+  transform: translateX(-100%);
+  transition: transform 0.25s ease-in-out;
+  z-index: 1001;
+  background: Canvas;
   overflow-x: hidden;
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.3);
+}
+
+body.module-index-page nav.js-toc.toc-open {
+  transform: translateX(0);
 }
 
 body.module-index-page main {
   margin-left: 0px;
   overflow-wrap: anywhere;
+}
+
+#toc-toggle {
+  display: block;
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 1002;
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: 0.2rem 0.55rem;
+  background: Canvas;
+  color: CanvasText;
+  border: 1px solid GrayText;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#toc-backdrop.toc-open {
+  display: block;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 1000;
 }
 
 }

--- a/doc/overview.html
+++ b/doc/overview.html
@@ -1,6 +1,9 @@
 <html>
 <body>
 
+<button id="toc-toggle" aria-label="Toggle table of contents" aria-expanded="false">&#9776;</button>
+<div id="toc-backdrop"></div>
+
 <h1 class="overview">User Guide</h1>
 
 <strong>

--- a/doc/resources/jstachio.js
+++ b/doc/resources/jstachio.js
@@ -14,3 +14,25 @@
  $('#related-package-summary').parent().detach().appendTo('.summary-list');
 
 anchors.add();
+
+// Mobile TOC drawer: #toc-toggle/#toc-backdrop only exist (and #toc-toggle
+// is only visible) on the overview page below the 800px breakpoint - see
+// jstachio.css. Harmless no-op elsewhere since the click targets are absent
+// or the CSS makes them non-interactive.
+$('#toc-toggle').on('click', function () {
+  var open = $('nav.js-toc').toggleClass('toc-open').hasClass('toc-open');
+  $('#toc-backdrop').toggleClass('toc-open', open);
+  $(this).attr('aria-expanded', open);
+});
+$('#toc-backdrop').on('click', function () {
+  $('nav.js-toc').removeClass('toc-open');
+  $(this).removeClass('toc-open');
+  $('#toc-toggle').attr('aria-expanded', false);
+});
+// Tapping a section link should close the drawer so the content underneath
+// is actually visible instead of staying covered until a second tap.
+$('nav.js-toc').on('click', 'a.toc-link', function () {
+  $('nav.js-toc').removeClass('toc-open');
+  $('#toc-backdrop').removeClass('toc-open');
+  $('#toc-toggle').attr('aria-expanded', false);
+});


### PR DESCRIPTION
The old mobile rule ("left: 0" alone) combined with the desktop-wide "margin-left: -300px" actually pushed nav.js-toc entirely off screen (right edge lands exactly at the viewport's left edge) - confirmed with a real headless-browser render, not just reading the CSS: the nav was in the DOM but completely inaccessible on a phone, not just cramped.

Adds a #toc-toggle hamburger button (hidden on desktop, shown only below the existing 800px breakpoint) that slides nav.js-toc in via CSS transform, plus a dimming #toc-backdrop. jstachio.js wires the toggle, closing on backdrop click and on tapping any TOC link (so the content underneath is actually visible after navigating, not still covered).

Verified end to end with Playwright (headless Chromium) against the real built docs, not assumptions: drawer opens/closes, its own overflow-y:auto correctly kicks in once content exceeds the viewport (scrollHeight 2011 vs clientHeight 844 in testing), link clicks both navigate and auto-close, backdrop click closes, and desktop is provably unaffected (toggle/backdrop stay display:none, nav.js-toc's box is pixel-identical to before this change).