### PR TITLE
Cache ChangePublisher.allowedChanges() and give CALLER a dedicated ac…

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -433,27 +433,45 @@ abstract class AbstractChangePublisher implements ChangePublisher {
 	@Override
 	public Set<ChangeType> allowedChanges(String loggerName) {
 		return changesCache.computeIfAbsent(loggerName, n -> {
-			try {
-				var value = config().properties().findOrNull(LogProperties.CHANGE_PREFIX, n, LogProperties::listOrNull);
-				return value == null ? Set.of() : ChangeType.parse(value);
-			}
-			catch (Exception e) {
-				/*
-				 * A malformed logging.change.<name> value must not be able to break
-				 * logging itself. ConcurrentHashMap#computeIfAbsent leaves nothing cached
-				 * when the mapping function throws, so without catching here a bad
-				 * property would re-parse and re-throw on every single allowedChanges(n)
-				 * call for this logger name, not just once - same amplification risk
-				 * CachedLevelResolver guards against for level properties. Fall back to
-				 * "nothing allowed to change" and alert exactly once per logger name
-				 * instead, since the fallback value is itself cached above just like a
-				 * successful parse would be.
-				 */
-				config().alerts()
-					.error(AbstractChangePublisher.class, "Failed to parse " + LogProperties.CHANGE_PREFIX
-							+ " for logger '" + n + "', falling back to no changes allowed", e);
+			/*
+			 * findOrNull walks the logger-name hierarchy (closest match wins, see its own
+			 * javadoc) trying each candidate key in turn - per candidate, resolve it as a
+			 * LogProperty and only return null (telling findOrNull to keep walking up)
+			 * when the key is genuinely Missing there. A present-but-malformed value is a
+			 * Result.Error, not a Missing - it must stop the walk right there rather than
+			 * silently falling through to a less specific ancestor's value.
+			 */
+			LogProperty.Result<Set<ChangeType>> result = config().properties()
+				.findOrNull(LogProperties.CHANGE_PREFIX, n, (props, fullKey) -> {
+					LogProperty.Result<Set<ChangeType>> r = props.forKey(fullKey).ofList().map(ChangeType::parse);
+					return r instanceof LogProperty.Result.Missing ? null : r;
+				});
+			if (result == null) {
 				return Set.of();
 			}
+			return switch (result) {
+				case LogProperty.Result.Success<Set<ChangeType>> s -> s.value();
+				case LogProperty.Result.Error<Set<ChangeType>> e -> {
+					/*
+					 * A malformed logging.change.<name> value must not be able to break
+					 * logging itself. ConcurrentHashMap#computeIfAbsent leaves nothing
+					 * cached when the mapping function throws, so without catching this
+					 * (here, via the Result.Error case rather than a try/catch -
+					 * LogProperty.Result#map already turned ChangeType.parse's thrown
+					 * exception into this Error, with a richer message than a manual
+					 * catch would build) a bad property would re-parse and re-alert on
+					 * every single allowedChanges(n) call for this logger name, not just
+					 * once - same amplification risk CachedLevelResolver guards against
+					 * for level properties. Fall back to "nothing allowed to change" and
+					 * alert exactly once per logger name instead, since the fallback
+					 * value is itself cached above just like a successful parse would be.
+					 */
+					config().alerts().error(AbstractChangePublisher.class, e.message(), e.cause());
+					yield Set.of();
+				}
+				// Unreachable: the lambda above never returns a Missing result.
+				case LogProperty.Result.Missing<Set<ChangeType>> m -> Set.of();
+			};
 		});
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -449,29 +449,26 @@ abstract class AbstractChangePublisher implements ChangePublisher {
 			if (result == null) {
 				return Set.of();
 			}
-			return switch (result) {
-				case LogProperty.Result.Success<Set<ChangeType>> s -> s.value();
-				case LogProperty.Result.Error<Set<ChangeType>> e -> {
-					/*
-					 * A malformed logging.change.<name> value must not be able to break
-					 * logging itself. ConcurrentHashMap#computeIfAbsent leaves nothing
-					 * cached when the mapping function throws, so without catching this
-					 * (here, via the Result.Error case rather than a try/catch -
-					 * LogProperty.Result#map already turned ChangeType.parse's thrown
-					 * exception into this Error, with a richer message than a manual
-					 * catch would build) a bad property would re-parse and re-alert on
-					 * every single allowedChanges(n) call for this logger name, not just
-					 * once - same amplification risk CachedLevelResolver guards against
-					 * for level properties. Fall back to "nothing allowed to change" and
-					 * alert exactly once per logger name instead, since the fallback
-					 * value is itself cached above just like a successful parse would be.
-					 */
-					config().alerts().error(AbstractChangePublisher.class, e.message(), e.cause());
-					yield Set.of();
-				}
-				// Unreachable: the lambda above never returns a Missing result.
-				case LogProperty.Result.Missing<Set<ChangeType>> m -> Set.of();
-			};
+			try {
+				return result.validateNow(ChangePublisher.class);
+			}
+			catch (LogProperty.ValidationException e) {
+				/*
+				 * A malformed logging.change.<name> value must not be able to break
+				 * logging itself. ConcurrentHashMap#computeIfAbsent leaves nothing cached
+				 * when the mapping function throws, so without catching this a bad
+				 * property would re-parse and re-alert on every single allowedChanges(n)
+				 * call for this logger name, not just once - same amplification risk
+				 * CachedLevelResolver guards against for level properties. Fall back to
+				 * "nothing allowed to change" and alert exactly once per logger name
+				 * instead, since the fallback value is itself cached above just like a
+				 * successful parse would be. validateNow's own Missing = failure
+				 * semantics are moot here - the lambda above never returns a Missing
+				 * result to it in the first place.
+				 */
+				config().alerts().error(ChangePublisher.class, e);
+				return Set.of();
+			}
 		});
 	}
 

--- a/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogConfig.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
@@ -146,6 +147,22 @@ public sealed interface LogConfig extends LogProperty.PropertySupport {
 		public Set<ChangeType> allowedChanges(String loggerName);
 
 		/**
+		 * Whether caller info should be computed for a logger. Unlike
+		 * {@link ChangeType#LEVEL}, which is genuinely re-evaluated on every
+		 * {@link #publish()}, this is resolved once when a logger is first created and
+		 * never revisited afterward - it reflects a static per-logger capability, not
+		 * something that changes at runtime, despite being parsed from the same
+		 * {@value LogProperties#CHANGE_PREFIX} property and the same {@link ChangeType}
+		 * set as {@code LEVEL} (deliberately, to avoid a second property lookup per
+		 * logger name).
+		 * @param loggerName logger name.
+		 * @return true if caller info is enabled for this logger.
+		 */
+		default boolean callerInfoEnabled(String loggerName) {
+			return allowedChanges(loggerName).contains(ChangeType.CALLER);
+		}
+
+		/**
 		 * Changing type options.
 		 */
 		public enum ChangeType {
@@ -155,7 +172,12 @@ public sealed interface LogConfig extends LogProperty.PropertySupport {
 			 */
 			LEVEL,
 			/**
-			 * The logger is allowed to change caller info.
+			 * Caller info is enabled for the logger. Despite being a member of this enum
+			 * and parsed from the same property as {@link #LEVEL}, this is not actually
+			 * re-evaluated on {@link ChangePublisher#publish()} the way {@code LEVEL} is
+			 * - it is a static per-logger capability decided once. See
+			 * {@link ChangePublisher#callerInfoEnabled(String)} for the accessor callers
+			 * should actually use.
 			 */
 			CALLER;
 
@@ -377,12 +399,21 @@ abstract class AbstractChangePublisher implements ChangePublisher {
 	 */
 	private final Collection<Consumer<? super LogConfig>> consumers = new CopyOnWriteArrayList<Consumer<? super LogConfig>>();
 
+	/*
+	 * Same shape as LevelResolver.java's CachedLevelResolver: allowedChanges(name) is
+	 * only ever called once per never-before-seen logger name (RainbowGumLoggerFactory
+	 * caches the resulting Logger forever afterward), so a ConcurrentHashMap here matches
+	 * the exact call pattern that made a ConcurrentHashMap the right tradeoff there too.
+	 */
+	private final ConcurrentHashMap<String, Set<ChangeType>> changesCache = new ConcurrentHashMap<>();
+
 	protected abstract LogConfig reload();
 
 	protected abstract LogConfig config();
 
 	@Override
 	public void publish() {
+		changesCache.clear();
 		LogConfig config = reload();
 		for (var c : consumers) {
 			c.accept(config);
@@ -401,9 +432,29 @@ abstract class AbstractChangePublisher implements ChangePublisher {
 
 	@Override
 	public Set<ChangeType> allowedChanges(String loggerName) {
-		var value = config().properties()
-			.findOrNull(LogProperties.CHANGE_PREFIX, loggerName, LogProperties::listOrNull);
-		return value == null ? Set.of() : ChangeType.parse(value);
+		return changesCache.computeIfAbsent(loggerName, n -> {
+			try {
+				var value = config().properties().findOrNull(LogProperties.CHANGE_PREFIX, n, LogProperties::listOrNull);
+				return value == null ? Set.of() : ChangeType.parse(value);
+			}
+			catch (Exception e) {
+				/*
+				 * A malformed logging.change.<name> value must not be able to break
+				 * logging itself. ConcurrentHashMap#computeIfAbsent leaves nothing cached
+				 * when the mapping function throws, so without catching here a bad
+				 * property would re-parse and re-throw on every single allowedChanges(n)
+				 * call for this logger name, not just once - same amplification risk
+				 * CachedLevelResolver guards against for level properties. Fall back to
+				 * "nothing allowed to change" and alert exactly once per logger name
+				 * instead, since the fallback value is itself cached above just like a
+				 * successful parse would be.
+				 */
+				config().alerts()
+					.error(AbstractChangePublisher.class, "Failed to parse " + LogProperties.CHANGE_PREFIX
+							+ " for logger '" + n + "', falling back to no changes allowed", e);
+				return Set.of();
+			}
+		});
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
@@ -90,11 +90,13 @@ class ChangePublisherTest {
 	}
 
 	/*
-	 * Golden-master pin of the exact alert produced today for a malformed
-	 * logging.change.<name> value, captured before refactoring allowedChanges() to use
-	 * LogProperty/Result instead of a raw try/catch around ChangeType.parse - so a
-	 * behavior change in the alert's loggerName/message/cause shape shows up as an
-	 * explicit, deliberate diff to this test rather than silently drifting.
+	 * Golden-master pin of the exact alert produced for a malformed logging.change.<name>
+	 * value. Originally captured before allowedChanges() switched from a raw try/catch
+	 * around ChangeType.parse to LogProperty.Result (see git history for the prior,
+	 * plainer message) - now pinned to that switch's richer message, built automatically
+	 * by Result#map's error handling rather than the hand-rolled string this test used to
+	 * check for, so any further behavior change here shows up as an explicit, deliberate
+	 * diff instead of silently drifting.
 	 */
 	@Test
 	void testMalformedChangeValueGoldenAlert() {
@@ -108,7 +110,11 @@ class ChangePublisherTest {
 
 		var event = badConfig.alerts().dump().get(0);
 		assertEquals(AbstractChangePublisher.class.getName(), event.loggerName());
-		assertEquals("Failed to parse logging.change for logger 'bad', falling back to no changes allowed",
+		assertEquals(
+				"""
+						Error for property. key: 'logging.change.bad' from PROPERTIES_STRING[logging.change.bad], \
+						java.lang.IllegalArgumentException No enum constant io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType.NONSENSE
+						Tried: 'logging.change.bad' from PROPERTIES_STRING[logging.change.bad]""",
 				event.message());
 		var throwable = event.throwableOrNull();
 		assertNotNull(throwable);

--- a/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
 import io.jstach.rainbowgum.LogConfig.ChangePublisher;
 import io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType;
+import io.jstach.rainbowgum.LogProperties.MutableLogProperties;
 
 class ChangePublisherTest {
 
@@ -34,6 +36,91 @@ class ChangePublisherTest {
 	void test() {
 		Set<ChangeType> changes = changePublisher.allowedChanges("anything");
 		assertEquals(EnumSet.of(ChangeType.LEVEL, ChangeType.CALLER), changes);
+	}
+
+	@Test
+	void testCallerInfoEnabledAgreesWithAllowedChanges() {
+		assertTrue(changePublisher.callerInfoEnabled("anything"));
+
+		var levelOnlyConfig = LogConfig.builder().properties(LogProperties.builder().fromProperties("""
+				logging.global.change=true
+				logging.change.only=level
+				""").build()).build();
+		ChangePublisher levelOnly = changePublisher(levelOnlyConfig);
+		assertFalse(levelOnly.callerInfoEnabled("only"));
+		assertTrue(levelOnly.allowedChanges("only").contains(ChangeType.LEVEL));
+	}
+
+	@Test
+	void testAllowedChangesIsCachedPerLoggerNameAndNotReparsed() {
+		var real = LogProperties.builder().fromProperties("""
+				logging.global.change=true
+				logging.change.foo=level
+				""").build();
+		AtomicInteger reads = new AtomicInteger();
+		LogProperties counting = key -> {
+			reads.incrementAndGet();
+			return real.valueOrNull(key);
+		};
+		var countingConfig = LogConfig.builder().properties(counting).build();
+		var cp = changePublisher(countingConfig);
+
+		var first = cp.allowedChanges("foo");
+		int afterFirst = reads.get();
+		assertTrue(afterFirst > 0, "first call must actually read the property");
+
+		var second = cp.allowedChanges("foo");
+		assertEquals(first, second);
+		assertEquals(afterFirst, reads.get(), "second call for the same name must not re-read the property");
+	}
+
+	@Test
+	void testMalformedChangeValueAlertsOnceAndCachesTheFallback() {
+		var badConfig = LogConfig.builder().properties(LogProperties.builder().fromProperties("""
+				logging.global.change=true
+				logging.change.bad=nonsense
+				""").build()).build();
+		var cp = changePublisher(badConfig);
+
+		assertEquals(Set.of(), cp.allowedChanges("bad"));
+		assertEquals(1, badConfig.alerts().dump().size());
+
+		assertEquals(Set.of(), cp.allowedChanges("bad"));
+		assertEquals(1, badConfig.alerts().dump().size(), "the fallback must be cached, not re-parsed and re-alerted");
+	}
+
+	@Test
+	void testPublishClearsTheCacheForNamesRequestedAfterward() {
+		MutableLogProperties props = MutableLogProperties.builder().copyProperties("""
+				logging.global.change=true
+				logging.change.foo=level
+				""").build();
+		var mutableConfig = LogConfig.builder().properties(props).build();
+		var cp = changePublisher(mutableConfig);
+
+		assertEquals(EnumSet.of(ChangeType.LEVEL), cp.allowedChanges("foo"));
+
+		props.put("logging.change.foo", "caller");
+		cp.publish();
+
+		assertEquals(EnumSet.of(ChangeType.CALLER), cp.allowedChanges("foo"),
+				"a name requested after publish() must see the updated property, not the cached pre-publish value");
+	}
+
+	private static ChangePublisher changePublisher(LogConfig config) {
+		return new AbstractChangePublisher() {
+
+			@Override
+			protected LogConfig reload() {
+				return config;
+			}
+
+			@Override
+			protected LogConfig config() {
+				return config;
+			}
+
+		};
 	}
 
 }

--- a/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
@@ -91,12 +91,12 @@ class ChangePublisherTest {
 
 	/*
 	 * Golden-master pin of the exact alert produced for a malformed logging.change.<name>
-	 * value. Originally captured before allowedChanges() switched from a raw try/catch
-	 * around ChangeType.parse to LogProperty.Result (see git history for the prior,
-	 * plainer message) - now pinned to that switch's richer message, built automatically
-	 * by Result#map's error handling rather than the hand-rolled string this test used to
-	 * check for, so any further behavior change here shows up as an explicit, deliberate
-	 * diff instead of silently drifting.
+	 * value. See git history for two earlier, plainer messages this evolved from: first a
+	 * hand-rolled string around a raw try/catch, then Result#map's own richer message
+	 * once allowedChanges() switched to LogProperty.Result - now pinned to
+	 * Result#validateNow(Class)'s ValidationException wrapping that same message (with a
+	 * "Validation failed for <component>:" header), so any further behavior change here
+	 * shows up as an explicit, deliberate diff instead of silently drifting.
 	 */
 	@Test
 	void testMalformedChangeValueGoldenAlert() {
@@ -109,18 +109,22 @@ class ChangePublisherTest {
 		cp.allowedChanges("bad");
 
 		var event = badConfig.alerts().dump().get(0);
-		assertEquals(AbstractChangePublisher.class.getName(), event.loggerName());
+		assertEquals(ChangePublisher.class.getName(), event.loggerName());
 		assertEquals(
 				"""
+						Validation failed for io.jstach.rainbowgum.LogConfig$ChangePublisher:
 						Error for property. key: 'logging.change.bad' from PROPERTIES_STRING[logging.change.bad], \
 						java.lang.IllegalArgumentException No enum constant io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType.NONSENSE
 						Tried: 'logging.change.bad' from PROPERTIES_STRING[logging.change.bad]""",
 				event.message());
 		var throwable = event.throwableOrNull();
 		assertNotNull(throwable);
-		assertEquals(IllegalArgumentException.class, throwable.getClass());
+		assertEquals(LogProperty.ValidationException.class, throwable.getClass());
+		var cause = throwable.getCause();
+		assertNotNull(cause);
+		assertEquals(IllegalArgumentException.class, cause.getClass());
 		assertEquals("No enum constant io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType.NONSENSE",
-				throwable.getMessage());
+				cause.getMessage());
 	}
 
 	@Test

--- a/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/ChangePublisherTest.java
@@ -89,6 +89,34 @@ class ChangePublisherTest {
 		assertEquals(1, badConfig.alerts().dump().size(), "the fallback must be cached, not re-parsed and re-alerted");
 	}
 
+	/*
+	 * Golden-master pin of the exact alert produced today for a malformed
+	 * logging.change.<name> value, captured before refactoring allowedChanges() to use
+	 * LogProperty/Result instead of a raw try/catch around ChangeType.parse - so a
+	 * behavior change in the alert's loggerName/message/cause shape shows up as an
+	 * explicit, deliberate diff to this test rather than silently drifting.
+	 */
+	@Test
+	void testMalformedChangeValueGoldenAlert() {
+		var badConfig = LogConfig.builder().properties(LogProperties.builder().fromProperties("""
+				logging.global.change=true
+				logging.change.bad=nonsense
+				""").build()).build();
+		var cp = changePublisher(badConfig);
+
+		cp.allowedChanges("bad");
+
+		var event = badConfig.alerts().dump().get(0);
+		assertEquals(AbstractChangePublisher.class.getName(), event.loggerName());
+		assertEquals("Failed to parse logging.change for logger 'bad', falling back to no changes allowed",
+				event.message());
+		var throwable = event.throwableOrNull();
+		assertNotNull(throwable);
+		assertEquals(IllegalArgumentException.class, throwable.getClass());
+		assertEquals("No enum constant io.jstach.rainbowgum.LogConfig.ChangePublisher.ChangeType.NONSENSE",
+				throwable.getMessage());
+	}
+
 	@Test
 	void testPublishClearsTheCacheForNamesRequestedAfterward() {
 		MutableLogProperties props = MutableLogProperties.builder().copyProperties("""

--- a/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
+++ b/rainbowgum-slf4j/src/main/java/io/jstach/rainbowgum/slf4j/RainbowGumLoggerFactory.java
@@ -135,6 +135,13 @@ class RainbowGumLoggerFactory implements ILoggerFactory {
 	private LogEventHandler maybeAddCallerInfo(String loggerName, Set<ChangeType> allowedChanges, LogEventLogger logger,
 			int depth) {
 		LogEventHandler _logger;
+		/*
+		 * allowedChanges is already resolved once per getLogger() call (needed for the
+		 * LEVEL branch too), so checking it directly here is cheaper than a second,
+		 * redundant ChangePublisher.callerInfoEnabled(loggerName) lookup that would just
+		 * re-derive the same Set - see ChangePublisher.callerInfoEnabled(String) for the
+		 * accessor callers that only care about CALLER (not LEVEL too) should use.
+		 */
 		if (allowedChanges.contains(ChangeType.CALLER)) {
 			_logger = LogEventHandler.ofCallerInfo(loggerName, logger, mdc, depth);
 		}

--- a/todo.md
+++ b/todo.md
@@ -196,9 +196,24 @@ unifying.
       directly, bypassing the shortcut) reads better since there's no such wrapping
       `.map()` in the way. Worth fixing when `fileAppender()` gets its cleanup pass
       above, rather than as a one-off.
-- [ ] **`ChangeType.CALLER` doesn't really belong under `ChangePublisher`/"changing"**,
-      and `ChangePublisher.allowedChanges(String)` has no caching at all. Two related
-      but separate problems:
+- [x] **`ChangeType.CALLER` doesn't really belong under `ChangePublisher`/"changing"**,
+      and `ChangePublisher.allowedChanges(String)` had no caching at all. Addressed on
+      `explore/changepublisher-caller-caching`: `AbstractChangePublisher` now caches
+      `allowedChanges(String)` in a `ConcurrentHashMap<String, Set<ChangeType>>`
+      (mirroring `CachedLevelResolver`'s exact shape - same call pattern, "once per
+      never-before-seen logger name" - and its alert-once-then-cache-a-fallback
+      behavior for a malformed property value), cleared on `publish()` so a property
+      change is visible to names requested afterward. `ChangePublisher` gained a
+      dedicated `callerInfoEnabled(String)` default method (backed by the same cache)
+      with javadoc stating plainly that, unlike `LEVEL`, it is resolved once and never
+      revisited - fixing the conceptual mislabeling without changing behavior:
+      `RainbowGumLoggerFactory.subscribe()` was deliberately left capturing
+      caller-awareness once at construction time, since that already-once-only
+      behavior turned out to be the *correct* semantics for a static per-logger
+      capability, not a bug to fix. `ChangeType` stays a two-value enum and
+      `allowedChanges(): Set<ChangeType>` stays the public return shape - no breaking
+      change, and the single-property-lookup tradeoff (see below) is preserved as-is.
+      Original problem description kept for context:
       - Conceptually, `ChangeType.CALLER` ("the logger is allowed to change caller
         info") isn't actually treated as something that changes at runtime the way
         `LEVEL` is - confirmed in code: `RainbowGumLoggerFactory.subscribe()`'s


### PR DESCRIPTION
…cessor

AbstractChangePublisher.allowedChanges(String) previously re-parsed the logging.change.<name> property on every call. Adds a ConcurrentHashMap-based cache mirroring CachedLevelResolver's exact shape (LevelResolver.java) - same call pattern (once per never-before-seen logger name, then cached forever via RainbowGumLoggerFactory.loggerMap), including its alert-once-then-cache-a- fallback behavior for a malformed property value instead of re-throwing on every call. The cache clears on publish() so a property change is visible to names requested afterward, matching DefaultChangePublisher.reload() already clearing the level resolver on the same event.

Also gives ChangeType.CALLER a dedicated, honestly-documented ChangePublisher.callerInfoEnabled(String) accessor, since it doesn't share LEVEL's "live, re-evaluated on every change" semantics despite living in the same enum and being read via the same allowedChanges() call - RainbowGumLoggerFactory.subscribe() capturing it once at logger-construction time and never revisiting it is correct behavior for a static per-logger capability, not the bug it looked like. ChangeType stays a two-value enum and allowedChanges(): Set<ChangeType> stays the public return shape, keeping the single-property-lookup tradeoff (recorded in todo.md) intact - no breaking change, no second property lookup introduced.