### PR TITLE
Add Result.validateNow(Class<?>) for one-off single-property validation

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -684,6 +684,36 @@ public interface LogProperty {
 		}
 
 		/**
+		 * Convenience for a genuine one-off, single-property validation that does not
+		 * need to participate in a larger batch: builds a single-use {@link Validator},
+		 * registers this result with it via {@link Validator#add(Result)}, and validates
+		 * immediately - instead of registering with a caller-managed {@link Validator}
+		 * via {@link #validate(Validator)} and deferring to a later
+		 * {@link Validator#validate()} call.
+		 * <p>
+		 * Uses {@link Validator#add(Result)} semantics: a still-{@link Missing} result is
+		 * treated as a failure, same as an absent required property with no fallback. If
+		 * this property is optional, apply a fallback first -
+		 * {@code properties.forKey(key).ofString().or(fallback).validateNow(component)} -
+		 * since a result with a fallback applied is never {@link Missing}. For a property
+		 * that should tolerate being missing but not being present-and-malformed, use
+		 * {@link #validateIfError(Validator)} with an externally-owned {@link Validator}
+		 * instead - there is deliberately no addIfError-equivalent of this method, to
+		 * avoid two same-named single-property convenience methods with silently
+		 * different failure semantics.
+		 * @param component the class on whose behalf this property is being resolved -
+		 * only used to name the source of the failure in the exception message.
+		 * @return value.
+		 * @throws ValidationException if this result is not a {@link Success}.
+		 */
+		default T validateNow(Class<?> component) {
+			var v = Validator.of(component);
+			v.add(this);
+			v.validate();
+			return value();
+		}
+
+		/**
 		 * Returns the current result if fallback is null or returns fallback as a result
 		 * if this result is missing.
 		 * @param fallback maybe <code>null</code>.

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -38,6 +38,31 @@ class LogPropertyTest {
 	}
 
 	@Test
+	void testValidateNowReturnsValueOnSuccess() {
+		var success = new PropertySuccess<>(LogProperties.StandardProperties.EMPTY,
+				LogProperties.StandardProperties.EMPTY, "key", "actual", PropertySuccess.Kind.VALUE, "actual");
+		assertEquals("actual", success.validateNow(LogPropertyTest.class));
+	}
+
+	@Test
+	void testValidateNowTreatsStillMissingAsFailure() {
+		Missing<String> missing = new Missing<>(LogProperties.StandardProperties.EMPTY, List.of("key"), "missing");
+		assertThrows(ValidationException.class, () -> missing.validateNow(LogPropertyTest.class));
+	}
+
+	@Test
+	void testValidateNowWithFallbackAppliedFirstDoesNotTreatItAsMissing() {
+		Missing<String> missing = new Missing<>(LogProperties.StandardProperties.EMPTY, List.of("key"), "missing");
+		assertEquals("fallback", missing.or("fallback").validateNow(LogPropertyTest.class));
+	}
+
+	@Test
+	void testValidateNowThrowsOnError() {
+		Error<String> error = new Error<>("key", "bad value", new NumberFormatException("nope"));
+		assertThrows(ValidationException.class, () -> error.validateNow(LogPropertyTest.class));
+	}
+
+	@Test
 	void testPropertyFunctionSneakyThrowsCheckedException() {
 		PropertyFunction<String, String, IOException> f = new PropertyFunction<>() {
 			@Override

--- a/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
+++ b/rainbowgum-systemlogger/src/main/java/io/jstach/rainbowgum/systemlogger/RainbowGumSystemLoggerFinder.java
@@ -7,7 +7,6 @@ import java.util.function.Supplier;
 import org.eclipse.jdt.annotation.Nullable;
 
 import io.jstach.rainbowgum.LogProperties;
-import io.jstach.rainbowgum.LogProperty;
 import io.jstach.rainbowgum.LogRouter;
 import io.jstach.rainbowgum.RainbowGum;
 import io.jstach.rainbowgum.spi.RainbowGumServiceProvider;
@@ -125,14 +124,11 @@ public abstract class RainbowGumSystemLoggerFinder extends System.LoggerFinder {
 	 * @return initialization option.
 	 */
 	protected static InitOption initOption(LogProperties properties) {
-		var v = LogProperty.Validator.of(RainbowGumSystemLoggerFinder.class);
-		var result = properties.forKey(INITIALIZE_RAINBOW_GUM_PROPERTY)
+		return properties.forKey(INITIALIZE_RAINBOW_GUM_PROPERTY)
 			.ofString()
 			.map(InitOption::parse)
 			.or(InitOption.CHECK)
-			.validate(v);
-		v.validate();
-		return result.value();
+			.validateNow(RainbowGumSystemLoggerFinder.class);
 	}
 
 	private interface RouterProvider {


### PR DESCRIPTION
Reintroduces the single-property convenience that validate(Class<?>) used to provide before it was replaced by validate(Validator)/validateIfError(Validator) (commit 6be3811d) - under a new name specifically to avoid the original problem: "validate" overloaded across Result.validate(Class)/validate(Validator) with silently different failure semantics was the reason it got removed in the first place. validateNow(Class<?>) always uses Validator.add() semantics (a still-Missing result is a failure) - same as before, and deliberately with no addIfError-equivalent, so there is exactly one way to spell "validate this one property right now," not three easily-confused ones.

Like the property being required with no fallback, a caller must apply a fallback first (.or(...)) for an optional property, same precondition validate(Validator)/Validator.add() already carries - covered directly in the new method's javadoc and by a dedicated test.

Refactors RainbowGumSystemLoggerFinder.initOption() - one of the two original validate(Class) callers before the removal - to use it, both as a real usage example and to drop the hand-built Validator boilerplate that commit reintroduced there.