### PR TITLE
Add theme toggle to overview.html top bar, fix dark-mode mobile TOC d…

### DIFF
--- a/doc/jstachio.css
+++ b/doc/jstachio.css
@@ -62,6 +62,28 @@ h2.toc-title:before {
     display: none;
 }
 
+/*
+  jstachio.js moves #theme-button (and #theme-panel) out of the hidden #navbar-top
+  above into .sub-nav .nav-list-search's row, since that's the only part of the
+  navbar left visible on this page. Its stylesheet.css rule (button#theme-button)
+  sizes and offsets it for the taller --top-nav-height row it normally lives in -
+  the sub-nav row is shorter (--sub-nav-height) and vertically centers its children
+  via flexbox, so the button needs to be smaller and not fight that centering with
+  its own "top: -9.5px" relative offset. background/background-color (the actual
+  sun/moon icon, driven by the --current-theme-svg variable) are left alone -
+  overridden here is only size/position, not which icon shows.
+*/
+.module-index-page .sub-nav #theme-button {
+    position: static;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    margin: 0 4px 0 0;
+    background-size: 16px 16px;
+    background-position: center;
+    flex: 0 0 auto;
+}
+
 .module-index-page .title {
   padding-bottom: 1.2em;
   font-size: 1.2rem;
@@ -142,7 +164,16 @@ body.module-index-page nav.js-toc {
   transform: translateX(-100%);
   transition: transform 0.25s ease-in-out;
   z-index: 1001;
-  background: Canvas;
+  /*
+    Was "Canvas" (a CSS system-color keyword) - that only tracks the OS/browser's
+    own dark-mode preference, not this site's [data-theme] attribute toggle, so
+    selecting Dark via the theme button left this drawer white while the rest of
+    the page went dark. --toc-background-color/--body-text-color are javadoc's own
+    theme variables (redefined under [data-theme="dark"] in stylesheet.css), same
+    ones #theme-panel below already uses for the same kind of floating panel.
+  */
+  background: var(--toc-background-color);
+  color: var(--body-text-color);
   overflow-x: hidden;
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.3);
 }
@@ -165,9 +196,10 @@ body.module-index-page main {
   font-size: 1.4rem;
   line-height: 1;
   padding: 0.2rem 0.55rem;
-  background: Canvas;
-  color: CanvasText;
-  border: 1px solid GrayText;
+  /* Same "Canvas doesn't track [data-theme]" issue as nav.js-toc above. */
+  background: var(--toc-background-color);
+  color: var(--body-text-color);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
 }

--- a/doc/resources/jstachio.js
+++ b/doc/resources/jstachio.js
@@ -15,6 +15,22 @@
 
 anchors.add();
 
+// #navbar-top (and everything in it, including the theme button javadoc's own
+// script.js already wires up a working click handler for) is hidden on the overview
+// page - see "module-index-page #navbar-top" in jstachio.css, which drops the
+// redundant Overview/Tree/Index/Help row since this page has its own custom header.
+// The theme button is still wanted though, so move it out to the one part of the
+// navbar that stays visible here: the sub-nav's search box row, just to the left of
+// the search box. #theme-panel (the light/dark/system dropdown) is position:fixed in
+// javadoc's own stylesheet, so its new DOM parent doesn't affect where it renders -
+// moved to <body> directly, clear of any risk of an ancestor with a CSS transform
+// (which would otherwise change what position:fixed is relative to). Harmless no-op
+// on every other page: #navbar-top is never hidden there, so this block never runs.
+if ($('body').hasClass('module-index-page')) {
+  $('#theme-button').insertBefore('.sub-nav .nav-list-search');
+  $('#theme-panel').appendTo('body');
+}
+
 // Mobile TOC drawer: #toc-toggle/#toc-backdrop only exist (and #toc-toggle
 // is only visible) on the overview page below the 800px breakpoint - see
 // jstachio.css. Harmless no-op elsewhere since the click targets are absent


### PR DESCRIPTION
…rawer

Two real, verified-in-a-real-browser bugs on the overview page specifically (normal generated class pages were never affected by either):

1. The theme button (light/dark/system) javadoc's own script.js already fully wires up a working click handler for was present in the DOM but completely invisible - jstachio.css hides all of #navbar-top on this page (module-index-page #navbar-top { display: none }) to drop the redundant Overview/Tree/Index/Help row, and the theme button lived inside that same hidden container. jstachio.js now relocates #theme-button (and #theme-panel, which is position:fixed so its new DOM parent doesn't affect where it renders) to the one part of the navbar left visible: the sub-nav's search box row, just to its left - confirmed via Playwright that it's visible, clickable, and toggling Dark actually flips data-theme and the whole page's colors. Needed its own, smaller sizing in jstachio.css since the sub-nav row is shorter than the row the button normally lives in and centers its children differently.

2. The mobile hamburger TOC drawer (nav.js-toc, #toc-toggle) used the CSS system-color keywords Canvas/CanvasText/GrayText for its background/ text/border - those track the OS/browser's own dark-mode preference, not this site's [data-theme] attribute, so selecting Dark left the drawer stuck white while the rest of the page went dark. Switched to the same --toc-background-color/--body-text-color/--border-color variables #theme-panel and everything else theme-aware on this page already use. Desktop TOC sidebar was unaffected either way (different, non-drawer CSS path) - confirmed via screenshot.

Both verified with a real headless Chromium session (Playwright), not just reasoning about the CSS - desktop class page (untouched), desktop overview (theme button + dark mode), and mobile overview (hamburger drawer, both light and dark, plus the existing open/close/auto-close-on-link-click behavior still intact).