### PR TITLE
Bump build-tool dependency versions (combines 5 Dependabot PRs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,11 @@
     <maven.core.version>3.9.16</maven.core.version>
     <jdk.release.version>26.0.2</jdk.release.version>
 
-    <ecj.version>3.46.0</ecj.version>
+    <ecj.version>3.46.100</ecj.version>
     <plexus-compiler-eclipse.version>2.17.0</plexus-compiler-eclipse.version>
     <error-prone.version>2.50.0</error-prone.version>
-    <nullaway.version>0.14.0</nullaway.version>
-    <checkerframework.version>4.2.2</checkerframework.version>
+    <nullaway.version>0.14.1</nullaway.version>
+    <checkerframework.version>4.2.3</checkerframework.version>
 
 
     <pistachio.version>0.1.2</pistachio.version>
@@ -309,7 +309,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.15.0</version>
+          <version>3.16.0</version>
           <configuration>
             <release>${java.version}</release>
             <encoding>${project.build.sourceEncoding}</encoding>
@@ -323,7 +323,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.6</version>
+          <version>3.6.0</version>
           <configuration>
             <trimStackTrace>false</trimStackTrace>
             <printSummary>true</printSummary>


### PR DESCRIPTION
Combines the Maven-plugin, NullAway, and CheckerFramework Dependabot PRs into one commit rather than merging each separately - excludes the runtime dependency bump (logback-classic, a benchmark-module dependency, not build tooling) and spring-javaformat-maven-plugin (a version bump there could shift formatting rules across the codebase and warrants its own dedicated pass).

- org.eclipse.jdt:ecj 3.46.0 -> 3.46.100
- com.uber.nullaway:nullaway 0.14.0 -> 0.14.1
- checkerframework.version 4.2.2 -> 4.2.3
- maven-compiler-plugin 3.15.0 -> 3.16.0
- maven-surefire-plugin 3.5.6 -> 3.6.0

Full reactor build and the checkerframework/errorprone analyzer profiles pass clean with the bumped versions.