### PR TITLE
Move aggregate code coverage to a dedicated rainbowgum-coverage-aggre…

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,4 +39,4 @@ jobs:
           slug: jstachio/rainbowgum
           fail_ci_if_error: true
           disable_search: true
-          files: ${{ github.workspace }}/rainbowgum/target/site/jacoco-aggregate/jacoco.xml
+          files: ${{ github.workspace }}/rainbowgum-coverage-aggregate/target/site/jacoco-aggregate/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -980,14 +980,12 @@
       <!--
         This per-module profile only records each module's own coverage (prepare-agent
         + report). The actual aggregate report across every module is a separate
-        report-aggregate execution in the rainbowgum module's own pom - see the comment
-        there on why a module must be a compile/runtime/provided (never scope=test)
-        dependency of rainbowgum to show up in that aggregate, and optional=true for one
-        that isn't really needed at runtime by the umbrella bundle. Piggybacking the
-        aggregate root on rainbowgum (a real, published artifact) rather than a
-        dedicated dummy/aggregator-only module is a known wart, worth revisiting -
-        rainbowgum's own dependency list keeps growing for reasons that have nothing to
-        do with what it actually ships.
+        report-aggregate execution in rainbowgum-coverage-aggregate's own pom - a
+        dedicated, unpublished pom-packaging module that exists solely to hold that
+        dependency list, rather than piggybacking it on rainbowgum (a real, published
+        bundle) the way it used to. See that module's own comment on why each dependency
+        needs scope=runtime, optional=true (never scope=test) to actually show up in the
+        aggregate.
       -->
       <id>codecover</id>
       <activation>
@@ -1298,6 +1296,7 @@
     <module>rainbowgum-tomcat</module>
     <module>rainbowgum-file</module>
     <module>spring</module>
+    <module>rainbowgum-coverage-aggregate</module>
     <module>rainbowgum-maven-last</module>
   </modules>
 </project>

--- a/rainbowgum-coverage-aggregate/pom.xml
+++ b/rainbowgum-coverage-aggregate/pom.xml
@@ -74,6 +74,20 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-test-file</artifactId>
+      <!--
+        Different symptom than the others above: RollingFileOutputTest (real end-to-end
+        rolling/writing, slow) lives in this test-support module rather than
+        rainbowgum-file itself. Without this dependency, report-aggregate never sees that
+        module's jacoco.exec at all, so RollingFileOutputBuilder/RollingFileOutput/
+        DefaultRollingFileOutput showed 0% coverage despite being exercised end to end.
+      -->
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/rainbowgum-coverage-aggregate/pom.xml
+++ b/rainbowgum-coverage-aggregate/pom.xml
@@ -1,0 +1,110 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.jstach.rainbowgum</groupId>
+    <artifactId>rainbowgum-maven-parent</artifactId>
+    <version>0.11.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>rainbowgum-coverage-aggregate</artifactId>
+  <name>rainbowgum-coverage-aggregate</name>
+  <packaging>pom</packaging>
+  <!--
+    Not a real, published artifact - exists solely so codecover's report-aggregate goal
+    below has one place to hang its dependency list, instead of that concern living on
+    rainbowgum (a real, distributed bundle whose own dependency list should reflect what
+    it actually ships/needs for its doc snippets, not what coverage tooling needs to see).
+    See each dependency's runtime+optional=true comment for why that scope specifically -
+    the short version: report-aggregate only aggregates coverage for modules that are
+    compile/runtime/provided-scope dependencies of *this* module; a scope=test dependency's
+    coverage data is invisible to it.
+  -->
+  <properties>
+    <parent.root>${basedir}/..</parent.root>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-core</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-pattern</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-slf4j</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-systemlogger</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-jdk</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-jul</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-json</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>rainbowgum-file</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>codecover</id>
+      <activation>
+        <property>
+          <name>codecover</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <configuration>
+                  <dataFileIncludes>
+                    <dataFileInclude>**/jacoco.exec</dataFileInclude>
+                  </dataFileIncludes>
+                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/rainbowgum/pom.xml
+++ b/rainbowgum/pom.xml
@@ -45,23 +45,22 @@
       <artifactId>rainbowgum-jul</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <!-- The below are just for code snippts and are not actual depedendencies -->
+    <!--
+      The below are just for code snippets and are not actual dependencies - see
+      rainbowgum-coverage-aggregate for why they aren't also runtime+optional=true here
+      the way they used to be: that module now owns the "must be visible to
+      report-aggregate" concern instead of this one growing scope=runtime dependencies
+      it doesn't actually need just to make coverage tooling happy.
+    -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-json</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rainbowgum-file</artifactId>
-      <!--
-        Must be runtime + optional=true (like rainbowgum-json above), not scope=test,
-        even though nothing here actually needs it at runtime - see the codecover
-        profile's report-aggregate comment below for why.
-      -->
-      <scope>runtime</scope>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -91,47 +90,4 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
-  <!--
-    codecover's report-aggregate goal below only aggregates coverage for modules that
-    are compile/runtime/provided-scope dependencies of this module - a scope=test
-    dependency's classes/coverage data are invisible to it, even though the module
-    itself still builds and runs its own tests fine. Any module (like
-    rainbowgum-json/rainbowgum-file above) that should show up in the aggregate report
-    but isn't a real runtime dependency of this bundle needs scope=runtime,
-    optional=true instead - optional=true keeps it from leaking into consumers'
-    transitive dependencies, matching the "just for code snippets" modules' actual
-    intent.
-  -->
-  <profiles>
-    <profile>
-      <id>codecover</id>
-      <activation>
-        <property>
-          <name>codecover</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>verify</phase>
-                <goals>
-                  <goal>report-aggregate</goal>
-                </goals>
-                <configuration>
-                  <dataFileIncludes>
-                    <dataFileInclude>**/jacoco.exec</dataFileInclude>
-                  </dataFileIncludes>
-                  <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/rainbowgum/pom.xml
+++ b/rainbowgum/pom.xml
@@ -74,20 +74,5 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rainbowgum-test-file</artifactId>
-      <!--
-        Also runtime + optional=true, same reason as rainbowgum-file above, but for a
-        different symptom: RollingFileOutputTest lives in this module (not rainbowgum-file
-        itself, since real rolling/writing is slow), so without this, report-aggregate
-        never sees that module's jacoco.exec at all and RollingFileOutputBuilder/
-        RollingFileOutput/DefaultRollingFileOutput show 0 coverage even though they're
-        exercised end to end.
-      -->
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
…gate module

rainbowgum-file's fix (scope=runtime, optional=true, so it shows up in the codecover aggregate report) made explicit what was already a known wart: rainbowgum (a real, published bundle) was doing double duty as the JaCoCo report-aggregate root, so its dependency list kept growing for reasons that have nothing to do with what it actually ships - the "just for code snippets" comment already hinted at this.

New rainbowgum-coverage-aggregate module: unpublished, pom-packaging, exists solely to hold the runtime+optional=true dependency list report-aggregate needs (core, pattern, slf4j, systemlogger, jdk, jul, json, file) and the report-aggregate execution itself, moved from rainbowgum's pom.

rainbowgum's own pom.xml goes back to reflecting only its real needs: rainbowgum-json/rainbowgum-file return to plain scope=test (their actual requirement - compiling FullConfigurationExample.java's snippets), no longer needing the runtime+optional=true workaround now that coverage aggregation lives elsewhere. More snippets exercising those two are planned, so the dependencies themselves stay - only the scope changes back to what they actually mean.

Verified: rainbowgum-coverage-aggregate/target/site/jacoco-aggregate/index.html lists all 8 modules (rainbowgum-file included) after `mvn -Pcodecover clean verify`; rainbowgum itself no longer produces any jacoco-aggregate output. Full reactor build, aggregate javadoc, and checkerframework all pass clean.