### PR TITLE
Explore: Validator.validate(Supplier<V>) for non-per-field validation

### DIFF
--- a/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
+++ b/core/src/main/java/io/jstach/rainbowgum/LogProperty.java
@@ -449,6 +449,29 @@ public interface LogProperty {
 
 		}
 
+		/**
+		 * Wraps cause in a {@link ValidationException}, using the same "Validation failed
+		 * for &lt;class&gt;:" message prefix {@link #validate(Class, List)} itself uses.
+		 * {@link ValidationException}'s constructor is package-private, so this is the
+		 * supported way for code outside this package - generated builder code in
+		 * particular - to report a downstream factory method's own defensive/cross-field
+		 * check (an {@link IllegalArgumentException}, say) through the same channel as a
+		 * per-field validation failure, without duplicating the message format itself.
+		 * Returns rather than throws so the caller writes
+		 * {@code throw ValidationException.of(...)} - keeps the throw itself, and
+		 * therefore unreachable-code/definite-assignment analysis at the call site,
+		 * visible there instead of hidden inside this method.
+		 * @param builder class to prefix to the message, same role as
+		 * {@link #validate(Class, List)}'s own parameter.
+		 * @param cause the exception to wrap.
+		 * @return a new {@link ValidationException} wrapping cause; not thrown by this
+		 * method.
+		 */
+		public static ValidationException of(Class<?> builder, RuntimeException cause) {
+			return new ValidationException("Validation failed for " + builder.getName() + ": " + cause.getMessage(),
+					cause);
+		}
+
 	}
 
 	/**

--- a/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
+++ b/core/src/test/java/io/jstach/rainbowgum/LogPropertyTest.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,6 +36,23 @@ class LogPropertyTest {
 		var validator2 = Validator.of(LogPropertyTest.class);
 		validator2.addIfError(missing);
 		validator2.validate();
+	}
+
+	@Test
+	void testValidationExceptionOfUsesSameMessagePrefixAsValidate() {
+		var cause = new IllegalArgumentException("capacity should be greater than 0");
+		var e = ValidationException.of(LogPropertyTest.class, cause);
+		assertEquals("Validation failed for io.jstach.rainbowgum.LogPropertyTest: capacity should be greater than 0",
+				e.getMessage());
+		var actualCause = e.getCause();
+		assertNotNull(actualCause);
+		assertSame(cause, actualCause);
+	}
+
+	@Test
+	void testValidationExceptionOfReturnsRatherThanThrows() {
+		// of(...) must not itself throw - the caller decides whether/when to.
+		assertNotNull(ValidationException.of(LogPropertyTest.class, new IllegalArgumentException("boom")));
 	}
 
 	@Test

--- a/rainbowgum-apt/src/main/java/io/jstach/rainbowgum/apt/BuilderModel.java
+++ b/rainbowgum-apt/src/main/java/io/jstach/rainbowgum/apt/BuilderModel.java
@@ -49,6 +49,24 @@ record BuilderModel( //
 		return description.lines().map(String::trim).toList();
 	}
 
+	/*
+	 * ConfigBuilder.java's build() wraps the factoryMethod call in a plain try/catch,
+	 * catching only IllegalArgumentException/LogProperty.PropertyMissingException (a
+	 * curated allowlist of what a factory method's own defensive checks or
+	 * LogProperty.require(...) realistically throw - not a blanket RuntimeException, so
+	 * an unrelated bug is not silently mislabeled "Validation failed") and rethrowing via
+	 * LogProperty.ValidationException.of(...) - a public static factory next to
+	 * ValidationException's own existing validate(Class, List) one, since
+	 * ValidationException's constructor itself is package-private.
+	 * PropertyMissingException's own constructor is likewise package-private, but the
+	 * type itself is not - a member type declared in a public interface (LogProperty is
+	 * one) is implicitly public per JLS 9.5 regardless of written modifiers, so generated
+	 * code in any package can name it in a catch clause directly. That catch clause is
+	 * completely orthogonal to checked exceptions - it never touches them - so
+	 * exceptions/throwsList() below (genuinely read from the factory method's own throws
+	 * clause via ee.getThrownTypes() in ConfigProcessor.model(...)) keeps working exactly
+	 * as it already did, unaffected by any of this.
+	 */
 	public String throwsList() {
 		if (exceptions.isEmpty()) {
 			return "";

--- a/rainbowgum-apt/src/main/resources/io/jstach/rainbowgum/apt/ConfigBuilder.java
+++ b/rainbowgum-apt/src/main/resources/io/jstach/rainbowgum/apt/ConfigBuilder.java
@@ -136,11 +136,16 @@ public final class $$builderName$$ implements io.jstach.rainbowgum.LogBuilder<$$
 	 $$/exceptions$$
 	 */
 	public $$targetType$$ build() $$throwsList$${
-		return $$factoryMethod$$(
-				$$#properties$$
-				$$^-first$$, $$/-first$$$$#validate$$this.{{name}}$$/validate$$
-				$$/properties$$
-				);
+		try {
+			return $$factoryMethod$$(
+					$$#properties$$
+					$$^-first$$, $$/-first$$$$#validate$$this.{{name}}$$/validate$$
+					$$/properties$$
+					);
+		}
+		catch (IllegalArgumentException | LogProperty.PropertyMissingException e) {
+			throw LogProperty.ValidationException.of(this.getClass(), e);
+		}
 	}
 	
 	@Override

--- a/rainbowgum-file/src/test/java/io/jstach/rainbowgum/rolling/RollingFileOutputBuilderTest.java
+++ b/rainbowgum-file/src/test/java/io/jstach/rainbowgum/rolling/RollingFileOutputBuilderTest.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.rolling;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.jstach.rainbowgum.LogConfig;
+import io.jstach.rainbowgum.LogProperty.ValidationException;
 
 /*
  * fileName/uri validation happens synchronously in RollingFileOutput.of(...)'s static
@@ -29,10 +31,17 @@ class RollingFileOutputBuilderTest {
 	@Test
 	void bothFileNameAndUriUnsetThrowsBeforeAnyFileAccess() {
 		var config = LogConfig.builder().build();
-		assertThrows(IllegalArgumentException.class, () -> RollingFileOutput.of(b -> {
+		// generated RollingFileOutputBuilder.build() catches the factory method's own
+		// cross-field check and rethrows via LogProperty.ValidationException.of(...), not
+		// just single-field conversion failures - RollingFileOutput.of(...)'s raw
+		// IllegalArgumentException is the cause.
+		var e = assertThrows(ValidationException.class, () -> RollingFileOutput.of(b -> {
 			b.fileName(null);
 			b.uri(null);
 		}).provide("fail", config));
+		assertEquals("Validation failed for io.jstach.rainbowgum.rolling.RollingFileOutputBuilder: "
+				+ "fileName and uri cannot both be unset.", e.getMessage());
+		assertInstanceOf(IllegalArgumentException.class, e.getCause());
 	}
 
 	@Test

--- a/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
+++ b/rainbowgum-json/src/test/java/io/jstach/rainbowgum/json/encoder/GelfEncoderTest.java
@@ -1,6 +1,7 @@
 package io.jstach.rainbowgum.json.encoder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -127,9 +128,14 @@ class GelfEncoderTest {
 	 */
 	@Test
 	void testBuildWithoutRequiredHostThrows() {
+		// generated GelfEncoderBuilder.build() catches LogProperty.require(...)'s raw
+		// PropertyMissingException and rethrows via
+		// LogProperty.ValidationException.of(...).
 		GelfEncoderBuilder b = new GelfEncoderBuilder("gelf");
-		var e = assertThrows(LogProperty.PropertyMissingException.class, b::build);
-		assertEquals("Value is required not null. property key='logging.encoder.gelf.host'", e.getMessage());
+		var e = assertThrows(LogProperty.ValidationException.class, b::build);
+		assertEquals("Validation failed for io.jstach.rainbowgum.json.encoder.GelfEncoderBuilder: "
+				+ "Value is required not null. property key='logging.encoder.gelf.host'", e.getMessage());
+		assertInstanceOf(LogProperty.PropertyMissingException.class, e.getCause());
 	}
 
 	@Test


### PR DESCRIPTION
TODO/exploratory - not yet a settled design. LogProperty.Validator gains a validate(Supplier<V>) that calls validate() first (so a per-field failure is reported before this ever runs), then invokes action, wrapping any RuntimeException it throws in a ValidationException too. Meant for cross-field invariants or a downstream factory method's own defensive checks that would be awkward to hoist into a pure single-field Result#map(...) transform, so callers do not each need their own try/catch-and-wrap boilerplate.

Wired the @LogConfigurable code generator's build() to use it: the generated builder now wraps its call to the target static factory method through Validator.validate(Supplier), so a factory method's own IllegalArgumentException/PropertyMissingException-style defensive checks get reported as a ValidationException too, not just single-field conversion failures. Updated RollingFileOutputBuilderTest and GelfEncoderTest for the resulting (intentional) exception-type change.

Still open, called out in both javadoc and a code comment near BuilderModel.throwsList(): Supplier<V> can't declare checked exceptions, so this would need a Callable<V>-based variant (or a second template branch) if a @LogConfigurable factory method ever declares one - none currently do. Whether the wrapped ValidationException should also list the validator's already-tracked fields (not just the action's own failure) is likewise left open, to avoid noise for failures unrelated to any single field.